### PR TITLE
Refactor puzzle inputs

### DIFF
--- a/src/aoc_clj/2015/day01.clj
+++ b/src/aoc_clj/2015/day01.clj
@@ -1,7 +1,8 @@
 (ns aoc-clj.2015.day01
+  "Solution to https://adventofcode.com/2015/day/1"
   (:require [aoc-clj.utils.core :as u]))
 
-(def day01-input (first (u/puzzle-input "inputs/2015/day01-input.txt")))
+(def parse first)
 
 (defn instructions
   [input]
@@ -19,10 +20,10 @@
        (u/index-of (u/equals? -1))))
 
 (defn day01-part1-soln
-  []
-  (final-floor day01-input))
+  [input]
+  (final-floor input))
 
 (defn day01-part2-soln
-  []
-  (first-pos-in-basement day01-input))
+  [input]
+  (first-pos-in-basement input))
 

--- a/src/aoc_clj/2015/day02.clj
+++ b/src/aoc_clj/2015/day02.clj
@@ -1,13 +1,14 @@
 (ns aoc-clj.2015.day02
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2015/day/2"
+  (:require [clojure.string :as str]))
 
 (defn parse-line
   [line]
   (map read-string (str/split line #"x")))
 
-(def day02-input
-  (map parse-line (u/puzzle-input "inputs/2015/day02-input.txt")))
+(defn parse
+  [input]
+  (map parse-line input))
 
 (defn wrapping-paper-area
   [[l w h]]
@@ -21,9 +22,9 @@
        (* l w h))))
 
 (defn day02-part1-soln
-  []
-  (reduce + (map wrapping-paper-area day02-input)))
+  [input]
+  (reduce + (map wrapping-paper-area input)))
 
 (defn day02-part2-soln
-  []
-  (reduce + (map ribbon-length day02-input)))
+  [input]
+  (reduce + (map ribbon-length input)))

--- a/src/aoc_clj/2015/day03.clj
+++ b/src/aoc_clj/2015/day03.clj
@@ -1,8 +1,7 @@
 (ns aoc-clj.2015.day03
-  (:require [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2015/day/3")
 
-(def day03-input
-  (first (u/puzzle-input "inputs/2015/day03-input.txt")))
+(def parse first)
 
 (def dir-map
   {\^ [0 -1]
@@ -32,9 +31,9 @@
          count)))
 
 (defn day03-part1-soln
-  []
-  (houses-visited day03-input))
+  [input]
+  (houses-visited input))
 
 (defn day03-part2-soln
-  []
-  (split-houses-visited day03-input))
+  [input]
+  (split-houses-visited input))

--- a/src/aoc_clj/2015/day04.clj
+++ b/src/aoc_clj/2015/day04.clj
@@ -1,7 +1,8 @@
 (ns aoc-clj.2015.day04
+  "Solution to https://adventofcode.com/2015/day/4"
   (:import java.security.MessageDigest))
 
-(def day04-input "yzbqklnj")
+(def parse first)
 (def md5-alg (MessageDigest/getInstance "MD5"))
 
 (defn md5-bytes
@@ -35,9 +36,9 @@
   (partial first-to-meet-condition starts-with-six-zeros?))
 
 (defn day04-part1-soln
-  []
-  (first-to-start-with-five-zeros day04-input))
+  [input]
+  (first-to-start-with-five-zeros input))
 
 (defn day04-part2-soln
-  []
-  (first-to-start-with-six-zeros day04-input))
+  [input]
+  (first-to-start-with-six-zeros input))

--- a/src/aoc_clj/2015/day05.clj
+++ b/src/aoc_clj/2015/day05.clj
@@ -1,7 +1,7 @@
 (ns aoc-clj.2015.day05
-  (:require [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2015/day/5")
 
-(def day05-input (u/puzzle-input "inputs/2015/day05-input.txt"))
+(def parse identity)
 
 (defn three-vowels?
   [s]
@@ -35,9 +35,9 @@
    repeat-with-letter-between?))
 
 (defn day05-part1-soln
-  []
-  (count (filter nice? day05-input)))
+  [input]
+  (count (filter nice? input)))
 
 (defn day05-part2-soln
-  []
-  (count (filter new-nice? day05-input)))
+  [input]
+  (count (filter new-nice? input)))

--- a/src/aoc_clj/2015/day06.clj
+++ b/src/aoc_clj/2015/day06.clj
@@ -1,19 +1,21 @@
 (ns aoc-clj.2015.day06
-  (:require [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2015/day/6")
 
 (def pattern #"(turn on|turn off|toggle) (\d+),(\d+) through (\d+),(\d+)")
 (def command {"turn on" :on
               "turn off" :off
               "toggle" :toggle})
 
-(defn parse
+(defn parse-line
   [line]
   (let [[a b c d e] (rest (first (re-seq pattern line)))]
     {:cmd (command a)
      :start [(read-string b) (read-string c)]
      :end   [(read-string d) (read-string e)]}))
 
-(def day06-input (map parse (u/puzzle-input "inputs/2015/day06-input.txt")))
+(defn parse
+  [input]
+  (map parse-line input))
 
 (defn rect-range
   [[sx sy] [ex ey]]
@@ -72,10 +74,10 @@
 
 (def update-grid-part1 (partial update-grid commands))
 (defn day06-part1-soln
-  []
-  (count-on (reduce update-grid-part1 {} day06-input)))
+  [input]
+  (count-on (reduce update-grid-part1 {} input)))
 
 (def update-grid-part2 (partial update-grid commands2))
 (defn day06-part2-soln
-  []
-  (brightness (reduce update-grid-part2 {} day06-input)))
+  [input]
+  (brightness (reduce update-grid-part2 {} input)))

--- a/src/aoc_clj/2015/day07.clj
+++ b/src/aoc_clj/2015/day07.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2015.day07
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2015/day/7"
+  (:require [clojure.string :as str]))
 
 (defn tokenize
   [s]
@@ -23,7 +23,7 @@
   [s]
   {:op :assign :args (tokenize s)})
 
-(defn parse
+(defn parse-line
   [line]
   (let [[ops dest] (str/split line #" -> ")
         inst (cond
@@ -32,7 +32,9 @@
                :else (parse-assign ops))]
     [(tokenize dest) inst]))
 
-(def day07-input (into {} (map parse (u/puzzle-input "inputs/2015/day07-input.txt"))))
+(defn parse
+  [input]
+  (into {} (map parse-line input)))
 
 (def wire-val
   (memoize
@@ -55,12 +57,12 @@
   (assoc circuit "b" {:op :assign :args val}))
 
 (defn day07-part1-soln
-  []
-  (wire-val day07-input "a"))
+  [input]
+  (wire-val input "a"))
 
 (defn day07-part2-soln
-  []
-  (let [circuit day07-input
+  [input]
+  (let [circuit input
         wirea (wire-val circuit "a")
         newcircuit (override-wire-b circuit wirea)]
     (wire-val newcircuit "a")))

--- a/src/aoc_clj/2015/day08.clj
+++ b/src/aoc_clj/2015/day08.clj
@@ -1,9 +1,9 @@
 (ns aoc-clj.2015.day08
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2015/day/8"
+  (:require [clojure.string :as str]))
 
 (def hex-pattern #"\\x[0-9a-f]{2}")
-(def day08-input (u/puzzle-input "inputs/2015/day08-input.txt"))
+(def parse identity)
 
 (defn hex->str
   [h]
@@ -59,9 +59,9 @@
      (reduce + (map code-chars input))))
 
 (defn day08-part1-soln
-  []
-  (unescaped-difference day08-input))
+  [input]
+  (unescaped-difference input))
 
 (defn day08-part2-soln
-  []
-  (escaped-difference day08-input))
+  [input]
+  (escaped-difference input))

--- a/src/aoc_clj/2015/day09.clj
+++ b/src/aoc_clj/2015/day09.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2015.day09
+  "Solution to https://adventofcode.com/2015/day/9"
   (:require [clojure.string :as str]
             [clojure.math.combinatorics :as combo]
             [aoc-clj.utils.core :as u]))
@@ -15,8 +16,6 @@
   (->> (mapcat parse-line input)
        (group-by first)
        (u/fmap #(apply merge (map second %)))))
-
-(def day09-input (parse (u/puzzle-input "inputs/2015/day09-input.txt")))
 
 (defn route-distance
   [dists route]
@@ -39,9 +38,9 @@
   (apply max (route-distances dists)))
 
 (defn day09-part1-soln
-  []
-  (shortest-route-distance day09-input))
+  [input]
+  (shortest-route-distance input))
 
 (defn day09-part2-soln
-  []
-  (longest-route-distance day09-input))
+  [input]
+  (longest-route-distance input))

--- a/src/aoc_clj/2015/day10.clj
+++ b/src/aoc_clj/2015/day10.clj
@@ -1,7 +1,8 @@
 (ns aoc-clj.2015.day10
+  "Solution to https://adventofcode.com/2015/day/10"
   (:require [clojure.string :as str]))
 
-(def day10-input "1113222113")
+(def parse first)
 
 (defn look-and-say
   [s]
@@ -10,9 +11,9 @@
     (str/join  (flatten  counts))))
 
 (defn day10-part1-soln
-  []
-  (count (nth (iterate look-and-say day10-input) 40)))
+  [input]
+  (count (nth (iterate look-and-say input) 40)))
 
 (defn day10-part2-soln
-  []
-  (count (nth (iterate look-and-say day10-input) 50)))
+  [input]
+  (count (nth (iterate look-and-say input) 50)))

--- a/src/aoc_clj/2015/day11.clj
+++ b/src/aoc_clj/2015/day11.clj
@@ -1,7 +1,8 @@
 (ns aoc-clj.2015.day11
+  "Solution to https://adventofcode.com/2015/day/11"
   (:require [clojure.string :as str]))
 
-(def day11-input "hxbxwxba")
+(def parse first)
 
 (defn char->int
   [c]
@@ -74,9 +75,11 @@
          nums->str)))
 
 (defn day11-part1-soln
-  []
-  (next-valid-password day11-input))
+  [input]
+  (next-valid-password input))
 
 (defn day11-part2-soln
-  []
-  (next-valid-password (next-password (day11-part1-soln))))
+  [input]
+  (-> (day11-part1-soln input)
+      next-password
+      next-valid-password))

--- a/src/aoc_clj/2015/day12.clj
+++ b/src/aoc_clj/2015/day12.clj
@@ -1,8 +1,8 @@
 (ns aoc-clj.2015.day12
-  (:require [cheshire.core :as c]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2015/day/11"
+  (:require [cheshire.core :as c]))
 
-(def day12-input (first  (u/puzzle-input "inputs/2015/day12-input.txt")))
+(def parse first)
 
 (defn all-numbers
   [s]
@@ -21,12 +21,12 @@
       s)))
 
 (defn day12-part1-soln
-  []
-  (reduce + (all-numbers day12-input)))
+  [input]
+  (reduce + (all-numbers input)))
 
 (defn day12-part2-soln
-  []
-  (->> (c/parse-string day12-input)
+  [input]
+  (->> (c/parse-string input)
        drop-red
        c/generate-string
        all-numbers

--- a/src/aoc_clj/2015/day13.clj
+++ b/src/aoc_clj/2015/day13.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2015.day13
+  "Solution to https://adventofcode.com/2015/day/13"
   (:require [clojure.string :as str]
             [clojure.math.combinatorics :as combo]
             [aoc-clj.utils.core :as u]))
@@ -18,8 +19,6 @@
   (->> (map parse-line input)
        (group-by first)
        (u/fmap #(into {} (map second %)))))
-
-(def day13-input (parse (u/puzzle-input "inputs/2015/day13-input.txt")))
 
 (defn adjacents
   [order]
@@ -46,9 +45,9 @@
     (assoc new-table "Me" (zipmap (keys new-table) (repeat 0)))))
 
 (defn day13-part1-soln
-  []
-  (max-happiness day13-input))
+  [input]
+  (max-happiness input))
 
 (defn day13-part2-soln
-  []
-  (max-happiness (add-me day13-input)))
+  [input]
+  (max-happiness (add-me input)))

--- a/src/aoc_clj/2015/day14.clj
+++ b/src/aoc_clj/2015/day14.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2015.day14
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2015/day/14"
+  (:require [clojure.string :as str]))
 
 (defn parse-line
   [line]
@@ -15,7 +15,6 @@
   [input]
   (into {} (map parse-line input)))
 
-(def day14-input (parse (u/puzzle-input "inputs/2015/day14-input.txt")))
 
 (defn distance-at-time
   [time {:keys [speed fly rest]}]
@@ -37,9 +36,9 @@
     (mapv (partial reduce +) scores)))
 
 (defn day14-part1-soln
-  []
-  (apply max (map (partial distance-at-time 2503) (vals day14-input))))
+  [input]
+  (apply max (map (partial distance-at-time 2503) (vals input))))
 
 (defn day14-part2-soln
-  []
-  (apply max (points-at-time 2503 day14-input)))
+  [input]
+  (apply max (points-at-time 2503 input)))

--- a/src/aoc_clj/2015/day15.clj
+++ b/src/aoc_clj/2015/day15.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2015.day15
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2015/day/15"
+  (:require [clojure.string :as str]))
 
 (defn parse-line
   [line]
@@ -15,7 +15,6 @@
   [input]
   (into {} (mapv parse-line input)))
 
-(def day15-input (parse (u/puzzle-input "inputs/2015/day15-input.txt")))
 (def max-teaspoons 100)
 
 (defn score
@@ -54,11 +53,11 @@
     (apply max-key (partial score-fn input) opts)))
 
 (defn day15-part1-soln
-  []
-  (let [best-combo (find-max-score score day15-input)]
-    (score day15-input best-combo)))
+  [input]
+  (let [best-combo (find-max-score score input)]
+    (score input best-combo)))
 
 (defn day15-part2-soln
-  []
-  (let [best-combo (find-max-score score-with-500cal day15-input)]
-    (score day15-input best-combo)))
+  [input]
+  (let [best-combo (find-max-score score-with-500cal input)]
+    (score input best-combo)))

--- a/src/aoc_clj/2015/day16.clj
+++ b/src/aoc_clj/2015/day16.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2015.day16
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2015/day/16"
+  (:require [clojure.string :as str]))
 
 (def criteria
   {:children 3
@@ -28,8 +28,6 @@
   [input]
   (into {} (mapv parse-line input)))
 
-(def day16-input (parse (u/puzzle-input "inputs/2015/day16-input.txt")))
-
 (defn exact-match?
   [[_ props]]
   (let [sub-criteria (select-keys criteria (keys props))]
@@ -54,9 +52,9 @@
   (ffirst (filter criteria aunts)))
 
 (defn day16-part1-soln
-  []
-  (matching-aunt exact-match? day16-input))
+  [input]
+  (matching-aunt exact-match? input))
 
 (defn day16-part2-soln
-  []
-  (matching-aunt range-match? day16-input))
+  [input]
+  (matching-aunt range-match? input))

--- a/src/aoc_clj/2015/day17.clj
+++ b/src/aoc_clj/2015/day17.clj
@@ -1,8 +1,10 @@
 (ns aoc-clj.2015.day17
-  (:require [clojure.math.combinatorics :as combo]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2015/day/17"
+  (:require [clojure.math.combinatorics :as combo]))
 
-(def day17-input (map read-string (u/puzzle-input "inputs/2015/day17-input.txt")))
+(defn parse
+  [input]
+  (map read-string input))
 
 (defn sums-to?
   [sum coll]
@@ -22,9 +24,9 @@
     (filter #(= min-containers (count %)) combos)))
 
 (defn day17-part1-soln
-  []
-  (count (combinations 150 day17-input)))
+  [input]
+  (count (combinations 150 input)))
 
 (defn day17-part2-soln
-  []
-  (count (minimal-combinations 150 day17-input)))
+  [input]
+  (count (minimal-combinations 150 input)))

--- a/src/aoc_clj/2015/day18.clj
+++ b/src/aoc_clj/2015/day18.clj
@@ -1,10 +1,11 @@
 (ns aoc-clj.2015.day18
-  (:require [aoc-clj.utils.grid.mapgrid :as mapgrid]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2015/day/18"
+  (:require [aoc-clj.utils.grid.mapgrid :as mapgrid]))
 
 (def char-map {\. :off \# :on})
-(def day18-input
-  (mapgrid/ascii->MapGrid2D char-map (u/puzzle-input "inputs/2015/day18-input.txt")))
+(defn parse
+  [input]
+  (mapgrid/ascii->MapGrid2D char-map input))
 
 (defn adj-coords
   [[x y]]
@@ -66,9 +67,9 @@
          count)))
 
 (defn day18-part1-soln
-  []
-  (lights-on-at-step-n 100 day18-input))
+  [input]
+  (lights-on-at-step-n 100 input))
 
 (defn day18-part2-soln
-  []
-  (lights-on-at-step-n true 100 (corners-on day18-input)))
+  [input]
+  (lights-on-at-step-n true 100 (corners-on input)))

--- a/src/aoc_clj/2015/day19.clj
+++ b/src/aoc_clj/2015/day19.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2015.day19
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2015/day/19"
+  (:require [clojure.string :as str]))
 
 (defn parse-replacement
   [line]
@@ -11,8 +11,6 @@
   (let [[replacements molecule] (str/split (str/join "\n" input) #"\n\n")]
     {:replacements (mapv parse-replacement (str/split replacements #"\n"))
      :molecule molecule}))
-
-(def day19-input (parse (u/puzzle-input "inputs/2015/day19-input.txt")))
 
 (defn indicesOf
   [s pattern]
@@ -55,9 +53,9 @@
                    (iterate de-fabricate (ordered-replacements input)))))
 
 (defn day19-part1-soln
-  []
-  (count (distinct-molecules day19-input)))
+  [input]
+  (count (distinct-molecules input)))
 
 (defn day19-part2-soln
-  []
-  (count (fabrication-steps day19-input)))
+  [input]
+  (count (fabrication-steps input)))

--- a/src/aoc_clj/2015/day20.clj
+++ b/src/aoc_clj/2015/day20.clj
@@ -1,6 +1,7 @@
-(ns aoc-clj.2015.day20)
+(ns aoc-clj.2015.day20
+  "Solution to https://adventofcode.com/2015/day/20")
 
-(def day20-input 33100000)
+(def parse (comp read-string first))
 
 (defn house-presents
   [house]
@@ -20,9 +21,9 @@
     (* 11 (reduce + factors))))
 
 (defn day20-part1-soln
-  []
-  (first-house-with-n-presents house-presents 776159 day20-input))
+  [input]
+  (first-house-with-n-presents house-presents 776159 input))
 
 (defn day20-part2-soln
-  []
-  (first-house-with-n-presents house-presents-part2 786239 day20-input))
+  [input]
+  (first-house-with-n-presents house-presents-part2 786239 input))

--- a/src/aoc_clj/2015/day21.clj
+++ b/src/aoc_clj/2015/day21.clj
@@ -1,7 +1,7 @@
 (ns aoc-clj.2015.day21
+  "Solution to https://adventofcode.com/2015/day/21"
   (:require [clojure.string :as str]
-            [clojure.math.combinatorics :as combo]
-            [aoc-clj.utils.core :as u]))
+            [clojure.math.combinatorics :as combo]))
 
 (defn parse-line
   [line]
@@ -12,7 +12,6 @@
   [input]
   (into {} (map parse-line input)))
 
-(def day21-input (parse (u/puzzle-input "inputs/2015/day21-input.txt")))
 (def player {:hit-points 100 :damage 0 :armor 0 :cost 0})
 
 (def weapons
@@ -80,9 +79,9 @@
     (apply max-key :cost losers)))
 
 (defn day21-part1-soln
-  []
-  (:cost (cheapest-winning-combo day21-input)))
+  [input]
+  (:cost (cheapest-winning-combo input)))
 
 (defn day21-part2-soln
-  []
-  (:cost (priciest-losing-combo day21-input)))
+  [input]
+  (:cost (priciest-losing-combo input)))

--- a/src/aoc_clj/2015/day22.clj
+++ b/src/aoc_clj/2015/day22.clj
@@ -1,18 +1,16 @@
 (ns aoc-clj.2015.day22
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2015/day/22")
 
-(defn parse-line
-  [line]
-  (let [[attr qty] (str/split line #": ")]
-    [(keyword (str/join "-" (str/split (str/lower-case attr) #" "))) (read-string qty)]))
+;; (defn parse-line
+;;   [line]
+;;   (let [[attr qty] (str/split line #": ")]
+;;     [(keyword (str/join "-" (str/split (str/lower-case attr) #" "))) (read-string qty)]))
 
-(defn parse
-  [input]
-  (into {} (map parse-line input)))
+;; (defn parse
+;;   [input]
+;;   (into {} (map parse-line input)))
 
-(def day22-input (parse (u/puzzle-input "inputs/2015/day22-input.txt")))
-(def player {:hit-points 50 :mana 500 :armor 0})
+;; (def player {:hit-points 50 :mana 500 :armor 0})
 (def spell-cost
   {:magic-missile 53
    :drain         73
@@ -98,28 +96,29 @@
    (-> (player-round hard? state spell)
        boss-round)))
 
-(defn player-wins?
-  [{:keys [player boss]}]
-  (and
-   (not (pos? (:hit-points boss)))
-   (pos? (:hit-points player))))
+;; (defn player-wins?
+;;   [{:keys [player boss]}]
+;;   (and
+;;    (not (pos? (:hit-points boss)))
+;;    (pos? (:hit-points player))))
 
-(defn available-spells
-  [{:keys [player effects]}]
-  (if (<= (:hit-points player) 0)
-    []
-    (let [active-effects (map first (filter #(> 1 (val %)) effects))]
-      (->> (u/without-keys spell-cost active-effects)
-           (filter #(>= (:mana player) (val %)))
-           (map first)))))
+;; (defn available-spells
+;;   [{:keys [player effects]}]
+;;   (if (<= (:hit-points player) 0)
+;;     []
+;;     (let [active-effects (map first (filter #(> 1 (val %)) effects))]
+;;       (->> (u/without-keys spell-cost active-effects)
+;;            (filter #(>= (:mana player) (val %)))
+;;            (map first)))))
 
+;; TODO - These ought to be implemented so that they work on abitrary
+;; inputs rather than hard-coding the winning plays
 (def winning-plays [:poison :recharge :shield :poison :recharge :magic-missile :poison :drain :magic-missile])
 (defn day22-part1-soln
   []
   (reduce + (map spell-cost winning-plays)))
 
 (def winning-plays-part2 [:poison :recharge :shield :poison :recharge :shield :poison :magic-missile :magic-missile])
-
 (defn day22-part2-soln
   []
   (reduce + (map spell-cost winning-plays-part2)))

--- a/src/aoc_clj/2015/day23.clj
+++ b/src/aoc_clj/2015/day23.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2015.day23
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2015/day/23"
+  (:require [clojure.string :as str]))
 
 (defn parse-line
   [line]
@@ -15,8 +15,6 @@
 (defn parse
   [input]
   (mapv parse-line input))
-
-(def day23-input (parse (u/puzzle-input "inputs/2015/day23-input.txt")))
 
 (defn apply-inst
   [instructions {:keys [next-inst] :as state}]
@@ -51,9 +49,9 @@
     (first (drop-while #(not-done? max-inst (:next-inst %)) (iterate (partial apply-inst instructions) init)))))
 
 (defn day23-part1-soln
-  []
-  (:b (run-program day23-input {:a 0 :b 0 :next-inst 0})))
+  [input]
+  (:b (run-program input {:a 0 :b 0 :next-inst 0})))
 
 (defn day23-part2-soln
-  []
-  (:b (run-program day23-input {:a 1 :b 0 :next-inst 0})))
+  [input]
+  (:b (run-program input {:a 1 :b 0 :next-inst 0})))

--- a/src/aoc_clj/2015/day24.clj
+++ b/src/aoc_clj/2015/day24.clj
@@ -1,8 +1,10 @@
 (ns aoc-clj.2015.day24
-  (:require [clojure.math.combinatorics :as combo]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2015/day/24"
+  (:require [clojure.math.combinatorics :as combo]))
 
-(def day24-input (map read-string (u/puzzle-input "inputs/2015/day24-input.txt")))
+(defn parse
+  [input]
+  (map read-string input))
 
 (defn smallest-groups
   [groups input]
@@ -27,9 +29,9 @@
        best-quantum-entanglement))
 
 (defn day24-part1-soln
-  []
-  (best-qe-thirds day24-input))
+  [input]
+  (best-qe-thirds input))
 
 (defn day24-part2-soln
-  []
-  (best-qe-fourths day24-input))
+  [input]
+  (best-qe-fourths input))

--- a/src/aoc_clj/2015/day25.clj
+++ b/src/aoc_clj/2015/day25.clj
@@ -1,13 +1,14 @@
 (ns aoc-clj.2015.day25
+  "Solution to https://adventofcode.com/2015/day/25"
   (:require [aoc-clj.utils.math :as m]))
 
 (def first-code 20151125)
 (def modulus 33554393)
 (def multiplier 252533)
 
-
-(def code-row 2981)
-(def code-col 3075)
+(defn parse
+  [input]
+  (map read-string (re-seq #"\d+" (first input))))
 
 ;https://en.wikipedia.org/wiki/Lazy_caterer%27s_sequence
 (defn lazy-caterer
@@ -31,5 +32,5 @@
       (m/mod-mul modulus (m/mod-pow modulus multiplier (dec code-num)) first-code))))
 
 (defn day25-part1-soln
-  []
-  (code code-row code-col))
+  [[row col]]
+  (code row col))

--- a/src/aoc_clj/2016/day01.clj
+++ b/src/aoc_clj/2016/day01.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2016.day01
+  "Solution to https://adventofcode.com/2016/day/1"
   (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]
             [aoc-clj.utils.math :as math]))
 
 (defn parse-cmd
@@ -10,10 +10,8 @@
     {:dir dir :dist dist}))
 
 (defn parse
-  [line]
-  (map parse-cmd (str/split line #", ")))
-
-(def day01-input (-> (u/puzzle-input "inputs/2016/day01-input.txt") first parse))
+  [input]
+  (map parse-cmd (str/split (first input) #", ")))
 
 (defn rotate
   [heading dir]
@@ -40,10 +38,6 @@
 (defn distance
   [steps]
   (-> steps move :pos (math/manhattan [0 0])))
-
-(defn day01-part1-soln
-  []
-  (distance day01-input))
 
 (defn all-steps
   [{:keys [visited heading]} {:keys [dir dist]}]
@@ -74,6 +68,10 @@
   [steps]
   (-> steps all-visited :visited first-duplicate (math/manhattan [0 0])))
 
+(defn day01-part1-soln
+  [input]
+  (distance input))
+
 (defn day01-part2-soln
-  []
-  (distance-to-first-duplicate day01-input))
+  [input]
+  (distance-to-first-duplicate input))

--- a/src/aoc_clj/2016/day02.clj
+++ b/src/aoc_clj/2016/day02.clj
@@ -1,7 +1,7 @@
 (ns aoc-clj.2016.day02
-  (:require [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2016/day/2")
 
-(def day02-input (u/puzzle-input "inputs/2016/day02-input.txt"))
+(def parse identity)
 
 (def square-keypad
   {[-1 -1] 1  [0 -1] 2  [1 -1] 3
@@ -46,9 +46,9 @@
 (def diagonal-bathroom-code (partial bathroom-code diagonal-keypad))
 
 (defn day02-part1-soln
-  []
-  (square-bathroom-code day02-input))
+  [input]
+  (square-bathroom-code input))
 
 (defn day02-part2-soln
-  []
-  (diagonal-bathroom-code day02-input))
+  [input]
+  (diagonal-bathroom-code input))

--- a/src/aoc_clj/2016/day03.clj
+++ b/src/aoc_clj/2016/day03.clj
@@ -1,11 +1,13 @@
 (ns aoc-clj.2016.day03
-  (:require [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2016/day/3")
 
 (defn parse-line
   [line]
   (read-string (str "[" line "]")))
 
-(def day03-input (map parse-line (u/puzzle-input "inputs/2016/day03-input.txt")))
+(defn parse
+  [input]
+  (map parse-line input))
 
 (defn valid-triangle?
   [[a b c]]
@@ -17,10 +19,6 @@
   [input]
   (->> input (filter valid-triangle?) count))
 
-(defn day03-part1-soln
-  []
-  (count-of-valid-triangles day03-input))
-
 (defn group-by-columns
   [input]
   (->> (concat (map #(nth % 0) input)
@@ -28,6 +26,10 @@
                (map #(nth % 2) input))
        (partition 3)))
 
+(defn day03-part1-soln
+  [input]
+  (count-of-valid-triangles input))
+
 (defn day03-part2-soln
-  []
-  (-> day03-input group-by-columns count-of-valid-triangles))
+  [input]
+  (-> input group-by-columns count-of-valid-triangles))

--- a/src/aoc_clj/2016/day04.clj
+++ b/src/aoc_clj/2016/day04.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2016.day04
+  "Solution to https://adventofcode.com/2016/day/4"
   (:require [clojure.string :as str]
             [aoc-clj.utils.core :as u]))
 
@@ -12,7 +13,9 @@
      :sector-id (read-string (last name))
      :checksum (butlast r)}))
 
-(def day04-input (map parse-line (u/puzzle-input "inputs/2016/day04-input.txt")))
+(defn parse
+  [input]
+  (map parse-line input))
 
 (defn freq-letter-compare
   [x y]
@@ -36,10 +39,6 @@
        (map :sector-id)
        (reduce +)))
 
-(defn day04-part1-soln
-  []
-  (real-room-sector-id-sum day04-input))
-
 (defn decipher
   [{:keys [encrypted-name sector-id] :as room}]
   (let [mapping (zipmap alphabet (u/rotate (mod sector-id 26) alphabet))]
@@ -53,6 +52,10 @@
        first
        :sector-id))
 
+(defn day04-part1-soln
+  [input]
+  (real-room-sector-id-sum input))
+
 (defn day04-part2-soln
-  []
-  (north-pole-objects-room day04-input))
+  [input]
+  (north-pole-objects-room input))

--- a/src/aoc_clj/2016/day05.clj
+++ b/src/aoc_clj/2016/day05.clj
@@ -1,20 +1,21 @@
 (ns aoc-clj.2016.day05
+  "Solution to https://adventofcode.com/2016/day/5"
   (:require [aoc-clj.utils.digest :as d]))
 
-(def day05-input "reyedfim")
+(def parse first)
 
-(defn starts-with-five-zeros?
-  [bytes]
-  (and (zero? (aget bytes 0))
-       (zero? (aget bytes 1))
-       (<= 0 (aget bytes 2) 15)))
+;; (defn starts-with-five-zeros?
+;;   [bytes]
+;;   (and (zero? (aget bytes 0))
+;;        (zero? (aget bytes 1))
+;;        (<= 0 (aget bytes 2) 15)))
 
-(defn valid-hash-offsets
-  [door-id]
-  (let [hashed #(d/md5-bytes (str door-id %))]
-    (->>  (range)
-          (filter (comp starts-with-five-zeros? hashed))
-          (take 30))))
+;; (defn valid-hash-offsets
+;;   [door-id]
+;;   (let [hashed #(d/md5-bytes (str door-id %))]
+;;     (->>  (range)
+;;           (filter (comp starts-with-five-zeros? hashed))
+;;           (take 30))))
 
 (def day05-input-valid-offsets
   "Found by calling (valid-hash-offsets day05-input) and waiting a long time!"
@@ -32,10 +33,6 @@
        (map #(nth % 5))
        (apply str)))
 
-(defn day05-part1-soln
-  []
-  (password day05-input day05-input-valid-offsets))
-
 (defn set-char
   [s [idx c]]
   (let [pos (read-string (str idx))]
@@ -51,6 +48,10 @@
        (reduce set-char [\* \* \* \* \* \* \* \*])
        (apply str)))
 
+(defn day05-part1-soln
+  [input]
+  (password input day05-input-valid-offsets))
+
 (defn day05-part2-soln
-  []
-  (password-part2 day05-input day05-input-valid-offsets))
+  [input]
+  (password-part2 input day05-input-valid-offsets))

--- a/src/aoc_clj/2016/day06.clj
+++ b/src/aoc_clj/2016/day06.clj
@@ -1,7 +1,7 @@
 (ns aoc-clj.2016.day06
-  (:require [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2016/day/6")
 
-(def day06-input (u/puzzle-input "inputs/2016/day06-input.txt"))
+(def parse identity)
 
 (defn frequent-chars
   [max-or-min-f input]
@@ -17,9 +17,9 @@
 (def least-frequent-chars (partial frequent-chars min-key))
 
 (defn day06-part1-soln
-  []
-  (most-frequent-chars day06-input))
+  [input]
+  (most-frequent-chars input))
 
 (defn day06-part2-soln
-  []
-  (least-frequent-chars day06-input))
+  [input]
+  (least-frequent-chars input))

--- a/src/aoc_clj/2016/day07.clj
+++ b/src/aoc_clj/2016/day07.clj
@@ -1,16 +1,17 @@
 (ns aoc-clj.2016.day07
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2016/day/7"
+  (:require [clojure.string :as str]))
 
 (defn parse-line
   [line]
   (let [chunks (str/split line #"\[")
         splits (map #(str/split % #"\]") (rest chunks))]
-    ;; (println start others)
     {:supernets (into [(first chunks)] (map second splits))
      :hypernets (mapv first splits)}))
 
-(def day07-input (map parse-line (u/puzzle-input "inputs/2016/day07-input.txt")))
+(defn parse
+  [input]
+  (map parse-line input))
 
 (defn abba?
   [s]
@@ -21,10 +22,6 @@
   (if (some identity (filter abba? hypernets))
     false
     (boolean (some identity (filter abba? supernets)))))
-
-(defn day07-part1-soln
-  []
-  (count (filter supports-tls? day07-input)))
 
 (defn all-abas
   [s]
@@ -43,7 +40,11 @@
        (some identity)
        boolean))
 
+(defn day07-part1-soln
+  [input]
+  (count (filter supports-tls? input)))
+
 (defn day07-part2-soln
-  []
-  (count (filter supports-ssl? day07-input)))
+  [input]
+  (count (filter supports-ssl? input)))
 

--- a/src/aoc_clj/2016/day08.clj
+++ b/src/aoc_clj/2016/day08.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2016.day08
+  "Solution to https://adventofcode.com/2016/day/8"
   (:require [clojure.string :as str]
             [aoc-clj.utils.core :as u]
             [aoc-clj.utils.grid :as grid]))
@@ -26,7 +27,9 @@
     (parse-rect s)
     (parse-rotate s)))
 
-(def day08-input (map parse-line (u/puzzle-input "inputs/2016/day08-input.txt")))
+(defn parse
+  [input]
+  (map parse-line input))
 
 (defn apply-rect
   [state {:keys [width height]}]
@@ -80,20 +83,19 @@
        count))
 
 (defn day08-part1-soln
-  []
-  (lit-pixels 50 6 day08-input))
-
-;; Execute to print message to screen
-(comment
-  (println (grid/Grid2D->ascii {\  :off \# :on} (apply-instructions 50 6 day08-input)))
-  "####  ##   ##  ###   ##  ###  #  # #   # ##   ##  "
-  "#    #  # #  # #  # #  # #  # #  # #   ##  # #  # "
-  "###  #  # #  # #  # #    #  # ####  # # #  # #  # "
-  "#    #  # #### ###  # ## ###  #  #   #  #### #  # "
-  "#    #  # #  # # #  #  # #    #  #   #  #  # #  # "
-  "####  ##  #  # #  #  ### #    #  #   #  #  #  ##  ")
+  [input]
+  (lit-pixels 50 6 input))
 
 (defn day08-part2-soln
-  []
+  [input]
+  ;; Execute the code in the comment to print the message
+  (comment
+    (println (grid/Grid2D->ascii {\  :off \# :on} (apply-instructions 50 6 input)))
+    "####  ##   ##  ###   ##  ###  #  # #   # ##   ##  "
+    "#    #  # #  # #  # #  # #  # #  # #   ##  # #  # "
+    "###  #  # #  # #  # #    #  # ####  # # #  # #  # "
+    "#    #  # #### ###  # ## ###  #  #   #  #### #  # "
+    "#    #  # #  # # #  #  # #    #  #   #  #  # #  # "
+    "####  ##  #  # #  #  ### #    #  #   #  #  #  ##  ")
   "EOARGPHYAO")
 

--- a/src/aoc_clj/2016/day09.clj
+++ b/src/aoc_clj/2016/day09.clj
@@ -1,8 +1,8 @@
 (ns aoc-clj.2016.day09
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2016/day/9"
+  (:require [clojure.string :as str]))
 
-(def day09-input (first (u/puzzle-input "inputs/2016/day09-input.txt")))
+(def parse first)
 
 (defn repeat-coll
   [n coll]
@@ -24,10 +24,6 @@
                  (rest remainder)
                  (into output (repeat-coll repeats repeat-seq))))))))
 
-(defn day09-part1-soln
-  []
-  (count (decompress day09-input)))
-
 (defn decompress-count
   [s]
   (loop [char-count 0 remaining s]
@@ -43,6 +39,10 @@
           (recur (+ (* (decompress-count repeat-string) repeats)
                     char-count open-marker-loc) new))))))
 
+(defn day09-part1-soln
+  [input]
+  (count (decompress input)))
+
 (defn day09-part2-soln
-  []
-  (decompress-count day09-input))
+  [input]
+  (decompress-count input))

--- a/src/aoc_clj/2016/day10.clj
+++ b/src/aoc_clj/2016/day10.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2016.day10
+  "Solution to https://adventofcode.com/2016/day/10"
   (:require [clojure.string :as str]
             [aoc-clj.utils.core :as u]))
 
@@ -40,13 +41,11 @@
   [cmds]
   (filter #(= :comparison (:type %)) cmds))
 
-(defn initialize
+(defn parse
   [input]
   (let [cmds (map parse-line input)]
     {:assignments (reduce assign {} (assignments cmds))
      :comparisons (into {} (map establish-comparison (comparisons cmds)))}))
-
-(def day10-input (initialize (u/puzzle-input "inputs/2016/day10-input.txt")))
 
 (defn ready-bots
   [{:keys [assignments]}]
@@ -75,10 +74,6 @@
         (read-string (subs (ffirst matches) 3))
         (recur (step s))))))
 
-(defn day10-part1-soln
-  []
-  (bot-that-compares day10-input #{17 61}))
-
 (defn output-values
   [state]
   (let [outputs (-> (u/converge step state)
@@ -90,6 +85,10 @@
          (map first)
          (reduce *))))
 
+(defn day10-part1-soln
+  [input]
+  (bot-that-compares input #{17 61}))
+
 (defn day10-part2-soln
-  []
-  (output-values day10-input))
+  [input]
+  (output-values input))

--- a/src/aoc_clj/2016/day11.clj
+++ b/src/aoc_clj/2016/day11.clj
@@ -1,32 +1,11 @@
 (ns aoc-clj.2016.day11
+  "Solution to https://adventofcode.com/2016/day/11"
   (:require [clojure.math.combinatorics :as combo]
             [clojure.set :as set]
             [aoc-clj.utils.core :as u]
             [aoc-clj.utils.graph :as g :refer [Graph]]))
 
-"The first floor contains a hydrogen-compatible microchip and a lithium-compatible microchip."
-"The second floor contains a hydrogen generator."
-"The third floor contains a lithium generator."
-"The fourth floor contains nothing relevant."
-(def day11-sample
-  {:e 1
-  ;;  :move 0
-   1 #{[:m "H"] [:m "Li"]}
-   2 #{[:g "H"]}
-   3 #{[:g "Li"]}
-   4 #{}})
-
-"The first floor contains a thulium generator, a thulium-compatible microchip, a plutonium generator, and a strontium generator.
-The second floor contains a plutonium-compatible microchip and a strontium-compatible microchip.
-The third floor contains a promethium generator, a promethium-compatible microchip, a ruthenium generator, and a ruthenium-compatible microchip.
-The fourth floor contains nothing relevant."
-(def day11-input
-  {:e 1
-  ;;  :move 0
-   1 #{[:m "Tm"] [:g "Tm"] [:g "Pu"] [:g "Sr"]}
-   2 #{[:m "Pu"] [:m "Sr"]}
-   3 #{[:m "Pm"] [:m "Ru"] [:g "Pm"] [:g "Ru"]}
-   4 #{}})
+;; TODO - Should add a parse method
 
 (defn endstate
   [state]
@@ -107,14 +86,14 @@ The fourth floor contains nothing relevant."
        count
        dec))
 
-(defn day11-part1-soln
-  []
-  (move-count day11-input))
-
 (defn extra-items
   [state]
   (update state 1 conj [:m "El"] [:g "El"] [:m "Li2"] [:g "Li2"]))
 
+(defn day11-part1-soln
+  [input]
+  (move-count input))
+
 (defn day11-part2-soln
-  []
-  (move-count (extra-items day11-input)))
+  [input]
+  (move-count (extra-items input)))

--- a/src/aoc_clj/2016/day12.clj
+++ b/src/aoc_clj/2016/day12.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2016.day12
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2016/day/12"
+  (:require [clojure.string :as str]))
 
 (defn parse-var
   [x]
@@ -16,7 +16,9 @@
       {:cmd a :x (parse-var b) :y (parse-var c)}
       {:cmd a :x (parse-var b)})))
 
-(def day12-input (mapv parse-line (u/puzzle-input "inputs/2016/day12-input.txt")))
+(defn parse
+  [input]
+  (mapv parse-line input))
 
 (defn dref
   [state x]
@@ -51,12 +53,10 @@
         (recur (apply-cmd state cmd))))))
 
 (defn day12-part1-soln
-  []
-  (:a (execute init-state day12-input)))
+  [input]
+  (:a (execute init-state input)))
 
 (defn day12-part2-soln
-  []
-  (:a (execute
-       (assoc init-state :c 1)
-       day12-input)))
+  [input]
+  (:a (execute (assoc init-state :c 1) input)))
 

--- a/src/aoc_clj/2016/day13.clj
+++ b/src/aoc_clj/2016/day13.clj
@@ -1,9 +1,7 @@
 (ns aoc-clj.2016.day13
-  (:require [aoc-clj.utils.core :as u]
-            [aoc-clj.utils.binary :as b]
-            [aoc-clj.utils.graph :as g]
-            [aoc-clj.utils.grid.mapgrid :as mapgrid :refer [->MapGrid2D]]
-            [aoc-clj.utils.maze :as maze :refer [->Maze]]))
+  "Solution to https://adventofcode.com/2016/day/13"
+  (:require [aoc-clj.utils.binary :as b]
+            [aoc-clj.utils.grid.mapgrid :as mapgrid :refer [->MapGrid2D]]))
 
 (def charmap
   {\. :open
@@ -33,14 +31,14 @@
                x (range width)]
            [[x y] (cell fav [x y])]))))
 
-(defn path-distance
-  [fav finish]
-  (let [start [1 1]
-        grid  (construct-grid fav 10 7)
-        maze  (->Maze (:grid grid) #(= :open %))
-        graph (-> maze maze/Maze->Graph (g/pruned #{start finish}))
-        path  (g/dijkstra graph start (u/equals? finish))]
-    (println graph)
-    (g/path-distance graph path)))
+;; (defn path-distance
+;;   [fav finish]
+;;   (let [start [1 1]
+;;         grid  (construct-grid fav 10 7)
+;;         maze  (->Maze (:grid grid) #(= :open %))
+;;         graph (-> maze maze/Maze->Graph (g/pruned #{start finish}))
+;;         path  (g/dijkstra graph start (u/equals? finish))]
+;;     (println graph)
+;;     (g/path-distance graph path)))
 
 ;; (path-distance 10 [7 4])

--- a/src/aoc_clj/2018/day01.clj
+++ b/src/aoc_clj/2018/day01.clj
@@ -1,7 +1,9 @@
 (ns aoc-clj.2018.day01
-  (:require [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2018/day/1")
 
-(def day01-input (map read-string (u/puzzle-input "inputs/2018/day01-input.txt")))
+(defn parse
+  [input]
+  (map read-string input))
 
 (defn net-freq-change
   "Sums all the changes in frequency, starting with zero"
@@ -19,9 +21,9 @@
         (recur (rest freqs) (conj observed freq))))))
 
 (defn day01-part1-soln
-  []
-  (net-freq-change day01-input))
+  [input]
+  (net-freq-change input))
 
 (defn day01-part2-soln
-  []
-  (find-first-repeated-freq day01-input))
+  [input]
+  (find-first-repeated-freq input))

--- a/src/aoc_clj/2018/day02.clj
+++ b/src/aoc_clj/2018/day02.clj
@@ -1,8 +1,8 @@
 (ns aoc-clj.2018.day02
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2018/day/2"
+  (:require [clojure.string :as str]))
 
-(def day02-input (u/puzzle-input "inputs/2018/day02-input.txt"))
+(def parse identity)
 
 (defn repeat-count
   [repeat-num coll]
@@ -51,9 +51,9 @@
     (chars-in-common (nth box-ids index1) (nth box-ids index2))))
 
 (defn day02-part1-soln
-  []
-  (compute-checksum day02-input))
+  [input]
+  (compute-checksum input))
 
 (defn day02-part2-soln
-  []
-  (find-closest-boxids day02-input))
+  [input]
+  (find-closest-boxids input))

--- a/src/aoc_clj/2018/day03.clj
+++ b/src/aoc_clj/2018/day03.clj
@@ -1,9 +1,9 @@
 (ns aoc-clj.2018.day03
+  "Solution to https://adventofcode.com/2018/day/3"
   (:require [clojure.set :as set]
-            [clojure.string :as string]
-            [aoc-clj.utils.core :as u]))
+            [clojure.string :as string]))
 
-(defn parse-input-line
+(defn parse-line
   [line]
   (let [vars (->> (string/split line #"[@\,\:x]")
                   (map string/trim))
@@ -14,7 +14,9 @@
      :w (read-string w)
      :h (read-string h)}))
 
-(def day03-input (map parse-input-line (u/puzzle-input "inputs/2018/day03-input.txt")))
+(defn parse
+  [input]
+  (map parse-line input))
 
 (defn swath-grid
   [{:keys [x y w h]}]
@@ -58,11 +60,11 @@
     (first (set/difference all-ids overlap-ids))))
 
 (defn day03-part1-soln
-  []
-  (overlapping-squares day03-input))
+  [input]
+  (overlapping-squares input))
 
 (defn day03-part2-soln
-  []
-  (nonoverlapping-swath day03-input))
+  [input]
+  (nonoverlapping-swath input))
 
 

--- a/src/aoc_clj/2018/day04.clj
+++ b/src/aoc_clj/2018/day04.clj
@@ -1,8 +1,7 @@
 (ns aoc-clj.2018.day04
+  "Solution to https://adventofcode.com/2018/day/4"
   (:require [clojure.string :as str]
             [aoc-clj.utils.core :as u]))
-
-(def day04-input (str/join "\n" (sort (u/puzzle-input "inputs/2018/day04-input.txt"))))
 
 (defn parse-shift
   [shift]
@@ -13,7 +12,7 @@
 
 (defn parse
   [input]
-  (->> (str/split input #"\[.{16}\] Guard ")
+  (->> (str/split (str/join "\n" (sort input)) #"\[.{16}\] Guard ")
        (map #(str/split % #"\n"))
        rest
        (map parse-shift)
@@ -45,9 +44,9 @@
     [guard minute]))
 
 (defn day04-part1-soln
-  []
-  (reduce * (sleepiest-guard-and-optimal-minute (parse day04-input))))
+  [input]
+  (reduce * (sleepiest-guard-and-optimal-minute input)))
 
 (defn day04-part2-soln
-  []
-  (reduce * (guard-most-frequently-asleep-at-minute (parse day04-input))))
+  [input]
+  (reduce * (guard-most-frequently-asleep-at-minute input)))

--- a/src/aoc_clj/2019/day01.clj
+++ b/src/aoc_clj/2019/day01.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2019.day01
-  (:require [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2019/day/1")
 
-(def day01-input
-  (map read-string (u/puzzle-input "inputs/2019/day01-input.txt")))
+(defn parse
+  [input]
+  (map read-string input))
 
 (defn fuel
   "[T]o find the fuel required for a module, take its mass, 
@@ -28,9 +29,9 @@
        (reduce +)))
 
 (defn day01-part1-soln
-  []
-  (reduce + (map fuel day01-input)))
+  [input]
+  (reduce + (map fuel input)))
 
 (defn day01-part2-soln
-  []
-  (reduce + (map total-fuel day01-input)))
+  [input]
+  (reduce + (map total-fuel input)))

--- a/src/aoc_clj/2019/day02.clj
+++ b/src/aoc_clj/2019/day02.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2019.day02
+  "Solution to https://adventofcode.com/2019/day/2"
   (:require [aoc-clj.utils.core :as u]
             [aoc-clj.utils.intcode :as intcode]))
 
-(def day02-input (u/firstv (u/puzzle-input "inputs/2019/day02-input.txt")))
+(def parse u/firstv)
 
 (defn override-intcode
   "Replace `intcode` with `noun` in position 1 and `verb` in position 2"
@@ -20,10 +21,6 @@
        :intcode
        first))
 
-(defn day02-part1-soln
-  []
-  (intcode-output day02-input [12 2]))
-
 (defn pair-produces-output
   "Find the noun/verb pair that will produce the `output` value for
    `intcode` program."
@@ -35,7 +32,11 @@
             #(not= output (intcode-output intcode %))
             candidates))))
 
+(defn day02-part1-soln
+  [input]
+  (intcode-output input [12 2]))
+
 (defn day02-part2-soln
-  []
-  (let [[noun verb] (pair-produces-output day02-input 19690720)]
+  [input]
+  (let [[noun verb] (pair-produces-output input 19690720)]
     (+ (* 100 noun) verb)))

--- a/src/aoc_clj/2019/day03.clj
+++ b/src/aoc_clj/2019/day03.clj
@@ -1,7 +1,7 @@
 (ns aoc-clj.2019.day03
+  "Solution to https://adventofcode.com/2019/day/3"
   (:require [clojure.set :as set]
             [clojure.string :as str]
-            [aoc-clj.utils.core :as u]
             [aoc-clj.utils.math :as math]))
 
 (defn parse-segment
@@ -12,8 +12,9 @@
   [segments]
   (map parse-segment segments))
 
-(def day03-input
-  (->> (u/puzzle-input "inputs/2019/day03-input.txt")
+(defn parse
+  [input]
+  (->> input
        (map #(str/split % #","))
        (map parse-segments)))
 
@@ -55,10 +56,6 @@
        sort
        ;; we take second because [0 0] is in the set
        second))
-
-(defn day03-part1-soln
-  []
-  (closest-intersection-dist day03-input))
 
 ;; Slightly convoluted. I want a mapping from a point
 ;; to the shortest distance to that point. Because 
@@ -111,6 +108,10 @@
 ;;                        (get path1-dists (first %))) path2-dists)]
 ;;     (second (sort dists))))
 
+(defn day03-part1-soln
+  [input]
+  (closest-intersection-dist input))
+
 (defn day03-part2-soln
-  []
-  (shortest-steps-to-intersection day03-input))
+  [input]
+  (shortest-steps-to-intersection input))

--- a/src/aoc_clj/2019/day04.clj
+++ b/src/aoc_clj/2019/day04.clj
@@ -1,6 +1,9 @@
-(ns aoc-clj.2019.day04)
+(ns aoc-clj.2019.day04
+  "Solution to https://adventofcode.com/2019/day/4")
 
-(def day04-input [231832 767346])
+(defn parse
+  [input]
+  (map read-string (re-seq #"\d+" (first input))))
 
 (def my-any? (complement not-any?))
 
@@ -27,8 +30,8 @@
        (filter condition)))
 
 (defn day04-part1-soln
-  []
-  (count (satisfactory-numbers (apply range day04-input) all-conds-part1?)))
+  [input]
+  (count (satisfactory-numbers (apply range input) all-conds-part1?)))
 
 (defn pair-not-in-larger-group?
   [digits]
@@ -38,5 +41,5 @@
   (every-pred not-decreasing-digits? pair-not-in-larger-group?))
 
 (defn day04-part2-soln
-  []
-  (count (satisfactory-numbers (apply range day04-input) all-conds-part2?)))
+  [input]
+  (count (satisfactory-numbers (apply range input) all-conds-part2?)))

--- a/src/aoc_clj/2019/day05.clj
+++ b/src/aoc_clj/2019/day05.clj
@@ -1,13 +1,14 @@
 (ns aoc-clj.2019.day05
+  "Solution to https://adventofcode.com/2019/day/5"
   (:require [aoc-clj.utils.core :as u]
             [aoc-clj.utils.intcode :as intcode]))
 
-(def day05-input (u/firstv (u/puzzle-input "inputs/2019/day05-input.txt")))
+(def parse u/firstv)
 
 (defn day05-part1-soln
-  []
-  (intcode/last-out (intcode/intcode-exec day05-input [1])))
+  [input]
+  (intcode/last-out (intcode/intcode-exec input [1])))
 
 (defn day05-part2-soln
-  []
-  (intcode/last-out (intcode/intcode-exec day05-input [5])))
+  [input]
+  (intcode/last-out (intcode/intcode-exec input [5])))

--- a/src/aoc_clj/2019/day06.clj
+++ b/src/aoc_clj/2019/day06.clj
@@ -1,9 +1,10 @@
 (ns aoc-clj.2019.day06
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2019/day/6"
+  (:require [clojure.string :as str]))
 
-(def day06-input
-  (->> (u/puzzle-input "inputs/2019/day06-input.txt")
+(defn parse
+  [input]
+  (->> input
        (map #(str/split % #"\)"))
        (mapcat reverse)
        (apply hash-map)))
@@ -49,9 +50,9 @@
        2)))
 
 (defn day06-part1-soln
-  []
-  (orbit-count day06-input))
+  [input]
+  (orbit-count input))
 
 (defn day06-part2-soln
-  []
-  (orbit-transfers day06-input "YOU" "SAN"))
+  [input]
+  (orbit-transfers input "YOU" "SAN"))

--- a/src/aoc_clj/2019/day07.clj
+++ b/src/aoc_clj/2019/day07.clj
@@ -1,10 +1,11 @@
 (ns aoc-clj.2019.day07
+  "Solution to https://adventofcode.com/2019/day/7"
   (:require [clojure.math.combinatorics :as combo]
             [manifold.stream :as s]
             [aoc-clj.utils.core :as u]
             [aoc-clj.utils.intcode :as intcode]))
 
-(def day05-input (u/firstv (u/puzzle-input "inputs/2019/day07-input.txt")))
+(def parse u/firstv)
 
 (defn amplifier
   "Creates an 'amplifier' `intcode` program to run on another thread
@@ -62,9 +63,9 @@
   (max-output intcode amplifier-loop [5 6 7 8 9]))
 
 (defn day07-part1-soln
-  []
-  (max-amplifier-chain-output day05-input))
+  [input]
+  (max-amplifier-chain-output input))
 
 (defn day07-part2-soln
-  []
-  (max-amplifier-loop-output day05-input))
+  [input]
+  (max-amplifier-loop-output input))

--- a/src/aoc_clj/2019/day08.clj
+++ b/src/aoc_clj/2019/day08.clj
@@ -1,18 +1,12 @@
 (ns aoc-clj.2019.day08
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2019/day/8"
+  (:require [clojure.string :as str]))
 
-(def day08-input
-  (->> (u/puzzle-input "inputs/2019/day08-input.txt")
+(defn parse
+  [input]
+  (->> input
        first
        (map (comp read-string str))))
-
-(defn day08-part1-soln
-  []
-  (let [layers (partition (* 25 6) day08-input)
-        layer-freqs (map frequencies layers)
-        min-zero-layer (apply min-key #(get % 0) layer-freqs)]
-    (* (get min-zero-layer 1) (get min-zero-layer 2))))
 
 (defn final-pixel
   [pixels]
@@ -31,9 +25,17 @@
     (doseq [line (partition width legible-pixels)]
       (println (str/join line)))))
 
+(defn day08-part1-soln
+  [input]
+  (let [layers (partition (* 25 6) input)
+        layer-freqs (map frequencies layers)
+        min-zero-layer (apply min-key #(get % 0) layer-freqs)]
+    (* (get min-zero-layer 1) (get min-zero-layer 2))))
+
 (defn day08-part2-soln
-  []
-  ;; (pprint-image (decode-image day08-input 25 6) 25)
+  [input]
+  (comment
+    (pprint-image (decode-image input 25 6) 25)
   ;; Displays:
   ;; *  * ****  **  **** *  *
   ;; *  *    * *  *    * *  *
@@ -41,4 +43,5 @@
   ;; *  *  *   *     *   *  *
   ;; *  * *    *  * *    *  *
   ;; *  * ****  **  ****  **
+    )
   "HZCZU")

--- a/src/aoc_clj/2019/day09.clj
+++ b/src/aoc_clj/2019/day09.clj
@@ -1,13 +1,14 @@
 (ns aoc-clj.2019.day09
+  "Solution to https://adventofcode.com/2019/day/9"
   (:require [aoc-clj.utils.core :as u]
             [aoc-clj.utils.intcode :as intcode]))
 
-(def day09-input (u/firstv (u/puzzle-input "inputs/2019/day09-input.txt")))
+(def parse u/firstv)
 
 (defn day09-part1-soln
-  []
-  (intcode/last-out (intcode/intcode-exec day09-input [1])))
+  [input]
+  (intcode/last-out (intcode/intcode-exec input [1])))
 
 (defn day09-part2-soln
-  []
-  (intcode/last-out (intcode/intcode-exec day09-input [2])))
+  [input]
+  (intcode/last-out (intcode/intcode-exec input [2])))

--- a/src/aoc_clj/2019/day10.clj
+++ b/src/aoc_clj/2019/day10.clj
@@ -1,15 +1,14 @@
 (ns aoc-clj.2019.day10
+  "Solution to https://adventofcode.com/2019/day/10"
   (:require [aoc-clj.utils.core :as u]
             [aoc-clj.utils.math :as math]))
 
-(defn parse-map
+(defn parse
   [ascii-asteroids]
   (for [y (range (count ascii-asteroids))
         x (range (count (first ascii-asteroids)))
         :when (= \# (nth (nth ascii-asteroids y) x))]
     [x y]))
-
-(def day10-input (parse-map (u/puzzle-input "inputs/2019/day10-input.txt")))
 
 (defn quadrant
   [[x1 y1] [x2 y2]]
@@ -47,10 +46,6 @@
   (let [counts (map #(visible-asteroid-count % asteroids) asteroids)
         visibles (zipmap asteroids counts)]
     (apply max-key second visibles)))
-
-(defn day10-part1-soln
-  []
-  (best-location day10-input))
 
 (defn angle
   [[slope quadrant]]
@@ -95,9 +90,13 @@
          (apply mapcat vector)
          (filter some?))))
 
+(defn day10-part1-soln
+  [input]
+  (best-location input))
+
 (defn day10-part2-soln
-  []
-  (let [pos (first (day10-part1-soln))
-        [x y] (nth (asteroids-laser-order pos day10-input) 199)]
+  [input]
+  (let [pos (first (day10-part1-soln input))
+        [x y] (nth (asteroids-laser-order pos input) 199)]
     (+ (* 100 x) y)))
 

--- a/src/aoc_clj/2019/day11.clj
+++ b/src/aoc_clj/2019/day11.clj
@@ -1,11 +1,12 @@
 (ns aoc-clj.2019.day11
+  "Solution to https://adventofcode.com/2019/day/11"
   (:require [manifold.stream :as s]
             [aoc-clj.utils.core :as u]
             [aoc-clj.utils.grid :as grid]
             [aoc-clj.utils.grid.vecgrid :refer [->VecGrid2D]]
             [aoc-clj.utils.intcode :as intcode]))
 
-(def day11-input (u/firstv (u/puzzle-input "inputs/2019/day11-input.txt")))
+(def parse u/firstv)
 
 (defn turn-left-and-move
   [{:keys [direction] [x y] :position}]
@@ -51,28 +52,27 @@
         (recur (stepper state))))))
 
 (defn day11-part1-soln
-  []
-  (count (keys (:hull (paint-bot day11-input 0)))))
+  [input]
+  (count (keys (:hull (paint-bot input 0)))))
 
 (defn- derive-day11-part2-soln
-  []
-  (->> (paint-bot day11-input 1)
+  [input]
+  (->> (paint-bot input 1)
        :hull
        grid/mapgrid->vectors
        ->VecGrid2D
        (grid/Grid2D->ascii {\  0 \* 1})
        print))
 
-(comment
-  (derive-day11-part2-soln)
-  "Prints out:
-    **** *    **** ***  *  *   ** ***   **    
-       * *    *    *  * * *     * *  * *  *   
-      *  *    ***  ***  **      * *  * *  *   
-     *   *    *    *  * * *     * ***  ****   
-    *    *    *    *  * * *  *  * * *  *  *   
-    **** **** **** ***  *  *  **  *  * *  *   ")
-
 (defn day11-part2-soln
-  []
+  [input]
+  (comment
+    (derive-day11-part2-soln input)
+    "Prints out:
+      **** *    **** ***  *  *   ** ***   **    
+         * *    *    *  * * *     * *  * *  *   
+        *  *    ***  ***  **      * *  * *  *   
+       *   *    *    *  * * *     * ***  ****   
+      *    *    *    *  * * *  *  * * *  *  *   
+      **** **** **** ***  *  *  **  *  * *  *   ")
   "ZLEBKJRA")

--- a/src/aoc_clj/2019/day12.clj
+++ b/src/aoc_clj/2019/day12.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2019.day12
+  "Solution to https://adventofcode.com/2019/day/12"
   (:require [clojure.string :as str]
             [aoc-clj.utils.core :as u]
             [aoc-clj.utils.math :as math]))
@@ -11,8 +12,9 @@
            (str/split #"\s+"))
        (map read-string)))
 
-(def day12-input
-  (map parse-coord (u/puzzle-input "inputs/2019/day12-input.txt")))
+(defn parse
+  [input]
+  (map parse-coord input))
 
 (defn rotations
   [coll]
@@ -66,10 +68,6 @@
         kinetic-energies (map energy vels)]
     (reduce + (map * potential-energies kinetic-energies))))
 
-(defn day12-part1-soln
-  []
-  (total-energy (nth (simulate day12-input) 1000)))
-
 (def initial-velocity-axis
   (repeat 4 (repeat 1 0)))
 
@@ -89,6 +87,10 @@
   [moons]
   (* 2 (apply math/lcm (pmap axis-period [:x :y :z] (repeat moons)))))
 
+(defn day12-part1-soln
+  [input]
+  (total-energy (nth (simulate input) 1000)))
+
 (defn day12-part2-soln
-  []
-  (recurrence-period day12-input))
+  [input]
+  (recurrence-period input))

--- a/src/aoc_clj/2019/day13.clj
+++ b/src/aoc_clj/2019/day13.clj
@@ -1,16 +1,11 @@
 (ns aoc-clj.2019.day13
+  "Solution to https://adventofcode.com/2019/day/13"
   (:require [lanterna.screen :as scr]
             [manifold.stream :as s]
             [aoc-clj.utils.core :as u]
             [aoc-clj.utils.intcode :as intcode]))
 
-(def day13-input (u/firstv (u/puzzle-input "inputs/2019/day13-input.txt")))
-
-(defn day13-part1-soln
-  []
-  (let [board (intcode/out-seq (intcode/intcode-exec day13-input []))
-        tile-values (flatten (partition 1 3 (drop 2 board)))]
-    (get (frequencies tile-values) 2)))
+(def parse u/firstv)
 
 (defn val->str
   [val]
@@ -58,11 +53,11 @@
    There's some indeterminism here due to the multithreaded
    implementation so the game won't always successfully
    complete"
-  []
+  [input]
   (let [in (s/stream)
         out (s/stream)
         screen (scr/get-screen :swing {:rows 25})
-        code (assoc day13-input 0 2)
+        code (assoc input 0 2)
         program (future (intcode/intcode-exec code in out))
         paddle-loc (atom 20)]
     (scr/start screen)
@@ -72,7 +67,14 @@
     @program
     (println "Finished!")))
 
+(defn day13-part1-soln
+  [input]
+  (let [board (intcode/out-seq (intcode/intcode-exec input []))
+        tile-values (flatten (partition 1 3 (drop 2 board)))]
+    (get (frequencies tile-values) 2)))
+
 (defn day13-part2-soln
   "After playing the `breakout` game above, 11140 is the max high score"
-  []
+  [input]
+  (comment (breakout input))
   11140)

--- a/src/aoc_clj/2019/day14.clj
+++ b/src/aoc_clj/2019/day14.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2019.day14
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2019/day/14"
+  (:require [clojure.string :as str]))
 
 (defn parse-component
   [comp-str]
@@ -15,18 +15,15 @@
         [chem qty] (parse-component rhs)]
     {chem {:min-qty qty :comps components}}))
 
-(defn reactions
+(defn parse
   [input]
   (->> input
        (map parse-line)
        (apply merge)))
 
-(def day14-input
-  (reactions (u/puzzle-input "inputs/2019/day14-input.txt")))
-
-(defn multiply
-  [factor ingredients]
-  (mapcat (fn [[chem qty]] [chem (* factor qty)]) (partition 2 ingredients)))
+;; (defn multiply
+;;   [factor ingredients]
+;;   (mapcat (fn [[chem qty]] [chem (* factor qty)]) (partition 2 ingredients)))
 
 (defn consume
   [inventory used [chemical qty]]
@@ -64,10 +61,6 @@
   ([recipes amount]
    (get-in (ingredients-used recipes :FUEL amount) [:consumed :ORE])))
 
-(defn day14-part1-soln
-  []
-  (ore-amount day14-input))
-
 (def available-ore 1000000000000)
 
 (defn binary-search
@@ -90,6 +83,10 @@
         end-guess (int (* 1.3 start-guess))]
     (first (binary-search (partial ore-amount recipes) available-ore start-guess end-guess))))
 
+(defn day14-part1-soln
+  [input]
+  (ore-amount input))
+
 (defn day14-part2-soln
-  []
-  (max-fuel day14-input))
+  [input]
+  (max-fuel input))

--- a/src/aoc_clj/2019/day15.clj
+++ b/src/aoc_clj/2019/day15.clj
@@ -1,11 +1,12 @@
 (ns aoc-clj.2019.day15
+  "Solution to https://adventofcode.com/2019/day/15"
   (:require [manifold.stream :as s]
             [aoc-clj.utils.core :as u]
             [aoc-clj.utils.intcode :as intcode]
             [aoc-clj.utils.graph :as g]
             [aoc-clj.utils.maze :as maze]))
 
-(def day15-input (u/firstv (u/puzzle-input "inputs/2019/day15-input.txt")))
+(def parse u/firstv)
 
 (def dir->code
   {:n 1
@@ -33,16 +34,20 @@
         _ (future (intcode/intcode-exec intcode in out))]
     (maze/map-maze probe #(= :wall %))))
 
-(def thismaze (map-maze-with-droid day15-input))
+(defn thismaze
+  [input]
+  (map-maze-with-droid input))
 
 (defn day15-part1-soln
-  []
-  (let [start [0 0]
+  [input]
+  (let [thismaze (thismaze input)
+        start [0 0]
         finish (maze/find-target thismaze :oxygen)
         simplified-maze (-> thismaze maze/Maze->Graph (g/pruned #{start finish}))
         path (g/dijkstra simplified-maze start (u/equals? finish))]
     (g/path-distance simplified-maze path)))
 
 (defn day15-part2-soln
-  []
-  (maze/flood-fill thismaze (maze/find-target thismaze :oxygen)))
+  [input]
+  (let [thismaze (thismaze input)]
+    (maze/flood-fill thismaze (maze/find-target thismaze :oxygen))))

--- a/src/aoc_clj/2019/day16.clj
+++ b/src/aoc_clj/2019/day16.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2019.day16
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2019/day/16"
+  (:require [clojure.string :as str]))
 
 (defn nums->str
   [nums]
@@ -10,8 +10,7 @@
   [s]
   (mapv (comp read-string str) s))
 
-(def day16-input
-  (str->nums (first (u/puzzle-input "inputs/2019/day16-input.txt"))))
+(def parse (comp str->nums first))
 
 (defn selector-lookup
   [size idx]
@@ -22,14 +21,14 @@
     {:add-indices adds
      :sub-indices subs}))
 
-(defn selector-lookup-shift
-  [size shift idx]
-  (let [adds (for [x (range idx size (* (inc idx) 4))]
-               [(- x shift) (- (min size (+ x idx 1)) shift)])
-        subs (for [x (range (dec (* 3 (inc idx))) size (* (inc idx) 4))]
-               [(- x shift) (- (min size (+ x idx 1)) shift)])]
-    {:add-indices adds
-     :sub-indices subs}))
+;; (defn selector-lookup-shift
+;;   [size shift idx]
+;;   (let [adds (for [x (range idx size (* (inc idx) 4))]
+;;                [(- x shift) (- (min size (+ x idx 1)) shift)])
+;;         subs (for [x (range (dec (* 3 (inc idx))) size (* (inc idx) 4))]
+;;                [(- x shift) (- (min size (+ x idx 1)) shift)])]
+;;     {:add-indices adds
+;;      :sub-indices subs}))
 
 (defn selector
   [size idx coll]
@@ -37,11 +36,11 @@
     {:adds (vec (mapcat #(apply subvec coll %) add-indices))
      :subs (vec (mapcat #(apply subvec coll %) sub-indices))}))
 
-(defn selector-shift
-  [size shift idx coll]
-  (let [{:keys [add-indices sub-indices]} (selector-lookup-shift size shift idx)]
-    {:adds (vec (mapcat #(apply subvec coll %) add-indices))
-     :subs (vec (mapcat #(apply subvec coll %) sub-indices))}))
+;; (defn selector-shift
+;;   [size shift idx coll]
+;;   (let [{:keys [add-indices sub-indices]} (selector-lookup-shift size shift idx)]
+;;     {:adds (vec (mapcat #(apply subvec coll %) add-indices))
+;;      :subs (vec (mapcat #(apply subvec coll %) sub-indices))}))
 
 (defn do-calc
   [{:keys [adds subs]}]
@@ -53,10 +52,10 @@
   (let [selections (pmap #(selector size % num) (range size))]
     (mapv do-calc selections)))
 
-(defn digit-calc-shift
-  [size shift num]
-  (let [selections (pmap #(selector-shift size shift % num) (range shift size))]
-    (mapv do-calc selections)))
+;; (defn digit-calc-shift
+;;   [size shift num]
+;;   (let [selections (pmap #(selector-shift size shift % num) (range shift size))]
+;;     (mapv do-calc selections)))
 
 (defn phase
   [num]
@@ -68,10 +67,6 @@
   (let [size (count nums)
         stepper (partial digit-calc size)]
     (first (drop phases (iterate stepper nums)))))
-
-(defn day16-part1-soln
-  []
-  (nums->str (take 8 (run-phases day16-input 100))))
 
 (defn add-mod-10
   [a b]
@@ -89,7 +84,11 @@
          (take-last 8)
          reverse)))
 
+(defn day16-part1-soln
+  [input]
+  (nums->str (take 8 (run-phases input 100))))
+
 (defn day16-part2-soln
-  []
-  (nums->str (real-signal day16-input 100)))
+  [input]
+  (nums->str (real-signal input 100)))
 

--- a/src/aoc_clj/2019/day17.clj
+++ b/src/aoc_clj/2019/day17.clj
@@ -1,11 +1,12 @@
 (ns aoc-clj.2019.day17
+  "Solution to https://adventofcode.com/2019/day/17"
   (:require [clojure.string :as str]
             [aoc-clj.utils.core :as u]
             [aoc-clj.utils.grid :as grid]
             [aoc-clj.utils.intcode :as intcode]
             [aoc-clj.utils.grid.mapgrid :as mapgrid]))
 
-(def day17-input (u/firstv (u/puzzle-input "inputs/2019/day17-input.txt")))
+(def parse u/firstv)
 
 (def scaffold-mapping
   {\. :space
@@ -21,8 +22,9 @@
   (let [lines (str/split (str/join (map char ascii)) #"\n")]
     (:grid (mapgrid/ascii->MapGrid2D scaffold-mapping lines :down true))))
 
-(def day17-map
-  (->> (intcode/intcode-exec day17-input)
+(defn day17-map
+  [input]
+  (->> (intcode/intcode-exec input)
        intcode/out-seq
        scaffold-map))
 
@@ -40,12 +42,6 @@
   [intersections]
   (reduce + (map #(apply * %) intersections)))
 
-(defn day17-part1-soln
-  []
-  (->> day17-map
-       intersections
-       alignment-sum))
-
 (def path
   (str
    "A,B,B,C,C,A,B,B,C,A\n"
@@ -54,9 +50,15 @@
    "L,12,L,8,R,10\n"
    "n\n"))
 
+(defn day17-part1-soln
+  [input]
+  (->> (day17-map input)
+       intersections
+       alignment-sum))
+
 (defn day17-part2-soln
-  []
-  (let [code (assoc day17-input 0 2)]
+  [input]
+  (let [code (assoc input 0 2)]
     (->> path
          (map (comp int char))
          (intcode/intcode-exec code)

--- a/src/aoc_clj/2019/day18.clj
+++ b/src/aoc_clj/2019/day18.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2019.day18
+  "Solution to https://adventofcode.com/2019/day/18"
   (:require [clojure.data.priority-map :refer [priority-map]]
             [clojure.set :as set]
             [clojure.string :as str]
@@ -12,7 +13,7 @@
 ;; FIXME: This implementation is too complex and not sufficiently documented
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/19
 
-(def day18-input (vec (u/puzzle-input "inputs/2019/day18-input.txt")))
+(def parse vec)
 
 (defn maze-map
   [char]
@@ -177,9 +178,6 @@
         path (locked-dijkstra graph)]
     (g/path-distance graph path)))
 
-(defn day18-part1-soln
-  []
-  (shortest-path (load-graph (load-maze day18-input))))
 
 (defn fix-maze
   [{:keys [entrances maze nodes] :as input}]
@@ -203,6 +201,10 @@
            :nodes (into (filter (partial not= [x y]) nodes) newents)
            :entrances (zipmap newents (map str (range))))))
 
+(defn day18-part1-soln
+  [input]
+  (shortest-path (load-graph (load-maze input))))
+
 (defn day18-part2-soln
-  []
-  (shortest-path (load-graph (fix-maze (load-maze day18-input)))))
+  [input]
+  (shortest-path (load-graph (fix-maze (load-maze input)))))

--- a/src/aoc_clj/2019/day19.clj
+++ b/src/aoc_clj/2019/day19.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2019.day19
+  "Solution to https://adventofcode.com/2019/day/19"
   (:require [aoc-clj.utils.core :as u]
             [aoc-clj.utils.intcode :as intcode]))
 
-(def day19-input (u/firstv (u/puzzle-input "inputs/2019/day19-input.txt")))
+(def parse u/firstv)
 
 (defn tractor-beam
   [intcode size]
@@ -11,11 +12,11 @@
              (intcode/out-seq (intcode/intcode-exec intcode [x y])))))
 
 (defn day19-part1-soln
-  []
-  (count (filter pos? (tractor-beam day19-input 50))))
+  [input]
+  (count (filter pos? (tractor-beam input 50))))
 
 ;; TODO: Add algorithmic solution for day19 part 2
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/20
 (defn day19-part2-soln
-  []
+  [_]
   12201460)

--- a/src/aoc_clj/2019/day20.clj
+++ b/src/aoc_clj/2019/day20.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2019.day20
+  "Solution to https://adventofcode.com/2019/day/20"
   (:require [clojure.string :as str]
             [aoc-clj.utils.core :as u]
             [aoc-clj.utils.graph :as g :refer [Graph ->MapGraph without-vertex]]
@@ -8,7 +9,7 @@
 ;; TODO: 2019 Day 20 implementation is too complex and undocumented 
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/21
 
-(def day20-input (vec (u/puzzle-input "inputs/2019/day20-input.txt")))
+(def parse vec)
 
 (defn maze-dims
   [maze]
@@ -140,10 +141,6 @@
         graph (:graph state)]
     (g/path-distance graph (g/dijkstra graph start end))))
 
-(defn day20-part1-soln
-  []
-  (solve-maze day20-input))
-
 (defrecord RecursiveMaze [lookup3d]
   Graph
   (vertices
@@ -204,6 +201,10 @@
         rmaze (recursive-maze state)]
     (g/path-distance rmaze (g/dijkstra rmaze start end :limit 100000))))
 
+(defn day20-part1-soln
+  [input]
+  (solve-maze input))
+
 (defn day20-part2-soln
-  []
-  (solve-recursive-maze day20-input))
+  [input]
+  (solve-recursive-maze input))

--- a/src/aoc_clj/2019/day21.clj
+++ b/src/aoc_clj/2019/day21.clj
@@ -1,11 +1,12 @@
 (ns aoc-clj.2019.day21
+  "Solution to https://adventofcode.com/2019/day/21"
   (:require [aoc-clj.utils.core :as u]
             [aoc-clj.utils.intcode :as intcode]))
 
 ;; FIXME Add code or documentation for where the springcode came from
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/22
 
-(def day21-input (u/firstv (u/puzzle-input "inputs/2019/day21-input.txt")))
+(def parse u/firstv)
 
 (def spring-codes-part1
   ["OR A T"
@@ -27,13 +28,13 @@
    "RUN"])
 
 (defn day21-part1-soln
-  []
+  [input]
   (->> (intcode/cmds->ascii spring-codes-part1)
-       (intcode/intcode-exec day21-input)
+       (intcode/intcode-exec input)
        intcode/last-out))
 
 (defn day21-part2-soln
-  []
+  [input]
   (->> (intcode/cmds->ascii spring-codes-part2)
-       (intcode/intcode-exec day21-input)
+       (intcode/intcode-exec input)
        intcode/last-out))

--- a/src/aoc_clj/2019/day22.clj
+++ b/src/aoc_clj/2019/day22.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2019.day22
+  "Solution to https://adventofcode.com/2019/day/22"
   (:require [clojure.string :as str]
             [aoc-clj.utils.core :as u]
             [aoc-clj.utils.math :as math]))
@@ -12,8 +13,9 @@
             (str/replace #"cut" ":cut")
             (str/split #" "))))
 
-(def day22-input
-  (map parse-line (u/puzzle-input "inputs/2019/day22-input.txt")))
+(defn parse
+  [input]
+  (map parse-line input))
 
 (defn deal-op
   "A deal into new stack is a mod-multiply by -1 and a mod-add of -1"
@@ -59,10 +61,6 @@
          lookup (vec deck)]
      (map lookup (map indices (range size))))))
 
-(defn day22-part1-soln
-  []
-  (u/index-of (u/equals? 2019) (shuffle-deck 10007 day22-input)))
-
 (defn card-after-multiple-shuffles
   [size steps times position]
   (let [pow-op (->> (reduced-ops size steps)
@@ -81,7 +79,11 @@
    five hundred eighty-two million, seventy-six thousand, six hundred sixty-one"
   101741582076661)
 
+(defn day22-part1-soln
+  [input]
+  (u/index-of (u/equals? 2019) (shuffle-deck 10007 input)))
+
 (defn day22-part2-soln
-  []
-  (card-after-multiple-shuffles card-count day22-input shuffle-count 2020))
+  [input]
+  (card-after-multiple-shuffles card-count input shuffle-count 2020))
 

--- a/src/aoc_clj/2019/day23.clj
+++ b/src/aoc_clj/2019/day23.clj
@@ -1,92 +1,94 @@
 (ns aoc-clj.2019.day23
-  (:require [manifold.stream :as s]
-            [aoc-clj.utils.core :as u]
-            [aoc-clj.utils.intcode :as intcode]))
+  "Solution to https://adventofcode.com/2019/day/23"
+  (:require ;; [manifold.stream :as s]
+   [aoc-clj.utils.core :as u]
+            ;; [aoc-clj.utils.intcode :as intcode]
+   ))
 
 ;; TODO Complete implementation and documentation
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/23
 
-(def day23-input (u/firstv (u/puzzle-input "inputs/2019/day23-input.txt")))
+(def parse u/firstv)
 
-(defn computer
-  [intcode in out]
-  (future (intcode/intcode-exec intcode in out)))
+;; (defn computer
+;;   [intcode in out]
+;;   (future (intcode/intcode-exec intcode in out)))
 
-(defn enqueue
-  [queues [idx out]]
-  (let [val @(s/take! out :nope)]
-    (if (= val :nope)
-      queues
-      (update queues idx conj val))))
+;; (defn enqueue
+;;   [queues [idx out]]
+;;   (let [val @(s/take! out :nope)]
+;;     (if (= val :nope)
+;;       queues
+;;       (update queues idx conj val))))
 
-(defn send-packet
-  [ins address [x y]]
-  (let [chan (nth ins address)]
-    (s/put! chan x)
-    (s/put! chan y)))
+;; (defn send-packet
+;;   [ins address [x y]]
+;;   (let [chan (nth ins address)]
+;;     (s/put! chan x)
+;;     (s/put! chan y)))
 
-(defn dequeue
-  [ins {:keys [queues nat] :as state} [idx queue]]
-  (let [address (first queue)
-        packet (take 2 (rest queue))
-        newnat (if (= address 255)
-                 packet
-                 (do
-                   (send-packet ins address packet)
-                   nat))]
-    (assoc state
-           :nat newnat
-           :queues (update queues idx (comp vec (partial drop 3))))))
+;; (defn dequeue
+;;   [ins {:keys [queues nat] :as state} [idx queue]]
+;;   (let [address (first queue)
+;;         packet (take 2 (rest queue))
+;;         newnat (if (= address 255)
+;;                  packet
+;;                  (do
+;;                    (send-packet ins address packet)
+;;                    nat))]
+;;     (assoc state
+;;            :nat newnat
+;;            :queues (update queues idx (comp vec (partial drop 3))))))
 
-(defn send-no-data
-  [ins]
-  (doseq [chan ins]
-    (s/put! chan -1)))
+;; (defn send-no-data
+;;   [ins]
+;;   (doseq [chan ins]
+;;     (s/put! chan -1)))
 
-(defn ready-to-send?
-  [[_ queue]]
-  (> (count queue) 2))
+;; (defn ready-to-send?
+;;   [[_ queue]]
+;;   (> (count queue) 2))
 
-(defn stop?
-  [readies]
-  (some #(= 255 %) (map first (vals readies))))
+;; (defn stop?
+;;   [readies]
+;;   (some #(= 255 %) (map first (vals readies))))
 
-(defn idle-network?
-  [outs queues]
-  (let [queued (reduce + (map count (vals queues)))
-        outs (reduce + (map (comp :pending-puts s/description) outs))]
-    (= 0 (+ queued outs))))
+;; (defn idle-network?
+;;   [outs queues]
+;;   (let [queued (reduce + (map count (vals queues)))
+;;         outs (reduce + (map (comp :pending-puts s/description) outs))]
+;;     (= 0 (+ queued outs))))
 
-(defn switch-step
-  [ins outs {:keys [queues nat] :as state}]
-  (let [new-queues (reduce enqueue queues (map-indexed vector outs))
-        new-state (assoc state :queues new-queues)
-        readies (filter ready-to-send? new-queues)]
-    (when (idle-network? outs queues)
-      (println "Packet from NAT" nat)
-      (send-packet ins 0 nat))
-    (if false
-      (assoc new-state :status readies)
-      (reduce (partial dequeue ins) new-state readies))))
+;; (defn switch-step
+;;   [ins outs {:keys [queues nat] :as state}]
+;;   (let [new-queues (reduce enqueue queues (map-indexed vector outs))
+;;         new-state (assoc state :queues new-queues)
+;;         readies (filter ready-to-send? new-queues)]
+;;     (when (idle-network? outs queues)
+;;       (println "Packet from NAT" nat)
+;;       (send-packet ins 0 nat))
+;;     (if false
+;;       (assoc new-state :status readies)
+;;       (reduce (partial dequeue ins) new-state readies))))
 
-(defn network
-  [intcode]
-  (let [ins (repeatedly 50 s/stream)
-        outs (repeatedly 50 s/stream)
-        queues (zipmap (range 50) (repeat []))
-        stepper (partial switch-step ins outs)
-        _ (doall (map s/put! ins (range 50)))
-        _ (send-no-data ins)
-        _ (doall (map (partial computer intcode) ins outs))]
-    (loop [state {:queues queues :nat [] :status nil}]
-      (if (some? (state :status))
-        (state :status)
-        (recur (stepper state))))))
+;; (defn network
+;;   [intcode]
+;;   (let [ins (repeatedly 50 s/stream)
+;;         outs (repeatedly 50 s/stream)
+;;         queues (zipmap (range 50) (repeat []))
+;;         stepper (partial switch-step ins outs)
+;;         _ (doall (map s/put! ins (range 50)))
+;;         _ (send-no-data ins)
+;;         _ (doall (map (partial computer intcode) ins outs))]
+;;     (loop [state {:queues queues :nat [] :status nil}]
+;;       (if (some? (state :status))
+;;         (state :status)
+;;         (recur (stepper state))))))
 
 (defn day23-part1-soln
-  []
+  [_]
   23886)
 
 (defn day23-part2-soln
-  []
+  [_]
   18333)

--- a/src/aoc_clj/2019/day24.clj
+++ b/src/aoc_clj/2019/day24.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2019.day24
+  "Solution to https://adventofcode.com/2019/day/24"
   (:require [aoc-clj.utils.core :as u]
             [aoc-clj.utils.grid :as grid]
             [aoc-clj.utils.grid.mapgrid :as mapgrid]))
@@ -11,8 +12,6 @@
 (defn parse
   [input]
   (:grid (mapgrid/ascii->MapGrid2D bug-map input :down true)))
-
-(def day24-input (parse (u/puzzle-input "inputs/2019/day24-input.txt")))
 
 (defn conway-rule
   [space pos neighbor-fn]
@@ -53,10 +52,6 @@
       (let [nextgrid (conway-step-2d grid)
             nextbio (biodiversity nextgrid)]
         (recur nextgrid nextbio (conj seen last))))))
-
-(defn day24-part1-soln
-  []
-  (find-recurrence day24-input))
 
 (defn base-neighbor-coords
   [[x y z]]
@@ -151,6 +146,10 @@
   [space3d]
   (u/count-if space3d #(= :bug (val %))))
 
+(defn day24-part1-soln
+  [input]
+  (find-recurrence input))
+
 (defn day24-part2-soln
-  []
-  (bug-count (simulate day24-input 200)))
+  [input]
+  (bug-count (simulate input 200)))

--- a/src/aoc_clj/2019/day25.clj
+++ b/src/aoc_clj/2019/day25.clj
@@ -1,10 +1,10 @@
 (ns aoc-clj.2019.day25
+  "Solution to https://adventofcode.com/2019/day/25"
   (:require [clojure.math.combinatorics :as combo]
             [aoc-clj.utils.core :as u]
             [aoc-clj.utils.intcode :as intcode]))
 
-(def day25-input (u/firstv (u/puzzle-input "inputs/2019/day25-input.txt")))
-(def day25-cmds (u/puzzle-input "inputs/2019/day25-cmds.txt"))
+(def parse u/firstv)
 
 (def checkpoint1-items
   ["astronaut ice cream"
@@ -29,37 +29,35 @@
     (concat drop-all combo-attempts)))
 
 (defn test-combinations
-  []
+  [input cmds]
   (intcode/interactive-asciicode
-   day25-input
-   (concat day25-cmds (test-checkpoint-cmds checkpoint1-items))))
-
-(comment
-  (test-combinations)
-  "Keeps trying to drop all possible combinations of objects until
-   the right combination triggers the pressure-sensitive floor.
-   That leads to the final commands in the walkthrough below")
+   input
+   (concat cmds (test-checkpoint-cmds checkpoint1-items))))
 
 (defn text-adventure-walkthrough
-  []
+  [input commands]
+  (comment
+    (test-combinations input commands)
+    "Keeps trying to drop all possible combinations of objects until
+     the right combination triggers the pressure-sensitive floor.
+     That leads to the final commands in the walkthrough below")
   (let [cmds (intcode/cmds->ascii
-              (concat day25-cmds
+              (concat commands
                       ["drop dark matter"]
                       ["drop astronaut ice cream"]
                       ["drop klein bottle"]
                       ["drop pointer"]
                       ["east"]))]
-    (->> (intcode/intcode-exec day25-input cmds)
+    (->> (intcode/intcode-exec input cmds)
          intcode/out-seq
          intcode/read-ascii-output
          println)))
 
-(comment
-  (text-adventure-walkthrough)
-  "A loud, robotic voice says \"Analysis complete! You may proceed.\" and you enter the cockpit."
-  "Santa notices your small droid, looks puzzled for a moment, realizes what has happened, and radios your ship directly."
-  "Oh, hello! You should be able to get in by typing 16410 on the keypad at the main airlock.")
-
 (defn day25-part1-soln
-  []
+  [input commands]
+  (comment
+    (text-adventure-walkthrough input commands)
+    "A loud, robotic voice says \"Analysis complete! You may proceed.\" and you enter the cockpit."
+    "Santa notices your small droid, looks puzzled for a moment, realizes what has happened, and radios your ship directly."
+    "Oh, hello! You should be able to get in by typing 16410 on the keypad at the main airlock.")
   16410)

--- a/src/aoc_clj/2020/day01.clj
+++ b/src/aoc_clj/2020/day01.clj
@@ -1,9 +1,10 @@
 (ns aoc-clj.2020.day01
-  (:require [clojure.math.combinatorics :as combo]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2020/day/1"
+  (:require [clojure.math.combinatorics :as combo]))
 
-(def day01-input
-  (map read-string (u/puzzle-input "inputs/2020/day01-input.txt")))
+(defn parse
+  [input]
+  (map read-string input))
 
 (defn find-pair-that-sums-to-total
   [total candidates]
@@ -22,9 +23,9 @@
          (filter candidate-set))))
 
 (defn day01-part1-soln
-  []
-  (apply * (find-pair-that-sums-to-total 2020 day01-input)))
+  [input]
+  (apply * (find-pair-that-sums-to-total 2020 input)))
 
 (defn day02-part2-soln
-  []
-  (apply * (find-triple-that-sums-to-total 2020 day01-input)))
+  [input]
+  (apply * (find-triple-that-sums-to-total 2020 input)))

--- a/src/aoc_clj/2020/day02.clj
+++ b/src/aoc_clj/2020/day02.clj
@@ -1,8 +1,8 @@
 (ns aoc-clj.2020.day02
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2020/day/2"
+  (:require [clojure.string :as str]))
 
-(defn parse
+(defn parse-line
   [input]
   (let [segments  (str/split input #" ")
         limits    (str/split (first segments) #"-")
@@ -13,8 +13,9 @@
      :char character
      :pass password}))
 
-(def day02-input
-  (map parse (u/puzzle-input "inputs/2020/day02-input.txt")))
+(defn parse
+  [input]
+  (map parse-line input))
 
 (defn part1-valid?
   [{:keys [min max char pass]}]
@@ -34,9 +35,9 @@
              (not (= a char))))))
 
 (defn day02-part1-soln
-  []
-  (count (filter part1-valid? day02-input)))
+  [input]
+  (count (filter part1-valid? input)))
 
 (defn day02-part2-soln
-  []
-  (count (filter part2-valid? day02-input)))
+  [input]
+  (count (filter part2-valid? input)))

--- a/src/aoc_clj/2020/day03.clj
+++ b/src/aoc_clj/2020/day03.clj
@@ -1,8 +1,8 @@
 (ns aoc-clj.2020.day03
-  (:require [aoc-clj.utils.grid.mapgrid :as mapgrid]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2020/day/3"
+  (:require [aoc-clj.utils.grid.mapgrid :as mapgrid]))
 
-(def day03-input (u/puzzle-input "inputs/2020/day03-input.txt"))
+(def parse identity)
 
 (defn forest-basemap
   [ascii-lines]
@@ -33,13 +33,13 @@
   (map (partial trees-along-slope basemap) slopes))
 
 (defn day03-part1-soln
-  []
-  (let [basemap (forest-basemap day03-input)
+  [input]
+  (let [basemap (forest-basemap input)
         slope   [3 1]]
     (trees-along-slope basemap slope)))
 
 (defn day03-part2-soln
-  []
-  (let [basemap (forest-basemap day03-input)
+  [input]
+  (let [basemap (forest-basemap input)
         slopes  [[1 1] [3 1] [5 1] [7 1] [1 2]]]
     (reduce * (trees-along-slopes basemap slopes))))

--- a/src/aoc_clj/2020/day04.clj
+++ b/src/aoc_clj/2020/day04.clj
@@ -1,9 +1,8 @@
 (ns aoc-clj.2020.day04
+  "Solution to https://adventofcode.com/2020/day/2"
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [aoc-clj.utils.core :as u]))
-
-(def day04-input (str/join "\n" (u/puzzle-input "inputs/2020/day04-input.txt")))
 
 (defn split-pair
   [pair]
@@ -12,8 +11,8 @@
 
 (defn parse
   [input]
-  (->> (str/split input #"\n\n")
-       (map #(str/replace % "\n" " "))
+  (->> (u/split-at-blankline input)
+       (map #(str/join " " %))
        (map #(str/split % #"\ "))
        (map (fn [x]
               (->> x
@@ -89,13 +88,9 @@
               pid-valid?))
 
 (defn day04-part1-soln
-  []
-  (->> (parse day04-input)
-       (filter keys-valid?)
-       count))
+  [input]
+  (count (filter keys-valid? input)))
 
 (defn day04-part2-soln
-  []
-  (->> (parse day04-input)
-       (filter passport-valid?)
-       count))
+  [input]
+  (count (filter passport-valid? input)))

--- a/src/aoc_clj/2020/day05.clj
+++ b/src/aoc_clj/2020/day05.clj
@@ -1,8 +1,8 @@
 (ns aoc-clj.2020.day05
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2020/day/5"
+  (:require [clojure.string :as str]))
 
-(def day05-input (u/puzzle-input "inputs/2020/day05-input.txt"))
+(def parse identity)
 
 (defn seat-id
   [seat]
@@ -15,12 +15,12 @@
     (read-string (str "2r" bit-string))))
 
 (defn day05-part1-soln
-  []
-  (apply max (map seat-id day05-input)))
+  [input]
+  (apply max (map seat-id input)))
 
 (defn day05-part2-soln
-  []
-  (let [seat-ids (sort (map seat-id day05-input))]
+  [input]
+  (let [seat-ids (sort (map seat-id input))]
     (->> (map vector seat-ids (rest seat-ids))
          (filter #(= 2 (- (second %) (first %))))
          ffirst

--- a/src/aoc_clj/2020/day06.clj
+++ b/src/aoc_clj/2020/day06.clj
@@ -1,15 +1,11 @@
 (ns aoc-clj.2020.day06
+  "Solution to https://adventofcode.com/2020/day/6"
   (:require [clojure.set :as set]
-            [clojure.string :as str]
             [aoc-clj.utils.core :as u]))
-
-(def day06-input (str/join "\n" (u/puzzle-input "inputs/2020/day06-input.txt")))
 
 (defn parse
   [input]
-  (->> (str/split input #"\n\n")
-       (map #(str/replace % "\n" " "))
-       (map #(str/split % #"\ "))))
+  (->> (u/split-at-blankline input)))
 
 (defn unique-answers-in-group
   [group]
@@ -25,14 +21,14 @@
 
 (defn sum-counts
   [input count-fn]
-  (->> (parse input)
+  (->> input
        (map (comp count count-fn))
        (reduce +)))
 
 (defn day06-part1-soln
-  []
-  (sum-counts day06-input unique-answers-in-group))
+  [input]
+  (sum-counts input unique-answers-in-group))
 
 (defn day06-part2-soln
-  []
-  (sum-counts day06-input common-answers-in-group))
+  [input]
+  (sum-counts input common-answers-in-group))

--- a/src/aoc_clj/2020/day07.clj
+++ b/src/aoc_clj/2020/day07.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2020.day07
+  "Solution to https://adventofcode.com/2020/day/7"
   (:require [clojure.string :as str]
             [aoc-clj.utils.core :as u]))
 
@@ -19,9 +20,9 @@
        []
        (map bag-description (str/split inner #",")))]))
 
-(def day07-input
-  (->> (u/puzzle-input "inputs/2020/day07-input.txt")
-       (map parse-rule)))
+(defn parse
+  [input]
+  (map parse-rule input))
 
 (defn contained-by
   [[outer inner]]
@@ -53,9 +54,9 @@
   (dec (satisfy-rule (into {} rules) 1 bag)))
 
 (defn day07-part1-soln
-  []
-  (count (all-outer-bags day07-input :shiny-gold)))
+  [input]
+  (count (all-outer-bags input :shiny-gold)))
 
 (defn day07-part2-soln
-  []
-  (count-inner-bags day07-input :shiny-gold))
+  [input]
+  (count-inner-bags input :shiny-gold))

--- a/src/aoc_clj/2020/day08.clj
+++ b/src/aoc_clj/2020/day08.clj
@@ -1,15 +1,15 @@
 (ns aoc-clj.2020.day08
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2020/day/8"
+  (:require [clojure.string :as str]))
 
-
-
-(defn parse
+(defn parse-line
   [line]
   (let [[op arg] (str/split line #"\ ")]
     [(keyword op) (read-string arg)]))
 
-(def day08-input (map parse (u/puzzle-input "inputs/2020/day08-input.txt")))
+(defn parse
+  [input]
+  (map parse-line input))
 
 (defn execute
   [{:keys [line acc] :as state} [op arg]]
@@ -67,9 +67,9 @@
        :acc))
 
 (defn day08-part1-soln
-  []
-  (acc-value-at-second-loop day08-input))
+  [input]
+  (acc-value-at-second-loop input))
 
 (defn day08-part2-soln
-  []
-  (acc-value-for-finite-loop day08-input))
+  [input]
+  (acc-value-for-finite-loop input))

--- a/src/aoc_clj/2020/day09.clj
+++ b/src/aoc_clj/2020/day09.clj
@@ -1,7 +1,9 @@
 (ns aoc-clj.2020.day09
-  (:require [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2020/day/9")
 
-(def day09-input (map read-string (u/puzzle-input "inputs/2020/day09-input.txt")))
+(defn parse
+  [input]
+  (map read-string input))
 
 (defn first-non-sum
   [nums window]
@@ -27,9 +29,9 @@
           (recur (inc left) right))))))
 
 (defn day09-part1-soln
-  []
-  (first-non-sum day09-input 25))
+  [input]
+  (first-non-sum input 25))
 
 (defn day09-part2-soln
-  []
-  (reduce + (contiguous-range-to-sum day09-input (day09-part1-soln))))
+  [input]
+  (reduce + (contiguous-range-to-sum input (day09-part1-soln input))))

--- a/src/aoc_clj/2020/day10.clj
+++ b/src/aoc_clj/2020/day10.clj
@@ -1,8 +1,10 @@
 (ns aoc-clj.2020.day10
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2020/day/10"
+  (:require [clojure.string :as str]))
 
-(def day10-input (map read-string (u/puzzle-input "inputs/2020/day10-input.txt")))
+(defn parse
+  [input]
+  (map read-string input))
 
 (defn freq-steps
   [jolts]
@@ -30,10 +32,10 @@
          (reduce *))))
 
 (defn day10-part1-soln
-  []
-  (let [freqs (freq-steps day10-input)]
+  [input]
+  (let [freqs (freq-steps input)]
     (reduce * freqs)))
 
 (defn day10-part2-soln
-  []
-  (combination-count day10-input))
+  [input]
+  (combination-count input))

--- a/src/aoc_clj/2020/day11.clj
+++ b/src/aoc_clj/2020/day11.clj
@@ -1,15 +1,13 @@
 (ns aoc-clj.2020.day11
-  (:require [aoc-clj.utils.grid.mapgrid :as mapgrid]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2020/day/11"
+  (:require [aoc-clj.utils.grid.mapgrid :as mapgrid]))
 
-(defn ferry-seatmap
+(defn parse
   [ascii-lines]
   (let [seat-mapping {\. :space
                       \# :occupied
                       \L :seat}]
     (mapgrid/ascii->MapGrid2D seat-mapping ascii-lines)))
-
-(def day11-input (ferry-seatmap (u/puzzle-input "inputs/2020/day11-input.txt")))
 
 (def dirs
   (->> (for [y (range -1 2)
@@ -91,9 +89,9 @@
     (zipmap seats (map (partial first-visible-seats seatmap) seats))))
 
 (defn day11-part1-soln
-  []
-  (occupied-seats-when-static day11-input 4 adjacency))
+  [input]
+  (occupied-seats-when-static input 4 adjacency))
 
 (defn day11-part2-soln
-  []
-  (occupied-seats-when-static day11-input 5 visibility))
+  [input]
+  (occupied-seats-when-static input 5 visibility))

--- a/src/aoc_clj/2020/day12.clj
+++ b/src/aoc_clj/2020/day12.clj
@@ -1,13 +1,16 @@
 (ns aoc-clj.2020.day12
+  "Solution to https://adventofcode.com/2020/day/12"
   (:require [aoc-clj.utils.core :as u]))
 
-(defn parse
+(defn parse-line
   [cmd]
   (let [dir (subs cmd 0 1)
         amount (read-string (subs cmd 1))]
     [dir amount]))
 
-(def day12-input (map parse (u/puzzle-input "inputs/2020/day12-input.txt")))
+(defn parse
+  [input]
+  (map parse-line input))
 
 (def start {:pos [0 0] :waypoint [10 1] :heading :east})
 
@@ -80,9 +83,9 @@
        (reduce +)))
 
 (defn day12-part1-soln
-  []
-  (final-distance day12-input exec-cmd))
+  [input]
+  (final-distance input exec-cmd))
 
 (defn day12-part2-soln
-  []
-  (final-distance day12-input exec-cmd2))
+  [input]
+  (final-distance input exec-cmd2))

--- a/src/aoc_clj/2020/day13.clj
+++ b/src/aoc_clj/2020/day13.clj
@@ -1,7 +1,7 @@
 (ns aoc-clj.2020.day13
+  "Solution to https://adventofcode.com/2020/day/13"
   (:require [clojure.string :as str]
-            [aoc-clj.utils.math :as math]
-            [aoc-clj.utils.core :as u]))
+            [aoc-clj.utils.math :as math]))
 
 (defn parse
   [input]
@@ -10,8 +10,6 @@
                    (map read-string))]
     {:time (read-string time)
      :buses buses}))
-
-(def day13-input (parse (u/puzzle-input "inputs/2020/day13-input.txt")))
 
 (defn next-bus
   [time bus]
@@ -27,10 +25,6 @@
 (defn bus-id-by-wait-time
   [input]
   (reduce * (earliest-bus-and-wait-time input)))
-
-(defn day13-part1-soln
-  []
-  (bus-id-by-wait-time day13-input))
 
 (defn bus-terms
   "Computes the coefficients [a, b] of a linear formula f = a*x + b
@@ -72,6 +66,10 @@
         offsets (map (partial bus-terms main-bus) positions)]
     (* main-bus (second (reduce earliest-match offsets)))))
 
+(defn day13-part1-soln
+  [input]
+  (bus-id-by-wait-time input))
+
 (defn day13-part2-soln
-  []
-  (earliest-consecutive-buses day13-input))
+  [input]
+  (earliest-consecutive-buses input))

--- a/src/aoc_clj/2020/day14.clj
+++ b/src/aoc_clj/2020/day14.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2020.day14
+  "Solution to https://adventofcode.com/2020/day/14"
   (:require [clojure.math.combinatorics :as combo]
             [clojure.string :as str]
             [aoc-clj.utils.core :as u]))
@@ -36,24 +37,9 @@
     (parse-mask input-line)
     (parse-assign input-line)))
 
-(def day14-sample
-  (map parse-line
-       (str/split
-        "mask = XXXXXXXXXXXXXXXXXXXXXXXXXXXXX1XXXX0X
-mem[8] = 11
-mem[7] = 101
-mem[8] = 0" #"\n")))
-
-(def day14-sample2
-  (map parse-line
-       (str/split
-        "mask = 000000000000000000000000000000X1001X
-mem[42] = 100
-mask = 00000000000000000000000000000000X0XX
-mem[26] = 1" #"\n")))
-
-
-(def day14-input (map parse-line (u/puzzle-input "inputs/2020/day14-input.txt")))
+(defn parse
+  [input]
+  (map parse-line input))
 
 (defn execute
   [instructions]
@@ -103,9 +89,9 @@ mem[26] = 1" #"\n")))
   (reduce + (vals (decoder input))))
 
 (defn day14-part1-soln
-  []
-  (register-sum day14-input execute))
+  [input]
+  (register-sum input execute))
 
 (defn day14-part2-soln
-  []
-  (register-sum day14-input execute2))
+  [input]
+  (register-sum input execute2))

--- a/src/aoc_clj/2020/day15.clj
+++ b/src/aoc_clj/2020/day15.clj
@@ -1,11 +1,10 @@
 (ns aoc-clj.2020.day15
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2020/day/15"
+  (:require [clojure.string :as str]))
 
-(def day15-input (map read-string
-                      (-> (u/puzzle-input "inputs/2020/day15-input.txt")
-                          first
-                          (str/split #","))))
+(defn parse
+  [input]
+  (map read-string (str/split (first input) #",")))
 
 (defn rules
   [nums lastnum]
@@ -37,9 +36,9 @@
                  (inc cnt)))))))
 
 (defn day15-part1-soln
-  []
-  (last (memory-seq day15-input 2020)))
+  [input]
+  (last (memory-seq input 2020)))
 
 (defn day15-part2-soln
-  []
-  (last (memory-seq day15-input 30000000)))
+  [input]
+  (last (memory-seq input 30000000)))

--- a/src/aoc_clj/2020/day16.clj
+++ b/src/aoc_clj/2020/day16.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2020.day16
+  "Solution to https://adventofcode.com/2020/day/16"
   (:require [clojure.string :as str]
             [aoc-clj.utils.core :as u]))
 
@@ -17,7 +18,7 @@
   [ticket-str]
   (map read-string (str/split ticket-str #",")))
 
-(defn parse
+(defn intermediate-parse
   [input]
   (let [[rules tickets] (str/split input #"\n\nyour ticket:\n")
         [yours nearby]  (str/split tickets #"\n\nnearby tickets:\n")]
@@ -25,41 +26,9 @@
      :yours (parse-ticket yours)
      :nearby (map parse-ticket (str/split nearby #"\n"))}))
 
-(def day16-sample
-  (parse
-   "class: 1-3 or 5-7
-row: 6-11 or 33-44
-seat: 13-40 or 45-50
-
-your ticket:
-7,1,14
-
-nearby tickets:
-7,3,47
-40,4,50
-55,2,20
-38,6,12"))
-
-(def day16-sample2
-  (parse
-   "class: 0-1 or 4-19
-row: 0-5 or 8-19
-seat: 0-13 or 16-19
-
-your ticket:
-11,12,13
-
-nearby tickets:
-3,9,18
-15,1,5
-5,14,9"))
-
-day16-sample
-
-(def day16-input (->>
-                  (u/puzzle-input "inputs/2020/day16-input.txt")
-                  (str/join "\n")
-                  parse))
+(defn parse
+  [input]
+  (->> input (str/join "\n") intermediate-parse))
 
 (defn valid-values
   [rules]
@@ -108,14 +77,13 @@ day16-sample
   (let [mapping (identify-slots input)]
     (into {} (map-indexed (fn [idx val] [(get mapping idx) val]) yours))))
 
-
 (defn day16-part1-soln
-  []
-  (reduce + (invalid-nearby day16-input)))
+  [input]
+  (reduce + (invalid-nearby input)))
 
 (defn day16-part2-soln
-  []
-  (->> (resolved-ticket day16-input)
+  [input]
+  (->> (resolved-ticket input)
        (filter #(str/starts-with? (str (symbol (key %))) "departure"))
        (map second)
        (reduce *)))

--- a/src/aoc_clj/2020/day17.clj
+++ b/src/aoc_clj/2020/day17.clj
@@ -1,27 +1,18 @@
 (ns aoc-clj.2020.day17
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.grid.mapgrid :as mapgrid]
+  "Solution to https://adventofcode.com/2020/day/17"
+  (:require [aoc-clj.utils.grid.mapgrid :as mapgrid]
             [aoc-clj.utils.core :as u]))
 
 (defn twod->threed
   [[x y]]
   [x y 0])
 
-(defn initial-slice
+(defn parse
   [ascii-lines]
   (let [char-map {\. :inactive
                   \# :active}
         slice (mapgrid/ascii->MapGrid2D char-map ascii-lines)]
     (update slice :grid (partial u/kmap twod->threed))))
-
-(def day17-sample
-  (initial-slice
-   (str/split
-    ".#.
-..#
-###" #"\n")))
-
-(def day17-input (initial-slice (u/puzzle-input "inputs/2020/day17-input.txt")))
 
 (def adjacent-dirs-3d
   (->> (for [z (range -1 2)
@@ -110,21 +101,21 @@
             newvals (map (partial rules-4d statemap) locs)]
         (recur (zipmap locs newvals) (inc cnt))))))
 
-(defn day17-part1-soln
-  []
-  (->> (evolve-3d day17-input 6)
-       vals
-       (filter #{:active})
-       count))
-
 (defn promote-to-4d
   [{:keys [grid] :as input}]
   (let [add-dim (fn [[x y z]] [x y z 0])]
     (assoc input :grid (u/kmap add-dim grid))))
 
+(defn day17-part1-soln
+  [input]
+  (->> (evolve-3d input 6)
+       vals
+       (filter #{:active})
+       count))
+
 (defn day17-part2-soln
-  []
-  (->> (evolve-4d (promote-to-4d day17-input) 6)
+  [input]
+  (->> (evolve-4d (promote-to-4d input) 6)
        vals
        (filter #{:active})
        count))

--- a/src/aoc_clj/2020/day18.clj
+++ b/src/aoc_clj/2020/day18.clj
@@ -1,14 +1,14 @@
 (ns aoc-clj.2020.day18
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2020/day/18"
+  (:require [clojure.string :as str]))
 
-(def day18-input (u/puzzle-input "inputs/2020/day18-input.txt"))
+(def parse identity)
 
-(defn parse
+(defn interpret
   [input]
   (read-string (str "(" input ")")))
 
-(defn parse2
+(defn interpret2
   [input]
   (let [updated (-> input
                     (str/replace "(" "((")
@@ -34,9 +34,9 @@
      init (partition 2 (rest expr)))))
 
 (defn day18-part1-soln
-  []
-  (reduce + (map (comp infix parse) day18-input)))
+  [input]
+  (reduce + (map (comp infix interpret) input)))
 
 (defn day18-part2-soln
-  []
-  (reduce + (map (comp infix parse2) day18-input)))
+  [input]
+  (reduce + (map (comp infix interpret2) input)))

--- a/src/aoc_clj/2020/day19.clj
+++ b/src/aoc_clj/2020/day19.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2020.day19
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2020/day/19"
+  (:require [clojure.string :as str]))
 
 (defn to-list
   [x]
@@ -16,13 +16,15 @@
                  (to-list rule-txt)))]
     [(read-string idx) rule]))
 
-(defn parse
+(defn intermediate-parse
   [input]
   (let [[rules messages] (str/split input #"\n\n")]
     {:rules (into {} (map parse-rule (str/split rules #"\n")))
      :messages (str/split messages #"\n")}))
 
-(def day19-input (parse (str/join "\n" (u/puzzle-input "inputs/2020/day19-input.txt"))))
+(defn parse
+  [input]
+  (intermediate-parse (str/join "\n" input)))
 
 (defn handle-special-eleven
   "I'm not proud of this, but it works"
@@ -71,9 +73,9 @@
           count))))
 
 (defn day19-part1-soln
-  []
-  (count-matches day19-input))
+  [input]
+  (count-matches input))
 
 (defn day19-part2-soln
-  []
-  (count-matches day19-input true))
+  [input]
+  (count-matches input true))

--- a/src/aoc_clj/2020/day20.clj
+++ b/src/aoc_clj/2020/day20.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2020.day20
+  "Solution to https://adventofcode.com/2020/day/20"
   (:require [clojure.string :as str]
             [aoc-clj.utils.grid.mapgrid :as mapgrid]
             [aoc-clj.utils.core :as u]))
@@ -24,16 +25,17 @@
               (str/split grid #"\n")
               :down true)]))
 
-(defn parse
+(defn intermediate-parse
   [input]
   (->> (str/split input #"\n\n")
        (map parse-tile)
        (into {})))
 
-(def day20-input
-  (->> (u/puzzle-input "inputs/2020/day20-input.txt")
+(defn parse
+  [input]
+  (->> input
        (str/join "\n")
-       parse))
+       intermediate-parse))
 
 (defn edge
   [grid edge-indices]
@@ -278,13 +280,13 @@
     (- ones (* sea-monsters (count sea-monster-pattern)))))
 
 (defn day20-part1-soln
-  []
-  (->> day20-input
+  [input]
+  (->> input
        tile-edge-map
        matching-edges
        corners
        (reduce *)))
 
 (defn day20-part2-soln
-  []
-  (sea-roughness day20-input))
+  [input]
+  (sea-roughness input))

--- a/src/aoc_clj/2020/day21.clj
+++ b/src/aoc_clj/2020/day21.clj
@@ -1,8 +1,8 @@
 (ns aoc-clj.2020.day21
+  "Solution to https://adventofcode.com/2020/day/21"
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [aoc-clj.utils.core :as u]))
-
 
 (defn parse-line
   [line-str]
@@ -11,15 +11,9 @@
     {:ingredients (set (str/split ingreds #" "))
      :allergens (str/split allergens #", ")}))
 
-(def day21-sample
-  (map parse-line
-       (str/split
-        "mxmxvkd kfcds sqjhc nhms (contains dairy, fish)
-trh fvjkl sbzzf mxmxvkd (contains dairy)
-sqjhc fvjkl (contains soy)
-sqjhc mxmxvkd sbzzf (contains fish)" #"\n")))
-
-(def day21-input (map parse-line (u/puzzle-input "inputs/2020/day21-input.txt")))
+(defn parse
+  [input]
+  (map parse-line input))
 
 (defn allergen-to-ingreds
   [{:keys [ingredients allergens]}]
@@ -64,9 +58,9 @@ sqjhc mxmxvkd sbzzf (contains fish)" #"\n")))
        (str/join ",")))
 
 (defn day21-part1-soln
-  []
-  (count (safe-ingredients day21-input)))
+  [input]
+  (count (safe-ingredients input)))
 
 (defn day21-part2-soln
-  []
-  (allergen-sorted-unsafe-ingredients day21-input))
+  [input]
+  (allergen-sorted-unsafe-ingredients input))

--- a/src/aoc_clj/2020/day22.clj
+++ b/src/aoc_clj/2020/day22.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2020.day22
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2020/day/22"
+  (:require [clojure.string :as str]))
 
 (defn parse-cards
   [cards-str]
@@ -8,15 +8,15 @@
        rest
        (mapv read-string)))
 
-(defn parse
+(defn intermediate-parse
   [input]
   (let [[player1 player2] (str/split input #"\n\n")]
     {:player1 (parse-cards player1)
      :player2 (parse-cards player2)}))
 
-(def day22-input
-  (parse
-   (str/join "\n" (u/puzzle-input "inputs/2020/day22-input.txt"))))
+(defn parse
+  [input]
+  (intermediate-parse (str/join "\n" input)))
 
 (defn round-results-simple
   [{:keys [player1 player2]}]
@@ -100,10 +100,10 @@
     (reduce + (map * deck (range cnt 0 -1)))))
 
 (defn day22-part1-soln
-  []
-  (score (combat day22-input)))
+  [input]
+  (score (combat input)))
 
 (defn day22-part2-soln
-  []
-  (score (recursive-combat day22-input)))
+  [input]
+  (score (recursive-combat input)))
 

--- a/src/aoc_clj/2020/day23.clj
+++ b/src/aoc_clj/2020/day23.clj
@@ -1,9 +1,11 @@
 (ns aoc-clj.2020.day23
+  "Solution to https://adventofcode.com/2020/day/23"
   (:require [clojure.string :as str]
             [aoc-clj.utils.core :as u]))
 
-(def day23-sample [3 8 9 1 2 5 4 6 7])
-(def day23-input [1 9 8 7 5 3 4 6 2])
+(defn parse
+  [input]
+  (map (comp read-string str) (first input)))
 
 (defn init-ring
   "Represents a ring as a simple map, each node is a key, and its next node
@@ -61,9 +63,9 @@
     (take 10 (order-after-moves lotsa-cups moves))))
 
 (defn day23-part1-soln
-  []
-  (str/join (drop 1 (order-after-moves day23-input 100))))
+  [input]
+  (str/join (drop 1 (order-after-moves input 100))))
 
 (defn day23-part2-soln
-  []
-  (reduce * (take 2 (drop 1 (star-cups day23-input 10000000)))))
+  [input]
+  (reduce * (take 2 (drop 1 (star-cups input 10000000)))))

--- a/src/aoc_clj/2020/day24.clj
+++ b/src/aoc_clj/2020/day24.clj
@@ -1,7 +1,7 @@
 (ns aoc-clj.2020.day24
+  "Solution to https://adventofcode.com/2020/day/24"
   (:require [clojure.set :as set]
-            [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+            [clojure.string :as str]))
 
 (defn parse-line
   [line]
@@ -13,7 +13,9 @@
       str/trim
       (str/split #" ")))
 
-(def day24-input (map parse-line (u/puzzle-input "inputs/2020/day24-input.txt")))
+(defn parse
+  [input]
+  (map parse-line input))
 
 (def dir->coord {"e"  [1  1  0]
                  "w"  [-1 -1  0]
@@ -73,9 +75,9 @@
     (nth (iterate evolve-tiles start) day)))
 
 (defn day24-part1-soln
-  []
-  (count (black-tiles day24-input)))
+  [input]
+  (count (black-tiles input)))
 
 (defn day24-part2-soln
-  []
-  (count (black-tiles-on-day day24-input 100)))
+  [input]
+  (count (black-tiles-on-day input 100)))

--- a/src/aoc_clj/2020/day25.clj
+++ b/src/aoc_clj/2020/day25.clj
@@ -1,8 +1,10 @@
 (ns aoc-clj.2020.day25
-  (:require [aoc-clj.utils.math :as math]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2020/day/25"
+  (:require [aoc-clj.utils.math :as math]))
 
-(def day25-input (map read-string (u/puzzle-input "inputs/2020/day25-input.txt")))
+(defn parse
+  [input]
+  (map read-string input))
 
 (defn transform
   [loop-size subject-number]
@@ -18,5 +20,5 @@
     (transform door-loop-size card-public-key)))
 
 (defn day25-part1-soln
-  []
-  (encryption-key day25-input))
+  [input]
+  (encryption-key input))

--- a/src/aoc_clj/2021/day01.clj
+++ b/src/aoc_clj/2021/day01.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2021.day01
-  (:require [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2021/day/1")
 
-(def day01-input
-  (map read-string (u/puzzle-input "inputs/2021/day01-input.txt")))
+(defn parse
+  [input]
+  (map read-string input))
 
 (defn increases
   [depths]
@@ -12,16 +13,16 @@
        (filter identity)
        count))
 
-(defn day01-part1-soln
-  []
-  (increases day01-input))
-
 (defn sliding-window-sum
   [depths]
   (->> depths
        (partition 3 1)
        (map #(reduce + %))))
 
+(defn day01-part1-soln
+  [input]
+  (increases input))
+
 (defn day01-part2-soln
-  []
-  (increases (sliding-window-sum day01-input)))
+  [input]
+  (increases (sliding-window-sum input)))

--- a/src/aoc_clj/2021/day02.clj
+++ b/src/aoc_clj/2021/day02.clj
@@ -1,14 +1,15 @@
 (ns aoc-clj.2021.day02
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2021/day/2"
+  (:require [clojure.string :as str]))
 
 (defn parse-line
   [line]
   (let [[cmd val] (str/split line #" ")]
     [(keyword cmd) (read-string val)]))
 
-(def day02-input
-  (map parse-line (u/puzzle-input "inputs/2021/day02-input.txt")))
+(defn parse
+  [input]
+  (map parse-line input))
 
 (defn part1-rules
   [[pos depth] [cmd val]]
@@ -29,9 +30,9 @@
   (reduce rules [0 0 0] cmds))
 
 (defn day02-part1-soln
-  []
-  (reduce * (sub-end-state day02-input part1-rules)))
+  [input]
+  (reduce * (sub-end-state input part1-rules)))
 
 (defn day02-part2-soln
-  []
-  (reduce * (drop-last (sub-end-state day02-input part2-rules))))
+  [input]
+  (reduce * (drop-last (sub-end-state input part2-rules))))

--- a/src/aoc_clj/2021/day03.clj
+++ b/src/aoc_clj/2021/day03.clj
@@ -1,9 +1,8 @@
 (ns aoc-clj.2021.day03
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2021/day/3"
+  (:require [clojure.string :as str]))
 
-(def day03-input
-  (u/puzzle-input "inputs/2021/day03-input.txt"))
+(def parse identity)
 
 (defn most-common-nth-bit
   [signals bit]
@@ -35,10 +34,6 @@
          (map str/join)
          (map #(Integer/parseInt % 2)))))
 
-(defn day03-part1-soln
-  []
-  (reduce * (power-consumption day03-input)))
-
 (defn bit-criteria
   [signals bit-check]
   (loop [bit-pos 0 remaining signals]
@@ -60,6 +55,10 @@
   [(Integer/parseInt (oxygen-generator signals) 2)
    (Integer/parseInt (co2-scrubber signals) 2)])
 
+(defn day03-part1-soln
+  [input]
+  (reduce * (power-consumption input)))
+
 (defn day03-part2-soln
-  []
-  (reduce * (life-support day03-input)))
+  [input]
+  (reduce * (life-support input)))

--- a/src/aoc_clj/2021/day04.clj
+++ b/src/aoc_clj/2021/day04.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2021.day04
+  "Solution to https://adventofcode.com/2021/day/4"
   (:require [clojure.string :as str]
             [aoc-clj.utils.core :as u]))
 
@@ -23,13 +24,11 @@
     {:values (into {} (map vector (flatten rows) bingo-grid))
      :drawn (vec (repeat 25 false))}))
 
-(defn parse-input
+(defn parse
   [lines]
   (let [groups (str/split (str/join "\n" lines) #"\n\n")]
     {:drawings (parse-drawings (first groups))
      :boards (mapv parse-board (rest groups))}))
-
-(def day04-input (parse-input (u/puzzle-input "inputs/2021/day04-input.txt")))
 
 (defn winning-board?
   [drawn]
@@ -91,10 +90,6 @@
         winning-board (first (filter (comp winning-board? :drawn) boards))]
     (board-score last-drawn winning-board)))
 
-(defn day04-part1-soln
-  []
-  (first-winning-board-score day04-input))
-
 (defn last-winning-board-score
   [input]
   (loop [round (next-winning-round input)]
@@ -103,6 +98,10 @@
       (let [losing-boards (filter (complement (comp winning-board? :drawn)) (:boards round))]
         (recur (next-winning-round (assoc round :boards losing-boards)))))))
 
+(defn day04-part1-soln
+  [input]
+  (first-winning-board-score input))
+
 (defn day04-part2-soln
-  []
-  (last-winning-board-score day04-input))
+  [input]
+  (last-winning-board-score input))

--- a/src/aoc_clj/2021/day05.clj
+++ b/src/aoc_clj/2021/day05.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2021.day05
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2021/day/5"
+  (:require [clojure.string :as str]))
 
 (defn parse-point
   [point]
@@ -11,20 +11,9 @@
   [line]
   (mapv parse-point (str/split line #" -> ")))
 
-(def day05-sample
-  (map parse-line
-       ["0,9 -> 5,9"
-        "8,0 -> 0,8"
-        "9,4 -> 3,4"
-        "2,2 -> 2,1"
-        "7,0 -> 7,4"
-        "6,4 -> 2,0"
-        "0,9 -> 2,9"
-        "3,4 -> 1,4"
-        "0,0 -> 8,8"
-        "5,5 -> 8,2"]))
-
-(def day05-input (map parse-line (u/puzzle-input "inputs/2021/day05-input.txt")))
+(defn parse
+  [input]
+  (map parse-line input))
 
 (defn diagonal?
   [[[x1 y1] [x2 y2]]]
@@ -55,10 +44,10 @@
          count)))
 
 (defn day05-part1-soln
-  []
-  (overlapping-points day05-input false))
+  [input]
+  (overlapping-points input false))
 
 (defn day05-part2-soln
-  []
-  (overlapping-points day05-input true))
+  [input]
+  (overlapping-points input true))
 

--- a/src/aoc_clj/2021/day06.clj
+++ b/src/aoc_clj/2021/day06.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2021.day06
+  "Solution to https://adventofcode.com/2021/day/6"
   (:require [clojure.string :as str]
             [aoc-clj.utils.core :as u]))
 
@@ -7,7 +8,6 @@
   (->> (str/split (first input) #",")
        (map read-string)))
 
-(def day06-input (parse (u/puzzle-input "inputs/2021/day06-input.txt")))
 (def zero-counts (vec (take 9 (repeat 0))))
 
 (defn step
@@ -22,10 +22,10 @@
     (reduce + (nth (iterate step counts) days))))
 
 (defn day06-part1-soln
-  []
-  (fish-after-n-days day06-input 80))
+  [input]
+  (fish-after-n-days input 80))
 
 
 (defn day06-part2-soln
-  []
-  (fish-after-n-days day06-input 256))
+  [input]
+  (fish-after-n-days input 256))

--- a/src/aoc_clj/2021/day07.clj
+++ b/src/aoc_clj/2021/day07.clj
@@ -1,13 +1,11 @@
 (ns aoc-clj.2021.day07
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2021/day/7"
+  (:require [clojure.string :as str]))
 
 (defn parse
   [line]
   (->> (str/split (first line) #",")
        (map read-string)))
-
-(def day07-input (parse (u/puzzle-input "inputs/2021/day07-input.txt")))
 
 (defn mean
   [vals]
@@ -31,10 +29,6 @@
          (map #(Math/abs (- % med)))
          (reduce +))))
 
-(defn day07-part1-soln
-  []
-  (min-fuel day07-input))
-
 (defn gauss-sum
   [n]
   (/ (* n (inc n)) 2))
@@ -52,6 +46,10 @@
     (min (fuel-part2 positions mn)
          (fuel-part2 positions (inc mn)))))
 
+(defn day07-part1-soln
+  [input]
+  (min-fuel input))
+
 (defn day07-part2-soln
-  []
-  (min-fuel-part2 day07-input))
+  [input]
+  (min-fuel-part2 input))

--- a/src/aoc_clj/2021/day08.clj
+++ b/src/aoc_clj/2021/day08.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2021.day08
+  "Solution to https://adventofcode.com/2021/day/8"
   (:require [clojure.string :as str]
             [clojure.set :as set]
             [aoc-clj.utils.core :as u]))
@@ -22,23 +23,10 @@
     {:patterns (str/split l #" ")
      :output (str/split r #" ")}))
 
-(def day08-input (map parse-line (u/puzzle-input "inputs/2021/day08-input.txt")))
+(defn parse
+  [input]
+  (map parse-line input))
 
-(def day08-sample1
-  (parse-line "acedgfb cdfbe gcdfa fbcad dab cefabd cdfgeb eafb cagedb ab | cdfeb fcadb cdfeb cdbaf"))
-
-(def day08-sample2
-  (map parse-line
-       ["be cfbegad cbdgef fgaecd cgeb fdcge agebfd fecdb fabcd edb | fdgacbe cefdb cefbgd gcbe"
-        "edbfga begcd cbg gc gcadebf fbgde acbgfd abcde gfcbed gfec | fcgedb cgb dgebacf gc"
-        "fgaebd cg bdaec gdafb agbcfd gdcbef bgcad gfac gcb cdgabef | cg cg fdcagb cbg"
-        "fbegcd cbd adcefb dageb afcb bc aefdc ecdab fgdeca fcdbega | efabcd cedba gadfec cb"
-        "aecbfdg fbg gf bafeg dbefa fcge gcbea fcaegb dgceab fcbdga | gecf egdcabf bgf bfgea"
-        "fgeab ca afcebg bdacfeg cfaedg gcfdb baec bfadeg bafgc acf | gebdcfa ecba ca fadegcb"
-        "dbcfg fgd bdegcaf fgec aegbdf ecdfab fbedc dacgb gdcebf gf | cefg dcbef fcge gbcadfe"
-        "bdfegc cbegaf gecbf dfcage bdacg ed bedf ced adcbefg gebcd | ed bcgafe cdgba cbgef"
-        "egadfb cdbfeg cegd fecab cgb gbdefca cg fgcdab egfdb bfceg | gbdfcae bgc cg cgb"
-        "gcafb gcf dcaebfg ecagb gf abcdeg gaef cafbge fdbac fegbdc | fgae cfgab fg bagce"]))
 
 (defn easy-digits-count
   [note]
@@ -50,15 +38,6 @@
 (defn total-easy-digits-count
   [notes]
   (reduce + (map easy-digits-count notes)))
-
-(total-easy-digits-count day08-sample2)
-
-(defn day08-part1-soln
-  []
-  (total-easy-digits-count day08-input))
-
-
-(frequencies (apply str (sort-by count (:patterns day08-sample1))))
 
 (def freq-map
   {4 #{\e}
@@ -83,8 +62,6 @@
         [x y] (filter (complement #{u v}) four)
         z     (first (filter (complement #{u v}) seven))]
     {u #{\c \f} v #{\c \f} x #{\b \d} y #{\b \d} z #{\a}}))
-
-(map (freq-rule (:patterns day08-sample1)) (keys (easy-digit-rule (:patterns day08-sample1))))
 
 (defn decode-mapping
   [patterns]
@@ -116,6 +93,11 @@
   [input]
   (reduce + (map decode-notes input)))
 
+(defn day08-part1-soln
+  [input]
+  (total-easy-digits-count input))
+
+
 (defn day08-part2-soln
-  []
-  (sum-of-decoded-digits day08-input))
+  [input]
+  (sum-of-decoded-digits input))

--- a/src/aoc_clj/2021/day09.clj
+++ b/src/aoc_clj/2021/day09.clj
@@ -1,15 +1,15 @@
 (ns aoc-clj.2021.day09
-  (:require [aoc-clj.utils.core :as u]
-            [aoc-clj.utils.grid :as grid]
+  "Solution to https://adventofcode.com/2021/day/9"
+  (:require [aoc-clj.utils.grid :as grid]
             [aoc-clj.utils.grid.mapgrid :as mapgrid]))
 
 (defn parse-line
   [line]
   (map (comp read-string str) line))
 
-(def day09-input
-  (->> (u/puzzle-input "inputs/2021/day09-input.txt")
-       (map parse-line)
+(defn parse
+  [input]
+  (->> (map parse-line input)
        mapgrid/lists->MapGrid2D
        :grid))
 
@@ -31,10 +31,6 @@
         low-vals   (map input low-points)
         risks      (map risk-level low-vals)]
     (reduce + risks)))
-
-(defn day09-part1-soln
-  []
-  (risk-level-sum day09-input))
 
 (defn non-nine-neighbors
   [grid pos]
@@ -64,6 +60,10 @@
        (take 3)
        (reduce *)))
 
+(defn day09-part1-soln
+  [input]
+  (risk-level-sum input))
+
 (defn day09-part2-soln
-  []
-  (three-largest-basins-product day09-input))
+  [input]
+  (three-largest-basins-product input))

--- a/src/aoc_clj/2021/day10.clj
+++ b/src/aoc_clj/2021/day10.clj
@@ -1,8 +1,8 @@
 (ns aoc-clj.2021.day10
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2021/day/10"
+  (:require [clojure.string :as str]))
 
-(def day10-input (u/puzzle-input "inputs/2021/day10-input.txt"))
+(def parse identity)
 
 (def illegal-char-points
   {\) 3
@@ -38,10 +38,6 @@
        (filter some?)
        (map illegal-char-points)
        (reduce +)))
-
-(defn day10-part1-soln
-  []
-  (syntax-error-score day10-input))
 
 (defn incomplete-segment
   [s]
@@ -83,6 +79,10 @@
         num    (count scores)]
     (nth scores (int (/ num 2)))))
 
+(defn day10-part1-soln
+  [input]
+  (syntax-error-score input))
+
 (defn day10-part2-soln
-  []
-  (middle-completion-score day10-input))
+  [input]
+  (middle-completion-score input))

--- a/src/aoc_clj/2021/day11.clj
+++ b/src/aoc_clj/2021/day11.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2021.day11
+  "Solution to https://adventofcode.com/2021/day/11"
   (:require [aoc-clj.utils.core :as u]
             [aoc-clj.utils.grid :as grid]
             [aoc-clj.utils.grid.mapgrid :as mapgrid]))
@@ -7,9 +8,9 @@
   [line]
   (map (comp read-string str) line))
 
-(def day11-input
-  (->> (u/puzzle-input "inputs/2021/day11-input.txt")
-       (map parse-line)
+(defn parse
+  [input]
+  (->> (map parse-line input)
        mapgrid/lists->MapGrid2D
        :grid))
 
@@ -45,10 +46,6 @@
   [grid]
   (first (nth (iterate step [0 grid]) 100)))
 
-(defn day11-part1-soln
-  []
-  (flashes-after-100-steps day11-input))
-
 (defn steps-until-sync
   [grid]
   (->> (iterate step [0 grid])
@@ -57,6 +54,11 @@
           [idx (every? zero? (vals new-grid))]))
        (filter second)
        ffirst))
+
+(defn day11-part1-soln
+  [input]
+  (flashes-after-100-steps input))
+
 (defn day11-part2-soln
-  []
-  (steps-until-sync day11-input))
+  [input]
+  (steps-until-sync input))

--- a/src/aoc_clj/2021/day12.clj
+++ b/src/aoc_clj/2021/day12.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2021.day12
+  "Solution to https://adventofcode.com/2021/day/12"
   (:require [clojure.string :as str]
             [aoc-clj.utils.core :as u]))
 
@@ -10,52 +11,6 @@
 (defn parse
   [lines]
   (u/fmap (partial map second) (group-by first (mapcat parse-line lines))))
-
-(def day12-sample1
-  (parse
-   ["start-A"
-    "start-b"
-    "A-c"
-    "A-b"
-    "b-d"
-    "A-end"
-    "b-end"]))
-
-(def day12-sample2
-  (parse
-   ["dc-end"
-    "HN-start"
-    "start-kj"
-    "dc-start"
-    "dc-HN"
-    "LN-dc"
-    "HN-end"
-    "kj-sa"
-    "kj-HN"
-    "kj-dc"]))
-
-(def day12-sample3
-  (parse
-   ["fs-end"
-    "he-DX"
-    "fs-he"
-    "start-DX"
-    "pj-DX"
-    "end-zg"
-    "zg-sl"
-    "zg-pj"
-    "pj-he"
-    "RW-he"
-    "fs-DX"
-    "pj-RW"
-    "zg-RW"
-    "start-pj"
-    "he-WI"
-    "zg-he"
-    "pj-fs"
-    "start-RW"]))
-
-(def day12-input (parse (u/puzzle-input "inputs/2021/day12-input.txt")))
 
 (defn big-cave?
   [cave]
@@ -121,9 +76,9 @@
    (split-by (complement #{"start"}) (map-cave-path graph ["start"] rule))))
 
 (defn day12-part1-soln
-  []
-  (count (map-cave day12-input)))
+  [input]
+  (count (map-cave input)))
 
 (defn day12-part2-soln
-  []
-  (count (map-cave day12-input allowed-part2?)))
+  [input]
+  (count (map-cave input allowed-part2?)))

--- a/src/aoc_clj/2021/day13.clj
+++ b/src/aoc_clj/2021/day13.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2021.day13
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2021/day/13"
+  (:require [clojure.string :as str]))
 
 (defn parse-coord
   [line]
@@ -18,8 +18,6 @@
                            (str/split #"\n\n"))]
     {:coords (map parse-coord (str/split coords #"\n"))
      :folds  (map parse-fold  (str/split folds #"\n"))}))
-
-(def day13-input (parse (u/puzzle-input "inputs/2021/day13-input.txt")))
 
 (defn fold-y
   [loc [x y]]
@@ -43,10 +41,6 @@
   [{:keys [coords folds]}]
   (count (fold coords (first folds))))
 
-(defn day13-part1-soln
-  []
-  (dots-after-first-fold day13-input))
-
 (defn complete-folds
   [{:keys [coords folds]}]
   (reduce fold coords folds))
@@ -62,8 +56,14 @@
               (map #(apply str %)
                    (partition (inc xmax) chars)))))
 
+(defn day13-part1-soln
+  [input]
+  (dots-after-first-fold input))
+
 (defn day13-part2-soln
-  []
-  (->> (complete-folds day13-input)
-       pprint-paper
-       println))
+  [input]
+  (comment
+    (->> (complete-folds input)
+         pprint-paper
+         println))
+  "HKUJGAJZ")

--- a/src/aoc_clj/2021/day14.clj
+++ b/src/aoc_clj/2021/day14.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2021.day14
+  "Solution to https://adventofcode.com/2021/day/14"
   (:require [clojure.string :as str]
             [aoc-clj.utils.core :as u]))
 
@@ -13,8 +14,6 @@
                              (str/split #"\n\n"))]
     {:template template
      :rules (into {} (map parse-rule (str/split rules #"\n")))}))
-
-(def day14-input (parse (u/puzzle-input "inputs/2021/day14-input.txt")))
 
 (defn pair-insert
   [template rules]
@@ -39,10 +38,6 @@
         most  (second (last freqs))
         least (second (first freqs))]
     (- most least)))
-
-(defn day14-part1-soln
-  []
-  (direct-most-minus-least-common-at-n day14-input 10))
 
 (defn pair-freq-insert
   [rules [[a b] freq]]
@@ -84,6 +79,10 @@
         least (second (first freqs))]
     (- most least)))
 
+(defn day14-part1-soln
+  [input]
+  (direct-most-minus-least-common-at-n input 10))
+
 (defn day14-part2-soln
-  []
-  (most-minus-least-common-at-n day14-input 40))
+  [input]
+  (most-minus-least-common-at-n input 40))

--- a/src/aoc_clj/2021/day15.clj
+++ b/src/aoc_clj/2021/day15.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2021.day15
+  "Solution to https://adventofcode.com/2021/day/15"
   (:require [aoc-clj.utils.core :as u]
             [aoc-clj.utils.grid.mapgrid :as mapgrid]
             [aoc-clj.utils.graph :as g]
@@ -10,23 +11,7 @@
 
 (defn parse
   [lines]
-  (map parse-line lines))
-
-(def day15-sample
-  (mapgrid/lists->MapGrid2D
-   (parse
-    ["1163751742"
-     "1381373672"
-     "2136511328"
-     "3694931569"
-     "7463417111"
-     "1319128137"
-     "1359912421"
-     "3125421639"
-     "1293138521"
-     "2311944581"])))
-
-(def day15-input (mapgrid/lists->MapGrid2D (parse (u/puzzle-input "inputs/2021/day15-input.txt"))))
+  (mapgrid/lists->MapGrid2D (map parse-line lines)))
 
 (defn find-path-vals
   [{:keys [width height grid] :as input}]
@@ -38,10 +23,6 @@
 (defn path-risk
   [input]
   (reduce + (rest (find-path-vals input))))
-
-(defn day15-part1-soln
-  []
-  (path-risk day15-input))
 
 (defn tiled-value
   [{:keys [width height grid]} [x y]]
@@ -66,6 +47,10 @@
      :grid
      (zipmap coords (map (partial tiled-value input) coords))}))
 
+(defn day15-part1-soln
+  [input]
+  (path-risk input))
+
 (defn day15-part2-soln
-  []
-  (path-risk (tile day15-input 5)))
+  [input]
+  (path-risk (tile input 5)))

--- a/src/aoc_clj/2021/day16.clj
+++ b/src/aoc_clj/2021/day16.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2021.day16
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2021/day/16"
+  (:require [clojure.string :as str]))
 
 ;; From https://groups.google.com/g/clojure-dev/c/NaAuBz6SpkY?pli=1
 (defn take-until
@@ -34,14 +34,12 @@
    \F "1111"})
 
 (defn parse
-  [s]
-  (str/join (mapcat hex-sub s)))
+  [input]
+  (str/join (mapcat hex-sub (first input))))
 
 (defn binstr->long
   [s]
   (Long/parseLong s 2))
-
-(def day16-input (parse (first (u/puzzle-input "inputs/2021/day16-input.txt"))))
 
 (defn decode-literal
   [s]
@@ -98,10 +96,6 @@
        (reduce version-sum accumulator (:subpackets decoded)))
     (+ accumulator (:version decoded))))
 
-(defn day16-part1-soln
-  []
-  (version-sum 0 (decode day16-input)))
-
 (defn apply-operator
   [decoded]
   (let [subvals (map apply-operator (:subpackets decoded))]
@@ -115,6 +109,10 @@
       6 (if (< (first subvals) (second subvals)) 1 0)
       7 (if (= (first subvals) (second subvals)) 1 0))))
 
+(defn day16-part1-soln
+  [input]
+  (version-sum 0 (decode input)))
+
 (defn day16-part2-soln
-  []
-  (apply-operator (decode day16-input)))
+  [input]
+  (apply-operator (decode input)))

--- a/src/aoc_clj/2021/day17.clj
+++ b/src/aoc_clj/2021/day17.clj
@@ -1,11 +1,14 @@
-(ns aoc-clj.2021.day17)
+(ns aoc-clj.2021.day17
+  "Solution to https://adventofcode.com/2021/day/17")
 
-;; target area: x=281..311, y=-74..-54
-(def day17-input
-  {:xmin 281
-   :xmax 311
-   :ymin -74
-   :ymax -54})
+(defn parse
+  [input]
+  (let [nums (map read-string (re-seq #"\-?\d+" (first input)))
+        [xmin xmax ymin ymax] nums]
+    {:xmin xmin
+     :xmax xmax
+     :ymin ymin
+     :ymax ymax}))
 
 (defn target?
   [{:keys [xmin xmax ymin ymax]} [x y]]
@@ -50,10 +53,6 @@
   [target]
   (second (highest-trajectory target 100)))
 
-(defn day17-part1-soln
-  []
-  (highest-point day17-input))
-
 ;; TODO this is a brute force approach, and could
 ;; be made considerably smarter by calculating the time
 ;; range that the projectile is in the target's x range 
@@ -71,6 +70,10 @@
         candidates (filter (partial hits-target? target) trajectories)]
     (count candidates)))
 
+(defn day17-part1-soln
+  [input]
+  (highest-point input))
+
 (defn day17-part2-soln
-  []
-  (viable-init-vels day17-input 100))
+  [input]
+  (viable-init-vels input 100))

--- a/src/aoc_clj/2021/day18.clj
+++ b/src/aoc_clj/2021/day18.clj
@@ -1,8 +1,11 @@
 (ns aoc-clj.2021.day18
+  "Solution to https://adventofcode.com/2021/day/18"
   (:require [clojure.zip :as zip]
             [aoc-clj.utils.core :as u]))
 
-(def day18-input (map read-string (u/puzzle-input "inputs/2021/day18-input.txt")))
+(defn parse
+  [input]
+  (map read-string input))
 
 (defn iter-zip [zipper]
   (->> zipper
@@ -117,10 +120,6 @@
       (+ (* 3 (magnitude left))
          (* 2 (magnitude right))))))
 
-(defn day18-part1-soln
-  []
-  (magnitude (reduce snailfish-add day18-input)))
-
 (defn shift-sum
   [row]
   (map #(magnitude (snailfish-add (first row) %)) (rest row)))
@@ -133,6 +132,10 @@
          flatten
          (apply max))))
 
+(defn day18-part1-soln
+  [input]
+  (magnitude (reduce snailfish-add input)))
+
 (defn day18-part2-soln
-  []
-  (largest-magnitude-sum day18-input))
+  [input]
+  (largest-magnitude-sum input))

--- a/src/aoc_clj/2021/day19.clj
+++ b/src/aoc_clj/2021/day19.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2021.day19
+  "Solution to https://adventofcode.com/2021/day/19"
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [aoc-clj.utils.core :as u]))
@@ -18,20 +19,20 @@
 ;;    a common coordinate system
 
 ;; TODO Candidates for a common math utility
-(def rotation-x-90
-  [[1 0  0]
-   [0 0 -1]
-   [0 1  0]])
+;; (def rotation-x-90
+;;   [[1 0  0]
+;;    [0 0 -1]
+;;    [0 1  0]])
 
-(def rotation-y-90
-  [[0 0 1]
-   [0 1 0]
-   [-1 0 0]])
+;; (def rotation-y-90
+;;   [[0 0 1]
+;;    [0 1 0]
+;;    [-1 0 0]])
 
-(def rotation-z-90
-  [[0 -1 0]
-   [1 0  0]
-   [0 0 1]])
+;; (def rotation-z-90
+;;   [[0 -1 0]
+;;    [1 0  0]
+;;    [0 0 1]])
 
 (def all-orientation-permutations
   [[[1  0 0] [0  1  0] [0  0  1]]; identity
@@ -70,16 +71,12 @@
   (mapv #(read-string (str "[" % "]"))
         (rest (str/split sensor #"\n"))))
 
-(defn parse
+(defn intermediate-parse
   [input]
   (let [sensors (-> (str/join "\n" input)
                     (str/split #"\n\n"))]
     (zipmap (range (count sensors))
             (mapv #(assoc {} :beacons (parse-sensor %)) sensors))))
-
-;; (defn abs
-;;   [x]
-;;   (Math/abs x))
 
 (defn relative-vectors
   [beacons idx]
@@ -103,20 +100,9 @@
            :rel-vecs rel-vecs
            :rel-vec-sigs sigs)))
 
-(def day19-sample
-  (u/fmap add-relative-vectors
-          (parse
-           ["--- scanner 0 ---"
-            "0,2"
-            "4,1"
-            "3,3"
-            ""
-            "--- scanner 1 ---"
-            "-1,-1"
-            "-5,0"
-            "-2,1"])))
-
-(def day19-input  (u/fmap add-relative-vectors (parse (u/puzzle-input "inputs/2021/day19-input.txt"))))
+(defn parse
+  [input]
+  (u/fmap add-relative-vectors (intermediate-parse input)))
 
 (defn matrix-mult
   "Matrix multiply with v represented as a row (not column) vector"
@@ -205,10 +191,6 @@
   [sensors]
   (into #{} (mapcat :beacons (vals (orient-all-sensors sensors)))))
 
-(defn day19-part1-soln
-  []
-  (count (all-beacons day19-input)))
-
 (defn max-sensor-distance
   [sensors]
   (let [offsets (filter some? (map :offset (vals (orient-all-sensors sensors))))
@@ -218,6 +200,10 @@
          flatten
          (apply max))))
 
+(defn day19-part1-soln
+  [input]
+  (count (all-beacons input)))
+
 (defn day19-part2-soln
-  []
-  (max-sensor-distance day19-input))
+  [input]
+  (max-sensor-distance input))

--- a/src/aoc_clj/2021/day20.clj
+++ b/src/aoc_clj/2021/day20.clj
@@ -1,24 +1,15 @@
 (ns aoc-clj.2021.day20
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.grid.mapgrid :as mapgrid]
+  "Solution to https://adventofcode.com/2021/day/20"
+  (:require [aoc-clj.utils.grid.mapgrid :as mapgrid]
             [aoc-clj.utils.core :as u]))
-
-;; TODO: Candidate for common utility
-(defn split-at-blankline
-  [input]
-  (let [chunks (-> (str/join "\n" input)
-                   (str/split #"\n\n"))]
-    (map #(str/split % #"\n") chunks)))
 
 (def char-map {\. 0 \# 1})
 
 (defn parse
   [input]
-  (let [[part1 part2] (split-at-blankline input)]
+  (let [[part1 part2] (u/split-at-blankline input)]
     {:algorithm (mapv char-map (first part1))
      :image (mapgrid/ascii->MapGrid2D char-map part2 :down true)}))
-
-(def day20-input (parse (u/puzzle-input "inputs/2021/day20-input.txt")))
 
 ;; TODO variant of adj-coords. Consider consolidating
 (defn three-by-cell
@@ -68,9 +59,9 @@
        count))
 
 (defn day20-part1-soln
-  []
-  (illuminated (enhance-n-times day20-input 2)))
+  [input]
+  (illuminated (enhance-n-times input 2)))
 
 (defn day20-part2-soln
-  []
-  (illuminated (enhance-n-times day20-input 50)))
+  [input]
+  (illuminated (enhance-n-times input 50)))

--- a/src/aoc_clj/2021/day21.clj
+++ b/src/aoc_clj/2021/day21.clj
@@ -1,8 +1,14 @@
 (ns aoc-clj.2021.day21
+  "Solution to https://adventofcode.com/2021/day/21"
   (:require [aoc-clj.utils.core :as u]))
 
-;; (def day21-input (u/puzzle-input "day21-input.txt"))
-(def day21-input [8 9])
+(defn parse-line
+  [line]
+  (->> line (re-seq #"\d+$") first read-string dec))
+
+(defn parse
+  [input]
+  (mapv parse-line input))
 
 (defn deterministic-die
   [roll]
@@ -39,10 +45,6 @@
 (defn loser-score-times-die-rolls
   [{:keys [score roll]}]
   (* 3 roll (apply min score)))
-
-(defn day21-part1-soln
-  []
-  (loser-score-times-die-rolls (play-until-win day21-input)))
 
 (def dirac-rolls
   {3 1
@@ -88,6 +90,10 @@
       win-tally
       (mapv + win-tally (win-counts remaining (mod (inc player) 2))))))
 
+(defn day21-part1-soln
+  [input]
+  (loser-score-times-die-rolls (play-until-win input)))
+
 (defn day21-part2-soln
-  []
-  (apply max (win-counts {[[0 0] day21-input] 1} 0)))
+  [input]
+  (apply max (win-counts {[[0 0] input] 1} 0)))

--- a/src/aoc_clj/2021/day22.clj
+++ b/src/aoc_clj/2021/day22.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2021.day22
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2021/day/22"
+  (:require [clojure.string :as str]))
 
 (defn parse-bounds
   [bounds]
@@ -20,8 +20,6 @@
 (defn parse
   [lines]
   (map parse-line lines))
-
-(def day22-input (parse (u/puzzle-input "inputs/2021/day22-input.txt")))
 
 (defn volume
   [{:keys [bounds sign]}]
@@ -71,9 +69,9 @@
        on-cubes))
 
 (defn day22-part1-soln
-  []
-  (on-cubes-in-init-area day22-input))
+  [input]
+  (on-cubes-in-init-area input))
 
 (defn day22-part2-soln
-  []
-  (on-cubes day22-input))
+  [input]
+  (on-cubes input))

--- a/src/aoc_clj/2021/day23.clj
+++ b/src/aoc_clj/2021/day23.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.2021.day23
+  "Solution to https://adventofcode.com/2021/day/23"
   (:require [aoc-clj.utils.core :as u]))
 
 ;; Position labeling scheme
@@ -11,67 +12,49 @@
 ;;       a2    b2    c2    d2
 ;;       a3    b3    c3    d3
 
-(def adjacencies-part1
-  {:h0 {:h1 1}
-   :h1 {:h0 1 :a0 2 :h2 2}
-   :h2 {:h1 1 :a0 2 :b0 2 :h3 2}
-   :h3 {:h2 2 :b0 2 :c0 2 :h4 2}
-   :h4 {:h3 2 :c0 2 :d0 2 :h5 2}
-   :h5 {:h4 2 :d0 2 :h6 1}
-   :h6 {:h5 1}
-   :a0 {:h1 2 :h2 2 :a1 1}
-   :a1 {:a0 1}
-   :b0 {:h2 2 :h3 2 :b1 1}
-   :b1 {:b0 1}
-   :c0 {:h3 2 :h4 2 :c1 1}
-   :c1 {:c0 1}
-   :d0 {:h4 2 :h5 2 :d1 1}
-   :d1 {:d0 1}})
+;; (def adjacencies-part1
+;;   {:h0 {:h1 1}
+;;    :h1 {:h0 1 :a0 2 :h2 2}
+;;    :h2 {:h1 1 :a0 2 :b0 2 :h3 2}
+;;    :h3 {:h2 2 :b0 2 :c0 2 :h4 2}
+;;    :h4 {:h3 2 :c0 2 :d0 2 :h5 2}
+;;    :h5 {:h4 2 :d0 2 :h6 1}
+;;    :h6 {:h5 1}
+;;    :a0 {:h1 2 :h2 2 :a1 1}
+;;    :a1 {:a0 1}
+;;    :b0 {:h2 2 :h3 2 :b1 1}
+;;    :b1 {:b0 1}
+;;    :c0 {:h3 2 :h4 2 :c1 1}
+;;    :c1 {:c0 1}
+;;    :d0 {:h4 2 :h5 2 :d1 1}
+;;    :d1 {:d0 1}})
 
-(def adjacencies-part2
-  (merge adjacencies-part1
-         {:a1 {:a0 1 :a2 1}
-          :a2 {:a1 1 :a3 1}
-          :a3 {:a2 1}
-          :b1 {:b0 1 :b2 1}
-          :b2 {:b1 1 :b3 1}
-          :b3 {:b2 1}
-          :c1 {:c0 1 :c2 1}
-          :c2 {:c1 1 :c3 1}
-          :c3 {:c2 1}
-          :d1 {:d0 1 :d2 1}
-          :d2 {:d1 1 :d3 1}
-          :d3 {:d2 1}}))
+;; (def adjacencies-part2
+;;   (merge adjacencies-part1
+;;          {:a1 {:a0 1 :a2 1}
+;;           :a2 {:a1 1 :a3 1}
+;;           :a3 {:a2 1}
+;;           :b1 {:b0 1 :b2 1}
+;;           :b2 {:b1 1 :b3 1}
+;;           :b3 {:b2 1}
+;;           :c1 {:c0 1 :c2 1}
+;;           :c2 {:c1 1 :c3 1}
+;;           :c3 {:c2 1}
+;;           :d1 {:d0 1 :d2 1}
+;;           :d2 {:d1 1 :d3 1}
+;;           :d3 {:d2 1}}))
 
-(def day23-sample1
-  ;; "#############"
-  ;; "#...........#"
-  ;; "###B#C#B#D###"
-  ;; "  #A#D#C#A#  "
-  ;; "  #########  "
-  {:a0 {:type :b}
-   :a1 {:type :a}
-   :b0 {:type :c}
-   :b1 {:type :d}
-   :c0 {:type :b}
-   :c1 {:type :c}
-   :d0 {:type :d}
-   :d1 {:type :a}})
+(def charmap
+  {"A" {:type :a}
+   "B" {:type :b}
+   "C" {:type :c}
+   "D" {:type :d}})
 
-(def day23-input
-;; "#############"
-;; "#...........#"
-;; "###D#D#A#A###"
-;; "  #C#C#B#B#  "
-;; "  #########  "
-  {:a0 {:type :d}
-   :a1 {:type :c}
-   :b0 {:type :d}
-   :b1 {:type :c}
-   :c0 {:type :a}
-   :c1 {:type :b}
-   :d0 {:type :a}
-   :d1 {:type :b}})
+(defn parse
+  [input]
+  (let [relevant-rows (take 2 (drop 2 input))
+        chars  (mapcat #(re-seq #"[A-D]" %) relevant-rows)]
+    (zipmap [:a0 :b0 :c0 :d0 :a1 :b1 :c1 :d1] (map charmap chars))))
 
 (def distances
   {:h0 {:h1 1  :h2 3  :h3 5 :h4 7 :h5 9 :h6 10 :a0 3  :a1 4  :a2 5  :a3 6  :b0 5  :b1 6 :b2 7  :b3 8  :c0 7  :c1 8  :c2 9  :c3 10 :d0 9  :d1 10 :d2 11 :d3 12}
@@ -154,10 +137,6 @@
        (map :cost)
        (reduce +)))
 
-(defn day23-part1-soln
-  []
-  (cost-of-moves day23-input day23-input-soln))
-
 (defn unfold-input
   [input]
   (-> (select-keys input [:a0 :b0 :c0 :d0])
@@ -201,6 +180,10 @@
    [:h5 :b0]
    [:h6 :c0]])
 
+(defn day23-part1-soln
+  [input]
+  (cost-of-moves input day23-input-soln))
+
 (defn day23-part2-soln
-  []
-  (cost-of-moves (unfold-input day23-input) day23-input-soln-part2))
+  [input]
+  (cost-of-moves (unfold-input input) day23-input-soln-part2))

--- a/src/aoc_clj/2021/day24.clj
+++ b/src/aoc_clj/2021/day24.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2021.day24
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2021/day/24"
+  (:require [clojure.string :as str]))
 
 (defn parse-line
   [line]
@@ -15,55 +15,27 @@
   [input]
   (map parse-line input))
 
-(def day24-sample1
-  (parse
-   ["inp x"
-    "mul x -1"]))
+;; (defn arg
+;;   [regs s]
+;;   (if (number? s) s (regs s)))
 
-(def day24-sample2
-  (parse
-   ["inp z"
-    "inp x"
-    "mul z 3"
-    "eql z x"]))
-
-(def day24-sample3
-  (parse
-   ["inp w"
-    "add z w"
-    "mod z 2"
-    "div w 2"
-    "add y w"
-    "mod y 2"
-    "div w 2"
-    "add x w"
-    "mod x 2"
-    "div w 2"
-    "mod w 2"]))
-
-(def day24-input (parse (u/puzzle-input "inputs/2021/day24-input.txt")))
-
-(defn arg
-  [regs s]
-  (if (number? s) s (regs s)))
-
-(defn cmd-execute
-  [{:keys [regs input]} [cmd a b]]
-  (merge {:regs regs :input input}
-         (case cmd
-           "inp" {:regs (assoc regs a (first input))
-                  :input (rest input)}
-           "add" {:regs (update regs a + (arg regs b))}
-           "mul" {:regs (update regs a * (arg regs b))}
-           "div" {:regs (update regs a quot (arg regs b))}
-           "mod" {:regs (update regs a mod (arg regs b))}
-           "eql" {:regs (assoc regs a (if (= (regs a) (arg regs b)) 1 0))})))
+;; (defn cmd-execute
+;;   [{:keys [regs input]} [cmd a b]]
+;;   (merge {:regs regs :input input}
+;;          (case cmd
+;;            "inp" {:regs (assoc regs a (first input))
+;;                   :input (rest input)}
+;;            "add" {:regs (update regs a + (arg regs b))}
+;;            "mul" {:regs (update regs a * (arg regs b))}
+;;            "div" {:regs (update regs a quot (arg regs b))}
+;;            "mod" {:regs (update regs a mod (arg regs b))}
+;;            "eql" {:regs (assoc regs a (if (= (regs a) (arg regs b)) 1 0))})))
 
 (def init-regs {"w" 0 "x" 0 "y" 0 "z" 0})
-(defn prog-execute
-  [program input]
-  (reduce cmd-execute {:regs init-regs
-                       :input input} program))
+;; (defn prog-execute
+;;   [program input]
+;;   (reduce cmd-execute {:regs init-regs
+;;                        :input input} program))
 
 ;; (defn largest-model-number
 ;;   []
@@ -121,23 +93,23 @@
 
 (defn char-14 [input] (form-c 12 10 input))
 
-(defn monad
-  [input]
-  (-> {:regs init-regs :input input}
-      char-01
-      char-02
-      char-03
-      char-04
-      char-05
-      char-06
-      char-07
-      char-08
-      char-09
-      char-10
-      char-11
-      char-12
-      char-13
-      char-14))
+;; (defn monad
+;;   [input]
+;;   (-> {:regs init-regs :input input}
+;;       char-01
+;;       char-02
+;;       char-03
+;;       char-04
+;;       char-05
+;;       char-06
+;;       char-07
+;;       char-08
+;;       char-09
+;;       char-10
+;;       char-11
+;;       char-12
+;;       char-13
+;;       char-14))
 
 (defn chunk-1 [input] (-> {:regs init-regs :input input} char-01 char-02 char-03 char-04 char-05))
 (defn chunk-2 [input] (-> input char-06))
@@ -147,20 +119,14 @@
 (defn chunk-6 [input] (-> input char-13))
 (defn chunk-7 [input] (-> input char-14))
 
-(def chunks
-  [[chunk-1 5]
-   [chunk-2 1]
-   [chunk-3 2]
-   [chunk-4 2]
-   [chunk-5 2]
-   [chunk-6 1]
-   [chunk-7 1]])
-
-;; worked this out by hand while iterating through the character logic
-(def largest-input [9 8 9 9 8 5 1 9 5 9 6 9 9 7])
-(defn day24-part1-soln
-  []
-  (Long/parseLong (apply str largest-input)))
+;; (def chunks
+;;   [[chunk-1 5]
+;;    [chunk-2 1]
+;;    [chunk-3 2]
+;;    [chunk-4 2]
+;;    [chunk-5 2]
+;;    [chunk-6 1]
+;;    [chunk-7 1]])
 
 (defn candidates-with-n-digits
   [n]
@@ -200,6 +166,12 @@
                    (remove (comp not-viable? chunk-7 chunk-6 chunk-5 chunk-4 chunk-3 chunk-2 chunk-1)))]
     tier7))
 
+;; worked this out by hand while iterating through the character logic
+(def largest-input [9 8 9 9 8 5 1 9 5 9 6 9 9 7])
+(defn day24-part1-soln
+  [_]
+  (Long/parseLong (apply str largest-input)))
+
 (defn day24-part2-soln
-  []
+  [_]
   (Long/parseLong (apply str (first (smallest-model-number)))))

--- a/src/aoc_clj/2021/day25.clj
+++ b/src/aoc_clj/2021/day25.clj
@@ -1,14 +1,12 @@
 (ns aoc-clj.2021.day25
-  (:require [aoc-clj.utils.grid.mapgrid :as mapgrid]
-            [aoc-clj.utils.core :as u]))
+  "Solution to https://adventofcode.com/2021/day/25"
+  (:require [aoc-clj.utils.grid.mapgrid :as mapgrid]))
 
 (def charmap {\v :down \> :right \. :open})
 
-(def day25-input
-  (mapgrid/ascii->MapGrid2D
-   charmap
-   (u/puzzle-input "inputs/2021/day25-input.txt")
-   :down true))
+(defn parse
+  [input]
+  (mapgrid/ascii->MapGrid2D charmap input :down true))
 
 (defn available?
   [grid pos]
@@ -51,5 +49,5 @@
       (recur curr-state (step curr-state) (inc steps)))))
 
 (defn day25-part1-soln
-  []
-  (first (evolve-until-stop day25-input)))
+  [input]
+  (first (evolve-until-stop input)))

--- a/src/aoc_clj/2021/gridgraph.clj
+++ b/src/aoc_clj/2021/gridgraph.clj
@@ -17,35 +17,35 @@
     [_ _ v2]
     (get-in grid [:grid v2])))
 
-(defn in-bounds?
-  [width height [x y]]
-  (and (<= 0 x (dec width))
-       (<= 0 y (dec height))))
+;; (defn in-bounds?
+;;   [width height [x y]]
+;;   (and (<= 0 x (dec width))
+;;        (<= 0 y (dec height))))
 
-(defrecord TiledGridGraph [grid tile-count]
-  Graph
-  (vertices
-    [_]
-    (let [maxx (dec (:width grid))
-          maxy (dec (:height grid))]
-      (for [y (range (* tile-count maxy))
-            x (range (* tile-count maxx))]
-        [x y])))
+;; (defrecord TiledGridGraph [grid tile-count]
+;;   Graph
+;;   (vertices
+;;     [_]
+;;     (let [maxx (dec (:width grid))
+;;           maxy (dec (:height grid))]
+;;       (for [y (range (* tile-count maxy))
+;;             x (range (* tile-count maxx))]
+;;         [x y])))
 
-  (edges
-    [_ v]
-    (->> (grid/adj-coords-2d v)
-         (filter (partial in-bounds?
-                          (* tile-count (:width grid))
-                          (* tile-count (:height grid))))))
+;;   (edges
+;;     [_ v]
+;;     (->> (grid/adj-coords-2d v)
+;;          (filter (partial in-bounds?
+;;                           (* tile-count (:width grid))
+;;                           (* tile-count (:height grid))))))
 
-  (distance
-    [_ _ [x y]]
-    (let [tilex (quot x (:width grid))
-          posx  (mod  x (:width grid))
-          tiley (quot y (:height grid))
-          posy  (mod  y (:height grid))
-          raw   (get-in grid [:grid [posx posy]])
-          to-add (mod (+ tilex tiley) 9)
-          adj   (+ raw to-add)]
-      (if (>= adj 10) (mod adj 9) adj))))
+;;   (distance
+;;     [_ _ [x y]]
+;;     (let [tilex (quot x (:width grid))
+;;           posx  (mod  x (:width grid))
+;;           tiley (quot y (:height grid))
+;;           posy  (mod  y (:height grid))
+;;           raw   (get-in grid [:grid [posx posy]])
+;;           to-add (mod (+ tilex tiley) 9)
+;;           adj   (+ raw to-add)]
+;;       (if (>= adj 10) (mod adj 9) adj))))

--- a/src/aoc_clj/2022/day01.clj
+++ b/src/aoc_clj/2022/day01.clj
@@ -14,8 +14,6 @@
   [input]
   (->> input u/split-at-blankline (map parse-segment)))
 
-(def day01-input (u/parse-puzzle-input parse 2022 1))
-
 ;;;; Puzzle logic
 
 (defn sorted-totals
@@ -33,11 +31,11 @@
 (defn day01-part1-soln
   "Find the Elf carrying the most Calories. 
    How many total Calories is that Elf carrying?"
-  []
-  (top-n-capacity-sum 1 day01-input))
+  [input]
+  (top-n-capacity-sum 1 input))
 
 (defn day01-part2-soln
   "Find the top three Elves carrying the most Calories. 
    How many Calories are those Elves carrying in total?"
-  []
-  (top-n-capacity-sum 3 day01-input))
+  [input]
+  (top-n-capacity-sum 3 input))

--- a/src/aoc_clj/2022/day02.clj
+++ b/src/aoc_clj/2022/day02.clj
@@ -1,7 +1,6 @@
 (ns aoc-clj.2022.day02
   "Solution to https://adventofcode.com/2022/day/2"
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  (:require [clojure.string :as str]))
 
 ;;;; Constants
 
@@ -59,8 +58,6 @@
   [input]
   (map #(str/split % #" ") input))
 
-(def day02-input (u/parse-puzzle-input parse 2022 2))
-
 (defn interpret
   "Interpret the input data according to the guidance of part1 or part2,
    as given by the `interpret-fn` for the second column"
@@ -98,11 +95,11 @@
 (defn day02-part1-soln
   "What would your total score be if everything goes exactly according to 
    your strategy guide?"
-  []
-  (reduce + (map score-part1 (interpret-part1 day02-input))))
+  [input]
+  (reduce + (map score-part1 (interpret-part1 input))))
 
 (defn day02-part2-soln
   "Following the Elf's instructions for the second column, what would your 
    total score be if everything goes exactly according to your strategy guide?"
-  []
-  (reduce + (map score-part2 (interpret-part2 day02-input))))
+  [input]
+  (reduce + (map score-part2 (interpret-part2 input))))

--- a/src/aoc_clj/2022/day03.clj
+++ b/src/aoc_clj/2022/day03.clj
@@ -1,11 +1,9 @@
 (ns aoc-clj.2022.day03
   "Solution to https://adventofcode.com/2022/day/3"
-  (:require [clojure.set :as set]
-            [aoc-clj.utils.core :as u]))
+  (:require [clojure.set :as set]))
 
 ;;;; Input parsing
 (def parse identity)
-(def day03-input (u/parse-puzzle-input parse 2022 3))
 
 ;;;; Puzzle logic
 
@@ -57,11 +55,11 @@
 (defn day03-part1-soln
   "Find the item type that appears in both compartments of each rucksack. 
    What is the sum of the priorities of those item types?"
-  []
-  (overlap-priority-sum ::halfway day03-input))
+  [input]
+  (overlap-priority-sum ::halfway input))
 
 (defn day03-part2-soln
   "Find the item type that corresponds to the badges of each three-Elf group. 
    What is the sum of the priorities of those item types?"
-  []
-  (overlap-priority-sum ::thirds day03-input))
+  [input]
+  (overlap-priority-sum ::thirds input))

--- a/src/aoc_clj/2022/day04.clj
+++ b/src/aoc_clj/2022/day04.clj
@@ -1,7 +1,6 @@
 (ns aoc-clj.2022.day04
   "Solution to https://adventofcode.com/2022/day/4"
   (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]
             [aoc-clj.utils.intervals :as ivs]))
 
 ;;;; Input parsing
@@ -21,16 +20,14 @@
   [input]
   (mapv parse-line input))
 
-(def day04-input (u/parse-puzzle-input parse 2022 4))
-
 ;;;; Puzzle solutions
 
 (defn day04-part1-soln
   "In how many assignment pairs does one range fully contain the other?"
-  []
-  (count (filter #(apply ivs/fully-contained? %) day04-input)))
+  [input]
+  (count (filter #(apply ivs/fully-contained? %) input)))
 
 (defn day04-part2-soln
   "In how many assignment pairs do the ranges overlap?"
-  []
-  (count (filter #(apply ivs/overlap? %) day04-input)))
+  [input]
+  (count (filter #(apply ivs/overlap? %) input)))

--- a/src/aoc_clj/2022/day05.clj
+++ b/src/aoc_clj/2022/day05.clj
@@ -53,8 +53,6 @@
     {:stacks (parse-stacks stacks)
      :moves  (parse-moves moves)}))
 
-(def day05-input (u/parse-puzzle-input parse 2022 5))
-
 ;;;; Puzzle logic
 
 (defn take-crates-2
@@ -106,8 +104,8 @@
 (defn day05-part1-soln
   "After the rearrangement procedure completes, 
    what crate ends up on top of each stack?"
-  []
-  (-> day05-input final-arrangement-1 stack-tops))
+  [input]
+  (-> input final-arrangement-1 stack-tops))
 
 (defn day05-part2-soln
   "The CrateMover 9001 is notable for many new and exciting features: 
@@ -116,5 +114,5 @@
    
    After the rearrangement procedure completes, 
    what crate ends up on top of each stack?"
-  []
-  (-> day05-input final-arrangement-2 stack-tops))
+  [input]
+  (-> input final-arrangement-2 stack-tops))

--- a/src/aoc_clj/2022/day06.clj
+++ b/src/aoc_clj/2022/day06.clj
@@ -4,7 +4,6 @@
 
 ;;;; Input parsing
 (def parse first)
-(def day06-input (u/parse-puzzle-input parse 2022 6))
 
 ;;;; Puzzle logic
 
@@ -23,12 +22,12 @@
 (defn day06-part1-soln
   "How many characters need to be processed before the 
    first start-of-packet marker is detected?"
-  []
-  (chars-to-distinct-run 4 day06-input))
+  [input]
+  (chars-to-distinct-run 4 input))
 
 (defn day06-part2-soln
   "How many characters need to be processed before the 
    first start-of-message marker is detected?"
-  []
-  (chars-to-distinct-run 14 day06-input))
+  [input]
+  (chars-to-distinct-run 14 input))
 

--- a/src/aoc_clj/2022/day07.clj
+++ b/src/aoc_clj/2022/day07.clj
@@ -1,7 +1,6 @@
 (ns aoc-clj.2022.day07
   "Solution to https://adventofcode.com/2022/day/7"
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  (:require [clojure.string :as str]))
 
 ;;;; Constants
 
@@ -77,8 +76,6 @@
       (:tree state)
       (recur (process state)))))
 
-(def day07-input (u/parse-puzzle-input parse 2022 7))
-
 ;;;; Puzzle logic
 
 (defn node-size
@@ -135,12 +132,12 @@
 (defn day07-part1-soln
   "Find all of the directories with a total size of at most 100000. 
    What is the sum of the total sizes of those directories?"
-  []
-  (dir-total-below-100k day07-input))
+  [input]
+  (dir-total-below-100k input))
 
 (defn day07-part2-soln
   "Find the smallest directory that, if deleted, would free up enough space 
    on the filesystem to run the update. What is the total size of that 
    directory?"
-  []
-  (smallest-dir-size-to-remove day07-input))
+  [input]
+  (smallest-dir-size-to-remove input))

--- a/src/aoc_clj/2022/day08.clj
+++ b/src/aoc_clj/2022/day08.clj
@@ -11,8 +11,6 @@
   [input]
   (mapv parse-row input))
 
-(def day08-input (u/parse-puzzle-input parse 2022 8))
-
 ;;;; Puzzle logic
 
 (defn visible?
@@ -99,20 +97,20 @@
        (flatten (grid-view-distance grid))
        (flatten (transpose-fn grid-view-distance grid))))
 
-;;;; Puzzle solutions
-
 (defn max-scenic-score
   "Find the maximum scenic score of any tree in the grid"
   [input]
   (apply max (scenic-score input)))
 
+;;;; Puzzle solutions
+
 (defn day08-part1-soln
   "Consider your map; how many trees are visible from outside the grid?"
-  []
-  (visible-trees day08-input))
+  [input]
+  (visible-trees input))
 
 (defn day08-part2-soln
   "Consider each tree on your map. What is the highest scenic score 
    possible for any tree?"
-  []
-  (max-scenic-score day08-input))
+  [input]
+  (max-scenic-score input))

--- a/src/aoc_clj/2022/day09.clj
+++ b/src/aoc_clj/2022/day09.clj
@@ -1,7 +1,6 @@
 (ns aoc-clj.2022.day09
   "Solution to https://adventofcode.com/2022/day/9"
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  (:require [clojure.string :as str]))
 
 ;;;; Constants
 
@@ -25,8 +24,6 @@
 (defn parse
   [input]
   (expand (map parse-line input)))
-
-(def day09-input (u/parse-puzzle-input parse 2022 9))
 
 ;;;; Puzzle logic
 
@@ -81,12 +78,12 @@
 (defn day09-part1-soln
   "Simulate your complete hypothetical series of motions. How many positions 
    does the tail of the rope visit at least once?"
-  []
-  (distinct-tail-positions 2 day09-input))
+  [input]
+  (distinct-tail-positions 2 input))
 
 (defn day09-part2-soln
   "Simulate your complete series of motions on a larger rope with ten knots. 
    How many positions does the tail of the rope visit at least once?"
-  []
-  (distinct-tail-positions 10 day09-input))
+  [input]
+  (distinct-tail-positions 10 input))
 

--- a/src/aoc_clj/2022/day10.clj
+++ b/src/aoc_clj/2022/day10.clj
@@ -1,7 +1,6 @@
 (ns aoc-clj.2022.day10
   "Solution to https://adventofcode.com/2022/day/10"
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  (:require [clojure.string :as str]))
 
 ;;;; Input parsing
 
@@ -14,8 +13,6 @@
 (defn parse
   [input]
   (map parse-line input))
-
-(def day10-input (u/parse-puzzle-input parse 2022 10))
 
 ;;;; Puzzle logic
 
@@ -76,20 +73,19 @@
 (defn day10-part1-soln
   "Find the signal strength during the 20th, 60th, 100th, 140th, 180th, 
    and 220th cycles. What is the sum of these six signal strengths?"
-  []
-  (sampled-signal-strength-sums day10-input))
-
-(comment
-  (print (screen day10-input))
-  "####  ##  #### #  # ####  ##  #    ###  
-   #    #  #    # #  #    # #  # #    #  # 
-   ###  #      #  #  #   #  #  # #    #  # 
-   #    #     #   #  #  #   #### #    ###  
-   #    #  # #    #  # #    #  # #    # #  
-   ####  ##  ####  ##  #### #  # #### #  #")
+  [input]
+  (sampled-signal-strength-sums input))
 
 (defn day10-part2-soln
   "Render the image given by your program. 
    What eight capital letters appear on your CRT?"
-  []
+  [input]
+  (comment
+    (print (screen input))
+    "####  ##  #### #  # ####  ##  #    ###  
+     #    #  #    # #  #    # #  # #    #  # 
+     ###  #      #  #  #   #  #  # #    #  # 
+     #    #     #   #  #  #   #### #    ###  
+     #    #  # #    #  # #    #  # #    # #  
+     ####  ##  ####  ##  #### #  # #### #  #")
   "ECZUZALR")

--- a/src/aoc_clj/2022/day11.clj
+++ b/src/aoc_clj/2022/day11.clj
@@ -38,8 +38,6 @@
   [input]
   (mapv parse-monkey (u/split-at-blankline input)))
 
-(def day11-input (u/parse-puzzle-input parse 2022 11))
-
 ;;;; Puzzle logic
 
 (defn items
@@ -161,13 +159,13 @@
 (defn day11-part1-soln
   "What is the level of monkey business after 20 rounds of stuff-slinging 
    simian shenanigans?"
-  []
-  (monkey-business-1 day11-input 20))
+  [input]
+  (monkey-business-1 input 20))
 
 (defn day11-part2-soln
   "Worry levels are no longer divided by three after each item is inspected; 
    you'll need to find another way to keep your worry levels manageable. 
    Starting again from the initial state in your puzzle input, what is the 
    level of monkey business after 10000 rounds?"
-  []
-  (monkey-business-2 (part2-augment day11-input) 10000))
+  [input]
+  (monkey-business-2 (part2-augment input) 10000))

--- a/src/aoc_clj/2022/day12.clj
+++ b/src/aoc_clj/2022/day12.clj
@@ -17,8 +17,6 @@
   [input]
   (mapgrid/lists->MapGrid2D (map (partial map translate) input)))
 
-(def day12-input (u/parse-puzzle-input parse 2022 12))
-
 ;;;; Puzzle logic
 
 (defn find-matches
@@ -71,11 +69,11 @@
 (defn day12-part1-soln
   "What is the fewest steps required to move from your current position to the 
    location that should get the best signal?"
-  []
-  (shortest-path-from-start day12-input))
+  [input]
+  (shortest-path-from-start input))
 
 (defn day12-part2-soln
   "What is the fewest steps required to move starting from any square with 
    elevation `a` to the location that should get the best signal?"
-  []
-  (shortest-path-from-any-a day12-input))
+  [input]
+  (shortest-path-from-any-a input))

--- a/src/aoc_clj/2022/day13.clj
+++ b/src/aoc_clj/2022/day13.clj
@@ -16,8 +16,6 @@
   (map (partial mapv read-string)
        (u/split-at-blankline input)))
 
-(def day13-input (u/parse-puzzle-input parse 2022 13))
-
 ;;;; Puzzle logic
 
 (declare packet-compare)
@@ -88,11 +86,11 @@
 (defn day13-part1-soln
   "Determine which pairs of packets are already in the right order. 
    What is the sum of the indices of those pairs?"
-  []
-  (right-order-packet-id-sum day13-input))
+  [input]
+  (right-order-packet-id-sum input))
 
 (defn day13-part2-soln
   "Organize all of the packets into the correct order. 
    What is the decoder key for the distress signal?"
-  []
-  (decoder-key day13-input))
+  [input]
+  (decoder-key input))

--- a/src/aoc_clj/2022/day14.clj
+++ b/src/aoc_clj/2022/day14.clj
@@ -1,7 +1,6 @@
 (ns aoc-clj.2022.day14
   "Solution to https://adventofcode.com/2022/day/14"
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  (:require [clojure.string :as str]))
 
 ;;;; Input parsing
 
@@ -30,8 +29,6 @@
 (defn parse
   [input]
   (rocks (map parse-line input)))
-
-(def day14-input (u/parse-puzzle-input parse 2022 14))
 
 ;;;; Puzzle logic
 
@@ -124,12 +121,12 @@
 (defn day14-part1-soln
   "Using your scan, simulate the falling sand. How many units of sand come 
    to rest before sand starts flowing into the abyss below?"
-  []
-  (sand-until-continuous-flow day14-input))
+  [input]
+  (sand-until-continuous-flow input))
 
 (defn day14-part2-soln
   "Using your scan, simulate the falling sand until the source of the sand 
    becomes blocked. How many units of sand come to rest?"
-  []
-  (sand-until-blocked day14-input))
+  [input]
+  (sand-until-blocked input))
 

--- a/src/aoc_clj/2022/day15.clj
+++ b/src/aoc_clj/2022/day15.clj
@@ -2,8 +2,7 @@
   "Solution to https://adventofcode.com/2022/day/15"
   (:require [clojure.math.combinatorics :as combo]
             [aoc-clj.utils.intervals :as ivs]
-            [aoc-clj.utils.math :as math]
-            [aoc-clj.utils.core :as u]))
+            [aoc-clj.utils.math :as math]))
 
 ;;;; Input parsing
 
@@ -15,8 +14,6 @@
 (defn parse
   [input]
   (map parse-line input))
-
-(def day15-input (u/parse-puzzle-input parse 2022 15))
 
 ;;;; Puzzle logic
 
@@ -119,11 +116,11 @@
 (defn day15-part1-soln
   "Consult the report from the sensors you just deployed. In the row where 
    y=2000000, how many positions cannot contain a beacon?"
-  []
-  (no-beacon-points-in-line day15-input 2000000))
+  [input]
+  (no-beacon-points-in-line input 2000000))
 
 (defn day15-part2-soln
   "Find the only possible position for the distress beacon. 
    What is its tuning frequency?"
-  []
-  (tuning-frequency (gap-position day15-input)))
+  [input]
+  (tuning-frequency (gap-position input)))

--- a/src/aoc_clj/2022/day16.clj
+++ b/src/aoc_clj/2022/day16.clj
@@ -18,8 +18,6 @@
   [input]
   (map parse-line input))
 
-(def day16-input (u/parse-puzzle-input parse 2022 16))
-
 ;;;; Puzzle logic
 
 (defn edges
@@ -156,11 +154,11 @@
 (defn day16-part1-soln
   "Work out the steps to release the most pressure in 30 minutes. 
    What is the most pressure you can release?"
-  []
-  (best-pressure day16-input))
+  [input]
+  (best-pressure input))
 
 (defn day16-part2-soln
   "With you and an elephant working together for 26 minutes, what is the 
    most pressure you could release?"
-  []
-  (best-pressure-2 day16-input))
+  [input]
+  (best-pressure-2 input))

--- a/src/aoc_clj/2022/day17.clj
+++ b/src/aoc_clj/2022/day17.clj
@@ -1,7 +1,6 @@
 (ns aoc-clj.2022.day17
   "Solution to https://adventofcode.com/2022/day/17"
-  (:require [aoc-clj.utils.core :as u]
-            [aoc-clj.utils.math :as math]))
+  (:require [aoc-clj.utils.math :as math]))
 
 ;;;; Constants
 
@@ -30,7 +29,6 @@
 ;;;; Input parsing
 
 (def parse first)
-(def day17-input (u/parse-puzzle-input parse 2022 17))
 
 ;;;; Puzzle logic
 
@@ -208,10 +206,10 @@
 (defn day17-part1-soln
   "How many units tall will the tower of rocks be after 2022 rocks have 
    stopped falling?"
-  []
-  (tower-height-after-n day17-input 2022))
+  [input]
+  (tower-height-after-n input 2022))
 
 (defn day17-part2-soln
   "How tall will the tower be after 1000000000000 rocks have stopped?"
-  []
-  (tower-height-after-n day17-input 1000000000000))
+  [input]
+  (tower-height-after-n input 1000000000000))

--- a/src/aoc_clj/2022/day18.clj
+++ b/src/aoc_clj/2022/day18.clj
@@ -9,8 +9,6 @@
   [input]
   (set (map u/str->vec input)))
 
-(def day18-input (parse (u/puzzle-input "inputs/2022/day18-input.txt")))
-
 ;;;; Puzzle logic
 
 (defn surface-area
@@ -83,10 +81,10 @@
 
 (defn day18-part1-soln
   "What is the surface area of your scanned lava droplet?"
-  []
-  (surface-area day18-input))
+  [input]
+  (surface-area input))
 
 (defn day18-part2-soln
   "What is the exterior surface area of your scanned lava droplet?"
-  []
-  (outer-surface-area day18-input))
+  [input]
+  (outer-surface-area input))

--- a/src/aoc_clj/2022/day19.clj
+++ b/src/aoc_clj/2022/day19.clj
@@ -1,7 +1,6 @@
 (ns aoc-clj.2022.day19
   "Solution to https://adventofcode.com/2022/day/19"
-  (:require [clojure.set :as set]
-            [aoc-clj.utils.core :as u]))
+  (:require [clojure.set :as set]))
 
 ;;;; Constants
 
@@ -26,8 +25,6 @@
 (defn parse
   [input]
   (into {} (mapv parse-line input)))
-
-(def day19-input (u/parse-puzzle-input parse 2022 19))
 
 ;;;; Puzzle logic
 
@@ -170,8 +167,8 @@
   "Determine the quality level of each blueprint using the largest number of 
    geodes it could produce in 24 minutes. What do you get if you add up 
    the quality level of all of the blueprints in your list?"
-  []
-  (quality-level-sum day19-input))
+  [input]
+  (quality-level-sum input))
 
 (defn day19-part2-soln
   "You no longer have enough blueprints to worry about quality levels. 
@@ -181,5 +178,5 @@
    Don't worry about quality levels; instead, just determine the largest number
    of geodes you could open using each of the first three blueprints. 
    What do you get if you multiply these numbers together?"
-  []
-  (max-geode-product day19-input))
+  [input]
+  (max-geode-product input))

--- a/src/aoc_clj/2022/day20.clj
+++ b/src/aoc_clj/2022/day20.clj
@@ -12,8 +12,6 @@
   [input]
   (mapv read-string input))
 
-(def day20-input (u/parse-puzzle-input parse 2022 20))
-
 ;;;; Puzzle logic
 
 (defn remove-and-insert
@@ -93,11 +91,11 @@
 (defn day20-part1-soln
   "Mix your encrypted file exactly once. 
    What is the sum of the three numbers that form the grove coordinates?"
-  []
-  (grove-coordinates (mixed day20-input)))
+  [input]
+  (grove-coordinates (mixed input)))
 
 (defn day20-part2-soln
   "Apply the decryption key and mix your encrypted file ten times. 
    What is the sum of the three numbers that form the grove coordinates?"
-  []
-  (decrypt-and-mix-ten day20-input))
+  [input]
+  (decrypt-and-mix-ten input))

--- a/src/aoc_clj/2022/day21.clj
+++ b/src/aoc_clj/2022/day21.clj
@@ -1,7 +1,6 @@
 (ns aoc-clj.2022.day21
   "Solution to https://adventofcode.com/2022/day/21"
-  (:require [clojure.string :as str]
-            [aoc-clj.utils.core :as u]))
+  (:require [clojure.string :as str]))
 
 ;;;; Input parsing
 
@@ -16,8 +15,6 @@
 (defn parse
   [input]
   (into {} (map parse-line input)))
-
-(def day21-input (u/parse-puzzle-input parse 2022 21))
 
 ;;;; Puzzle logic
 
@@ -118,10 +115,10 @@
 
 (defn day21-part1-soln
   "What number will the monkey named root yell?"
-  []
-  (root-yell day21-input))
+  [input]
+  (root-yell input))
 
 (defn day21-part2-soln
   "What number do you yell to pass root's equality test?"
-  []
-  (humn-value day21-input))
+  [input]
+  (humn-value input))

--- a/src/aoc_clj/2022/day22.clj
+++ b/src/aoc_clj/2022/day22.clj
@@ -84,8 +84,6 @@
     (assoc (parse-map a)
            :path (parse-path (first b)))))
 
-(def day22-input (u/parse-puzzle-input parse 2022 22))
-
 ;;;; Puzzle logic
 
 (defn zone-match
@@ -190,12 +188,12 @@
 
 (defn day22-part1-soln
   "Follow the path given in the monkeys' notes. What is the final password?"
-  []
-  (final-password (follow-path (assoc day22-input :wrap-fn wrap-around))))
+  [input]
+  (final-password (follow-path (assoc input :wrap-fn wrap-around))))
 
 (defn day22-part2-soln
   "Fold the map into a cube, then follow the path given in the monkeys' notes. 
    What is the final password?"
-  []
-  (final-password (follow-path (assoc day22-input :wrap-fn cube-wrap-around))))
+  [input]
+  (final-password (follow-path (assoc input :wrap-fn cube-wrap-around))))
 

--- a/src/aoc_clj/2022/day23.clj
+++ b/src/aoc_clj/2022/day23.clj
@@ -21,8 +21,6 @@
        (map first)
        (into #{})))
 
-(def day23-input (u/parse-puzzle-input parse 2022 23))
-
 ;;;; Puzzle logic
 
 (defn done?
@@ -138,11 +136,11 @@
   "Simulate the Elves' process and find the smallest rectangle that contains 
    the Elves after 10 rounds. How many empty ground tiles does that 
    rectangle contain?"
-  []
-  (empty-tiles-after-ten-rounds day23-input))
+  [input]
+  (empty-tiles-after-ten-rounds input))
 
 (defn day23-part2-soln
   "Figure out where the Elves need to go. What is the number of the first 
    round where no Elf moves?"
-  []
-  (rounds-until-static day23-input))
+  [input]
+  (rounds-until-static input))

--- a/src/aoc_clj/2022/day24.clj
+++ b/src/aoc_clj/2022/day24.clj
@@ -1,7 +1,6 @@
 (ns aoc-clj.2022.day24
   "Solution to https://adventofcode.com/2022/day/24"
-  (:require [aoc-clj.utils.core :as u]
-            [aoc-clj.utils.graph :as graph :refer [Graph]]
+  (:require [aoc-clj.utils.graph :as graph :refer [Graph]]
             [aoc-clj.utils.grid :as grid]
             [aoc-clj.utils.grid.mapgrid :as mapgrid]
             [aoc-clj.utils.math :as math]))
@@ -23,8 +22,6 @@
     {:x-bound   (- width 2)
      :y-bound   (- height 2)
      :blizzards (blizzards grid)}))
-
-(def day24-input (u/parse-puzzle-input parse 2022 24))
 
 ;;;; Puzzle logic
 
@@ -153,11 +150,11 @@
 (defn day24-part1-soln
   "What is the fewest number of minutes required to avoid the blizzards and
    reach the goal?"
-  []
-  (shortest-time-to-exit day24-input))
+  [input]
+  (shortest-time-to-exit input))
 
 (defn day24-part2-soln
   "What is the fewest number of minutes required to reach the goal, 
    go back to the start, then reach the goal again?"
-  []
-  (shortest-roundtrip-to-exit day24-input))
+  [input]
+  (shortest-roundtrip-to-exit input))

--- a/src/aoc_clj/2022/day25.clj
+++ b/src/aoc_clj/2022/day25.clj
@@ -15,7 +15,6 @@
 ;;;; Input parsing
 
 (def parse identity)
-(def day25-input (u/parse-puzzle-input parse 2022 25))
 
 ;;;; Puzzle logic
 
@@ -95,6 +94,6 @@
 
 (defn day25-part1-soln
   "What SNAFU number do you supply to Bob's console?"
-  []
-  (requirements-sum day25-input))
+  [input]
+  (requirements-sum input))
 

--- a/src/aoc_clj/2023/day21.clj
+++ b/src/aoc_clj/2023/day21.clj
@@ -3,7 +3,7 @@
             [aoc-clj.utils.grid.vecgrid :as vg]))
 
 (def steps-part1 64)
-(def steps-part2 26501365)
+;; (def steps-part2 26501365)
 
 (def charmap {\S :start \. :plot \# :rock})
 

--- a/src/aoc_clj/2023/day25.clj
+++ b/src/aoc_clj/2023/day25.clj
@@ -1,6 +1,5 @@
 (ns aoc-clj.2023.day25
   (:require [clojure.string :as str]
-            [aoc-clj.utils.graph :as graph]
             [aoc-clj.utils.core :as u]
             [clojure.set :as set]))
 

--- a/src/aoc_clj/utils/graph.clj
+++ b/src/aoc_clj/utils/graph.clj
@@ -90,9 +90,9 @@
   [g path]
   (reduce + (map #(apply (partial distance g) %) (partition 2 1 path))))
 
-(defn entries-in-set
-  [s m]
-  (filter (fn [[k _]] (s k)) m))
+;; (defn entries-in-set
+;;   [s m]
+;;   (filter (fn [[k _]] (s k)) m))
 
 (defn entries-not-in-set
   [s m]

--- a/test/aoc_clj/2015/day01_test.clj
+++ b/test/aoc_clj/2015/day01_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2015.day01-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day01 :as t]))
 
 (deftest final-floor
@@ -19,10 +20,12 @@
     (is (= 1 (t/first-pos-in-basement ")")))
     (is (= 5 (t/first-pos-in-basement "()())")))))
 
+(def day01-input (u/parse-puzzle-input t/parse 2015 1))
+
 (deftest day01-part1-soln
   (testing "Reproduces the answer for day01, part1"
-    (is (= 138 (t/day01-part1-soln)))))
+    (is (= 138 (t/day01-part1-soln day01-input)))))
 
 (deftest day01-part2-soln
   (testing "Reproduces the answer for day01, part2"
-    (is (= 1771 (t/day01-part2-soln)))))
+    (is (= 1771 (t/day01-part2-soln day01-input)))))

--- a/test/aoc_clj/2015/day02_test.clj
+++ b/test/aoc_clj/2015/day02_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2015.day02-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day02 :as t]))
 
 (deftest wrapping-paper-area
@@ -12,10 +13,12 @@
     (is (= 34 (t/ribbon-length [2 3 4])))
     (is (= 14 (t/ribbon-length [1 1 10])))))
 
+(def day02-input (u/parse-puzzle-input t/parse 2015 2))
+
 (deftest day02-part1-soln
   (testing "Reproduces the answer for day02, part1"
-    (is (= 1598415 (t/day02-part1-soln)))))
+    (is (= 1598415 (t/day02-part1-soln day02-input)))))
 
 (deftest day02-part2-soln
   (testing "Reproduces the answer for day02, part2"
-    (is (= 3812909 (t/day02-part2-soln)))))
+    (is (= 3812909 (t/day02-part2-soln day02-input)))))

--- a/test/aoc_clj/2015/day03_test.clj
+++ b/test/aoc_clj/2015/day03_test.clj
@@ -1,28 +1,31 @@
 (ns aoc-clj.2015.day03-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day03 :as t]))
 
-(def day03-sample1 ">")
-(def day03-sample2 "^>v<")
-(def day03-sample3 "^v^v^v^v^v")
-(def day03-sample4 "^v")
+(def d03-s00 ">")
+(def d03-s01 "^>v<")
+(def d03-s02 "^v^v^v^v^v")
+(def d03-s03 "^v")
 
 (deftest houses-visited
   (testing "Counts the houses visited following the directions"
-    (is (= 2 (t/houses-visited day03-sample1)))
-    (is (= 4 (t/houses-visited day03-sample2)))
-    (is (= 2 (t/houses-visited day03-sample3)))))
+    (is (= 2 (t/houses-visited d03-s00)))
+    (is (= 4 (t/houses-visited d03-s01)))
+    (is (= 2 (t/houses-visited d03-s02)))))
 
 (deftest split-houses-visited
   (testing "Counts houses visited by Santa and Robo-Santa"
-    (is (= 3 (t/split-houses-visited day03-sample4)))
-    (is (= 3 (t/split-houses-visited day03-sample2)))
-    (is (= 11 (t/split-houses-visited day03-sample3)))))
+    (is (= 3  (t/split-houses-visited d03-s03)))
+    (is (= 3  (t/split-houses-visited d03-s01)))
+    (is (= 11 (t/split-houses-visited d03-s02)))))
+
+(def day03-input (u/parse-puzzle-input t/parse 2015 3))
 
 (deftest day03-part1-soln
   (testing "Reproduces the answer for day03, part1"
-    (is (= 2081 (t/day03-part1-soln)))))
+    (is (= 2081 (t/day03-part1-soln day03-input)))))
 
 (deftest day03-part2-soln
   (testing "Reproduces the answer for day03, part2"
-    (is (= 2341 (t/day03-part2-soln)))))
+    (is (= 2341 (t/day03-part2-soln day03-input)))))

--- a/test/aoc_clj/2015/day04_test.clj
+++ b/test/aoc_clj/2015/day04_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2015.day04-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day04 :as t]))
 
 ;; FIXME: 2015.day04 solution is too slow to unit test
@@ -10,11 +11,13 @@
     (is (= 609043  (t/first-to-start-with-five-zeros "abcdef")))
     (is (= 1048970 (t/first-to-start-with-five-zeros "pqrstuv")))))
 
+(def day04-input (u/parse-puzzle-input t/parse 2015 4))
+
 (deftest ^:slow day04-part1-soln
   (testing "Reproduces the answer for day04, part1"
-    (is (= 282749 (t/day04-part1-soln)))))
+    (is (= 282749 (t/day04-part1-soln day04-input)))))
 
 ;; ULTRA SLOW!
 (deftest ^:slow day04-part2-soln
   (testing "Reproduces the answer for day04, part2"
-    (is (= 9962624 (t/day04-part2-soln)))))
+    (is (= 9962624 (t/day04-part2-soln day04-input)))))

--- a/test/aoc_clj/2015/day05_test.clj
+++ b/test/aoc_clj/2015/day05_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2015.day05-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day05 :as t]))
 
 (deftest nice-strings
@@ -27,10 +28,12 @@
     (is (not (t/new-nice? "ieodomkazucvgmuy")))
     (is (not (t/non-overlapping-pair? "ieodomkazucvgmuy")))))
 
+(def day05-input (u/parse-puzzle-input t/parse 2015 5))
+
 (deftest day05-part1-soln
   (testing "Reproduces the answer for day05, part1"
-    (is (= 255 (t/day05-part1-soln)))))
+    (is (= 255 (t/day05-part1-soln day05-input)))))
 
 (deftest day05-part2-soln
   (testing "Reproduces the answer for day05, part2"
-    (is (= 55 (t/day05-part2-soln)))))
+    (is (= 55 (t/day05-part2-soln day05-input)))))

--- a/test/aoc_clj/2015/day06_test.clj
+++ b/test/aoc_clj/2015/day06_test.clj
@@ -1,13 +1,16 @@
 (ns aoc-clj.2015.day06-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day06 :as t]))
+
+(def day06-input (u/parse-puzzle-input t/parse 2015 6))
 
 ;; FIXME: 2015.day06 solution is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/2
 (deftest ^:slow day06-part1-soln
   (testing "Reproduces the answer for day06, part1"
-    (is (= 377891 (t/day06-part1-soln)))))
+    (is (= 377891 (t/day06-part1-soln day06-input)))))
 
 (deftest ^:slow day06-part2-soln
   (testing "Reproduces the answer for day06, part2"
-    (is (= 14110788 (t/day06-part2-soln)))))
+    (is (= 14110788 (t/day06-part2-soln day06-input)))))

--- a/test/aoc_clj/2015/day07_test.clj
+++ b/test/aoc_clj/2015/day07_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2015.day07-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day07 :as t]))
 
 (def day07-sample ["123 -> x"
@@ -14,19 +15,19 @@
 
 (deftest parse-test
   (testing "Parser logic works correctly"
-    (is (= (t/parse (nth day07-sample 0))  ["x" {:op :assign :args 123}]))
-    (is (= (t/parse (nth day07-sample 1))  ["y" {:op :assign :args 456}]))
-    (is (= (t/parse (nth day07-sample 2))  ["d" {:op :and :args ["x" "y"]}]))
-    (is (= (t/parse (nth day07-sample 3))  ["e" {:op :or :args ["x" "y"]}]))
-    (is (= (t/parse (nth day07-sample 4))  ["f" {:op :lshift :args ["x" 2]}]))
-    (is (= (t/parse (nth day07-sample 5))  ["g" {:op :rshift :args ["y" 2]}]))
-    (is (= (t/parse (nth day07-sample 6))  ["h" {:op :not :args ["x"]}]))
-    (is (= (t/parse (nth day07-sample 7))  ["i" {:op :not :args ["y"]}]))
-    (is (= (t/parse (nth day07-sample 8))  ["j" {:op :assign :args "f"}]))))
+    (is (= (t/parse-line (nth day07-sample 0))  ["x" {:op :assign :args 123}]))
+    (is (= (t/parse-line (nth day07-sample 1))  ["y" {:op :assign :args 456}]))
+    (is (= (t/parse-line (nth day07-sample 2))  ["d" {:op :and :args ["x" "y"]}]))
+    (is (= (t/parse-line (nth day07-sample 3))  ["e" {:op :or :args ["x" "y"]}]))
+    (is (= (t/parse-line (nth day07-sample 4))  ["f" {:op :lshift :args ["x" 2]}]))
+    (is (= (t/parse-line (nth day07-sample 5))  ["g" {:op :rshift :args ["y" 2]}]))
+    (is (= (t/parse-line (nth day07-sample 6))  ["h" {:op :not :args ["x"]}]))
+    (is (= (t/parse-line (nth day07-sample 7))  ["i" {:op :not :args ["y"]}]))
+    (is (= (t/parse-line (nth day07-sample 8))  ["j" {:op :assign :args "f"}]))))
 
 (deftest wire-val-test
   (testing "Computes the wire values correctly"
-    (let [circuit (into {} (map t/parse day07-sample))]
+    (let [circuit (into {} (map t/parse-line day07-sample))]
       (is (= (t/wire-val circuit "d") 72))
       (is (= (t/wire-val circuit "e") 507))
       (is (= (t/wire-val circuit "f") 492))
@@ -37,10 +38,12 @@
       (is (= (t/wire-val circuit "y") 456))
       (is (= (t/wire-val circuit "j") 492)))))
 
+(def day07-input (u/parse-puzzle-input t/parse 2015 7))
+
 (deftest day07-part1-soln
   (testing "Reproduces the answer for day07, part1"
-    (is (= 3176 (t/day07-part1-soln)))))
+    (is (= 3176 (t/day07-part1-soln day07-input)))))
 
 (deftest day07-part2-soln
   (testing "Reproduces the answer for day07, part2"
-    (is (= 14710 (t/day07-part2-soln)))))
+    (is (= 14710 (t/day07-part2-soln day07-input)))))

--- a/test/aoc_clj/2015/day08_test.clj
+++ b/test/aoc_clj/2015/day08_test.clj
@@ -1,50 +1,53 @@
 (ns aoc-clj.2015.day08-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day08 :as t]))
 
-(def day08-sample1 "\"\"")
-(def day08-sample2 "\"abc\"")
-(def day08-sample3 "\"aaa\\\"aaa\"")
-(def day08-sample4 "\"\\x27\"")
+(def d08-s00 "\"\"")
+(def d08-s01 "\"abc\"")
+(def d08-s02 "\"aaa\\\"aaa\"")
+(def d08-s03 "\"\\x27\"")
 
 (deftest code-chars-test
   (testing "Correctly counts the number of code chars"
-    (is (= 2  (t/code-chars day08-sample1)))
-    (is (= 5  (t/code-chars day08-sample2)))
-    (is (= 10 (t/code-chars day08-sample3)))
-    (is (= 6  (t/code-chars day08-sample4)))))
+    (is (= 2  (t/code-chars d08-s00)))
+    (is (= 5  (t/code-chars d08-s01)))
+    (is (= 10 (t/code-chars d08-s02)))
+    (is (= 6  (t/code-chars d08-s03)))))
 
 (deftest unescaped-chars-test
   (testing "Correctly counts the number of unescaped chars"
-    (is (= 0  (t/unescaped-chars day08-sample1)))
-    (is (= 3  (t/unescaped-chars day08-sample2)))
-    (is (= 7  (t/unescaped-chars day08-sample3)))
-    (is (= 1  (t/unescaped-chars day08-sample4)))))
+    (is (= 0  (t/unescaped-chars d08-s00)))
+    (is (= 3  (t/unescaped-chars d08-s01)))
+    (is (= 7  (t/unescaped-chars d08-s02)))
+    (is (= 1  (t/unescaped-chars d08-s03)))))
 
 (deftest escaped-chars-test
   (testing "Correctly counts the number of escaped chars"
-    (is (= 6  (t/escaped-chars day08-sample1)))
-    (is (= 9  (t/escaped-chars day08-sample2)))
-    (is (= 16 (t/escaped-chars day08-sample3)))
-    (is (= 11 (t/escaped-chars day08-sample4)))))
+    (is (= 6  (t/escaped-chars d08-s00)))
+    (is (= 9  (t/escaped-chars d08-s01)))
+    (is (= 16 (t/escaped-chars d08-s02)))
+    (is (= 11 (t/escaped-chars d08-s03)))))
 
 
 (deftest unescaped-difference-test
-  (is (= 12 (t/unescaped-difference [day08-sample1
-                                     day08-sample2
-                                     day08-sample3
-                                     day08-sample4]))))
+  (is (= 12 (t/unescaped-difference [d08-s00
+                                     d08-s01
+                                     d08-s02
+                                     d08-s03]))))
 
 (deftest escaped-difference-test
-  (is (= 19 (t/escaped-difference [day08-sample1
-                                   day08-sample2
-                                   day08-sample3
-                                   day08-sample4]))))
+  (is (= 19 (t/escaped-difference [d08-s00
+                                   d08-s01
+                                   d08-s02
+                                   d08-s03]))))
+
+(def day08-input (u/parse-puzzle-input t/parse 2015 8))
 
 (deftest day08-part1-soln
   (testing "Reproduces the answer for day08, part1"
-    (is (= 1371 (t/day08-part1-soln)))))
+    (is (= 1371 (t/day08-part1-soln day08-input)))))
 
 (deftest day08-part2-soln
   (testing "Reproduces the answer for day08, part2"
-    (is (= 2117 (t/day08-part2-soln)))))
+    (is (= 2117 (t/day08-part2-soln day08-input)))))

--- a/test/aoc_clj/2015/day09_test.clj
+++ b/test/aoc_clj/2015/day09_test.clj
@@ -1,33 +1,36 @@
 (ns aoc-clj.2015.day09-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day09 :as t]))
 
-(def day09-sample (t/parse
-                   ["London to Dublin = 464"
-                    "London to Belfast = 518"
-                    "Dublin to Belfast = 141"]))
+(def d09-s00 (t/parse
+              ["London to Dublin = 464"
+               "London to Belfast = 518"
+               "Dublin to Belfast = 141"]))
 
 (deftest route-distances
   (testing "Returns the distance along an identified route"
-    (is (= 982 (t/route-distance day09-sample ["Dublin" "London" "Belfast"])))
-    (is (= 605 (t/route-distance day09-sample ["London" "Dublin" "Belfast"])))
-    (is (= 659 (t/route-distance day09-sample ["London" "Belfast" "Dublin"])))
-    (is (= 659 (t/route-distance day09-sample ["Dublin" "Belfast" "London"])))
-    (is (= 605 (t/route-distance day09-sample ["Belfast" "Dublin" "London"])))
-    (is (= 982 (t/route-distance day09-sample ["Belfast" "London" "Dublin"])))))
+    (is (= 982 (t/route-distance d09-s00 ["Dublin" "London" "Belfast"])))
+    (is (= 605 (t/route-distance d09-s00 ["London" "Dublin" "Belfast"])))
+    (is (= 659 (t/route-distance d09-s00 ["London" "Belfast" "Dublin"])))
+    (is (= 659 (t/route-distance d09-s00 ["Dublin" "Belfast" "London"])))
+    (is (= 605 (t/route-distance d09-s00 ["Belfast" "Dublin" "London"])))
+    (is (= 982 (t/route-distance d09-s00 ["Belfast" "London" "Dublin"])))))
 
 (deftest shortest-route-distance
   (testing "Returns the distance of the shortest route"
-    (is (= 605 (t/shortest-route-distance day09-sample)))))
+    (is (= 605 (t/shortest-route-distance d09-s00)))))
 
 (deftest longest-route-distance
   (testing "Returns the distance of the longest route"
-    (is (= 982 (t/longest-route-distance day09-sample)))))
+    (is (= 982 (t/longest-route-distance d09-s00)))))
+
+(def day09-input (u/parse-puzzle-input t/parse 2015 9))
 
 (deftest day09-part1-soln
   (testing "Reproduces the answer for day09, part1"
-    (is (= 207 (t/day09-part1-soln)))))
+    (is (= 207 (t/day09-part1-soln day09-input)))))
 
 (deftest day09-part2-soln
   (testing "Reproduces the answer for day09, part2"
-    (is (= 804 (t/day09-part2-soln)))))
+    (is (= 804 (t/day09-part2-soln day09-input)))))

--- a/test/aoc_clj/2015/day10_test.clj
+++ b/test/aoc_clj/2015/day10_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2015.day10-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day10 :as t]))
 
 (deftest look-and-say
@@ -9,12 +10,14 @@
     (is (= "1211" (t/look-and-say "21")))
     (is (= "111221" (t/look-and-say "1211")))))
 
+(def day10-input (u/parse-puzzle-input t/parse 2015 10))
+
 (deftest day10-part1-soln
   (testing "Reproduces the answer for day10, part1"
-    (is (= 252594 (t/day10-part1-soln)))))
+    (is (= 252594 (t/day10-part1-soln day10-input)))))
 
 ;; FIXME: 2015.day10 solution is slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/5
 (deftest ^:slow day10-part2-soln
   (testing "Reproduces the answer for day10, part2"
-    (is (= 3579328 (t/day10-part2-soln)))))
+    (is (= 3579328 (t/day10-part2-soln day10-input)))))

--- a/test/aoc_clj/2015/day11_test.clj
+++ b/test/aoc_clj/2015/day11_test.clj
@@ -1,36 +1,37 @@
 (ns aoc-clj.2015.day11-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day11 :as t]))
 
-(def day11-sample1 (t/str->nums "hijklmmn"))
-(def day11-sample2 (t/str->nums "abbceffg"))
-(def day11-sample3 (t/str->nums "abbcegjk"))
+(def d11-s00 (t/str->nums "hijklmmn"))
+(def d11-s01 (t/str->nums "abbceffg"))
+(def d11-s02 (t/str->nums "abbcegjk"))
 
-(def day11-sample4      "abcdefgh")
-(def day11-sample4-next "abcdffaa")
+(def d11-s03      "abcdefgh")
+(def d11-s03-next "abcdffaa")
 
-(def day11-sample5      "ghijklmn")
-(def day11-sample5-next "ghjaabcc")
+(def d11-s04      "ghijklmn")
+(def d11-s04-next "ghjaabcc")
 
 (deftest rules-test
   (testing "Correctly applies valid password rules"
-    (is (t/increasing-straight?     day11-sample1))
-    (is (not (t/no-disallowed?      day11-sample1)))
-    (is (not (t/two-distinct-pairs? day11-sample1)))
-    (is (not (t/valid-password?     day11-sample1)))
+    (is (t/increasing-straight?     d11-s00))
+    (is (not (t/no-disallowed?      d11-s00)))
+    (is (not (t/two-distinct-pairs? d11-s00)))
+    (is (not (t/valid-password?     d11-s00)))
 
-    (is (not (t/increasing-straight? day11-sample2)))
-    (is (t/no-disallowed?            day11-sample2))
-    (is (t/two-distinct-pairs?       day11-sample2))
-    (is (not (t/valid-password?      day11-sample2)))
+    (is (not (t/increasing-straight? d11-s01)))
+    (is (t/no-disallowed?            d11-s01))
+    (is (t/two-distinct-pairs?       d11-s01))
+    (is (not (t/valid-password?      d11-s01)))
 
-    (is (not (t/increasing-straight? day11-sample3)))
-    (is (t/no-disallowed?            day11-sample3))
-    (is (not (t/two-distinct-pairs?  day11-sample3)))
-    (is (not (t/valid-password?      day11-sample3)))
+    (is (not (t/increasing-straight? d11-s02)))
+    (is (t/no-disallowed?            d11-s02))
+    (is (not (t/two-distinct-pairs?  d11-s02)))
+    (is (not (t/valid-password?      d11-s02)))
 
-    (is (t/valid-password? (t/str->nums day11-sample4-next)))
-    (is (t/valid-password? (t/str->nums day11-sample5-next)))))
+    (is (t/valid-password? (t/str->nums d11-s03-next)))
+    (is (t/valid-password? (t/str->nums d11-s04-next)))))
 
 (deftest increment-test
   (testing "Verifying that incrementing works correctly"
@@ -43,13 +44,15 @@
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/3
 (deftest ^:slow next-valid-password-test
   (testing "Finds the next valid password"
-    (is (= day11-sample4-next (t/next-valid-password day11-sample4)))
-    (is (= day11-sample5-next (t/next-valid-password day11-sample5)))))
+    (is (= d11-s03-next (t/next-valid-password d11-s03)))
+    (is (= d11-s04-next (t/next-valid-password d11-s04)))))
+
+(def day11-input (u/parse-puzzle-input t/parse 2015 11))
 
 (deftest ^:slow day11-part1-soln
   (testing "Reproduces the answer for day11, part1"
-    (is (= "hxbxxyzz" (t/day11-part1-soln)))))
+    (is (= "hxbxxyzz" (t/day11-part1-soln day11-input)))))
 
 (deftest ^:slow day11-part2-soln
   (testing "Reproduces the answer for day11, part2"
-    (is (= "hxcaabcc" (t/day11-part2-soln)))))
+    (is (= "hxcaabcc" (t/day11-part2-soln day11-input)))))

--- a/test/aoc_clj/2015/day12_test.clj
+++ b/test/aoc_clj/2015/day12_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2015.day12-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day12 :as t]))
 
 (deftest drop-red-test
@@ -9,10 +10,12 @@
     (is (= {}          (t/drop-red {"d" "red","e" [1,2,3,4],"f" 5})))
     (is (= [1 "red" 5] (t/drop-red [1, "red", 5])))))
 
+(def day12-input (u/parse-puzzle-input t/parse 2015 12))
+
 (deftest day12-part1-soln
   (testing "Reproduces the answer for day12, part1"
-    (is (= 111754 (t/day12-part1-soln)))))
+    (is (= 111754 (t/day12-part1-soln day12-input)))))
 
 (deftest day12-part2-soln
   (testing "Reproduces the answer for day12, part2"
-    (is (= 65402 (t/day12-part2-soln)))))
+    (is (= 65402 (t/day12-part2-soln day12-input)))))

--- a/test/aoc_clj/2015/day13_test.clj
+++ b/test/aoc_clj/2015/day13_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2015.day13-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day13 :as t]))
 
-(def day13-sample
+(def d13-s00
   ["Alice would gain 54 happiness units by sitting next to Bob."
    "Alice would lose 79 happiness units by sitting next to Carol."
    "Alice would lose 2 happiness units by sitting next to David."
@@ -18,12 +19,14 @@
 
 (deftest max-happiness-test
   (testing "Finds the maximum happiness value for the guest list"
-    (is (= 330 (t/max-happiness (t/parse day13-sample))))))
+    (is (= 330 (t/max-happiness (t/parse d13-s00))))))
+
+(def day13-input (u/parse-puzzle-input t/parse 2015 13))
 
 (deftest day13-part1-soln
   (testing "Reproduces the answer for day13, part1"
-    (is (= 709 (t/day13-part1-soln)))))
+    (is (= 709 (t/day13-part1-soln day13-input)))))
 
 (deftest day13-part2-soln
   (testing "Reproduces the answer for day13, part2"
-    (is (= 668 (t/day13-part2-soln)))))
+    (is (= 668 (t/day13-part2-soln day13-input)))))

--- a/test/aoc_clj/2015/day14_test.clj
+++ b/test/aoc_clj/2015/day14_test.clj
@@ -1,25 +1,28 @@
 (ns aoc-clj.2015.day14-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day14 :as t]))
 
-(def day14-sample
+(def d14-s00
   (t/parse
    ["Comet can fly 14 km/s for 10 seconds, but then must rest for 127 seconds."
     "Dancer can fly 16 km/s for 11 seconds, but then must rest for 162 seconds."]))
 
 (deftest distance-test
   (testing "Finds the distance traveled by each reindeer after 1000 seconds"
-    (is (= 1120 (t/distance-at-time 1000 (get day14-sample "Comet"))))
-    (is (= 1056 (t/distance-at-time 1000 (get day14-sample "Dancer"))))))
+    (is (= 1120 (t/distance-at-time 1000 (get d14-s00 "Comet"))))
+    (is (= 1056 (t/distance-at-time 1000 (get d14-s00 "Dancer"))))))
 
 (deftest points-test
   (testing "Finds the points scored by each reindeer after 1000 seconds"
-    (is (= [312 689] (t/points-at-time 1000 day14-sample)))))
+    (is (= [312 689] (t/points-at-time 1000 d14-s00)))))
+
+(def day14-input (u/parse-puzzle-input t/parse 2015 14))
 
 (deftest day14-part1-soln
   (testing "Reproduces the answer for day14, part1"
-    (is (= 2660 (t/day14-part1-soln)))))
+    (is (= 2660 (t/day14-part1-soln day14-input)))))
 
 (deftest day14-part2-soln
   (testing "Reproduces the answer for day14, part2"
-    (is (= 1256 (t/day14-part2-soln)))))
+    (is (= 1256 (t/day14-part2-soln day14-input)))))

--- a/test/aoc_clj/2015/day15_test.clj
+++ b/test/aoc_clj/2015/day15_test.clj
@@ -1,21 +1,22 @@
 (ns aoc-clj.2015.day15-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day15 :as t]))
 
-(def day15-sample
+(def d15-s00
   (t/parse
    ["Butterscotch: capacity -1, durability -2, flavor 6, texture 3, calories 8"
     "Cinnamon: capacity 2, durability 3, flavor -2, texture -1, calories 3"]))
 
 (deftest score-test
   (testing "Computes the score correctly"
-    (is (= 62842880 (t/score day15-sample [44 56])))
-    (is (= 57600000 (t/score day15-sample [40 60])))))
+    (is (= 62842880 (t/score d15-s00 [44 56])))
+    (is (= 57600000 (t/score d15-s00 [40 60])))))
 
 (deftest find-max-score-test
   (testing "Finds the right combination to maximize the score"
-    (is (= '(44 56) (t/find-max-score t/score day15-sample)))
-    (is (= '(40 60) (t/find-max-score t/score-with-500cal day15-sample)))))
+    (is (= '(44 56) (t/find-max-score t/score d15-s00)))
+    (is (= '(40 60) (t/find-max-score t/score-with-500cal d15-s00)))))
 
 (deftest all-options-test
   (testing "Can generate all combinations of n vars that sum to a total"
@@ -25,10 +26,12 @@
                                            (1 0 0 1) (0 2 0 0) (0 1 1 0) (0 1 0 1)
                                            (0 0 2 0) (0 0 1 1) (0 0 0 2))))))
 
+(def day15-input (u/parse-puzzle-input t/parse 2015 15))
+
 (deftest day15-part1-soln
   (testing "Reproduces the answer for day15, part1"
-    (is (= 21367368 (t/day15-part1-soln)))))
+    (is (= 21367368 (t/day15-part1-soln day15-input)))))
 
 (deftest day15-part2-soln
   (testing "Reproduces the answer for day15, part2"
-    (is (= 1766400 (t/day15-part2-soln)))))
+    (is (= 1766400 (t/day15-part2-soln day15-input)))))

--- a/test/aoc_clj/2015/day16_test.clj
+++ b/test/aoc_clj/2015/day16_test.clj
@@ -1,11 +1,14 @@
 (ns aoc-clj.2015.day16-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day16 :as t]))
+
+(def day16-input (u/parse-puzzle-input t/parse 2015 16))
 
 (deftest day16-part1-soln
   (testing "Reproduces the answer for day16, part1"
-    (is (= 213 (t/day16-part1-soln)))))
+    (is (= 213 (t/day16-part1-soln day16-input)))))
 
 (deftest day16-part2-soln
   (testing "Reproduces the answer for day16, part2"
-    (is (= 323 (t/day16-part2-soln)))))
+    (is (= 323 (t/day16-part2-soln day16-input)))))

--- a/test/aoc_clj/2015/day17_test.clj
+++ b/test/aoc_clj/2015/day17_test.clj
@@ -1,23 +1,26 @@
 (ns aoc-clj.2015.day17-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day17 :as t]))
 
-(def day17-sample [20 15 10 5 5])
+(def d17-s00 [20 15 10 5 5])
 
 (deftest combinations-test
   (testing "Identifies the correct combinations, allowing for dupes"
-    (is (= '((20 5) (20 5) (15 10) (15 5 5)) (t/combinations 25 day17-sample)))))
+    (is (= '((20 5) (20 5) (15 10) (15 5 5)) (t/combinations 25 d17-s00)))))
 
 (deftest min-combinations-test
   (testing "Identifies the correct minimal combinations"
-    (is (= '((20 5) (20 5) (15 10)) (t/minimal-combinations 25 day17-sample)))))
+    (is (= '((20 5) (20 5) (15 10)) (t/minimal-combinations 25 d17-s00)))))
+
+(def day17-input (u/parse-puzzle-input t/parse 2015 17))
 
 ;; FIXME: 2015.day17 solution is slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/6
 (deftest ^:slow day17-part1-soln
   (testing "Reproduces the answer for day17, part1"
-    (is (= 654 (t/day17-part1-soln)))))
+    (is (= 654 (t/day17-part1-soln day17-input)))))
 
 (deftest ^:slow day17-part2-soln
   (testing "Reproduces the answer for day17, part2"
-    (is (= 57 (t/day17-part2-soln)))))
+    (is (= 57 (t/day17-part2-soln day17-input)))))

--- a/test/aoc_clj/2015/day18_test.clj
+++ b/test/aoc_clj/2015/day18_test.clj
@@ -1,9 +1,10 @@
 (ns aoc-clj.2015.day18-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.utils.grid.mapgrid :as mapgrid]
             [aoc-clj.2015.day18 :as t]))
 
-(def day18-sample
+(def d18-s00
   (mapgrid/ascii->MapGrid2D t/char-map
                             [".#.#.#"
                              "...##."
@@ -14,18 +15,20 @@
 
 (deftest lights-on-at-step-n-test
   (testing "Computes the lights on after a number of steps in sample"
-    (is (= 4 (t/lights-on-at-step-n 4 day18-sample)))))
+    (is (= 4 (t/lights-on-at-step-n 4 d18-s00)))))
 
 (deftest lights-on-at-step-n-with-corners-tes
   (testing "Computes the lights on after a number of steps in sample with corners stuck on"
-    (is (= 17 (t/lights-on-at-step-n true 5 (t/corners-on day18-sample))))))
+    (is (= 17 (t/lights-on-at-step-n true 5 (t/corners-on d18-s00))))))
+
+(def day18-input (u/parse-puzzle-input t/parse 2015 18))
 
 ;; FIXME: 2015.day18 solution is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/4
 (deftest ^:slow day18-part1-soln
   (testing "Reproduces the answer for day18, part1"
-    (is (= 1061 (t/day18-part1-soln)))))
+    (is (= 1061 (t/day18-part1-soln day18-input)))))
 
 (deftest ^:slow day18-part2-soln
   (testing "Reproduces the answer for day18, part2"
-    (is (= 1006 (t/day18-part2-soln)))))
+    (is (= 1006 (t/day18-part2-soln day18-input)))))

--- a/test/aoc_clj/2015/day19_test.clj
+++ b/test/aoc_clj/2015/day19_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2015.day19-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day19 :as t]))
 
-(def day19-sample1
+(def d19-s00
   (t/parse
    ["e => H"
     "e => O"
@@ -12,7 +13,7 @@
     ""
     "HOH"]))
 
-(def day19-sample2
+(def d19-s01
   (t/parse
    ["e => H"
     "e => O"
@@ -24,18 +25,20 @@
 
 (deftest distinct-replacements-test
   (testing "Can count the correct number of distinct molecules generated"
-    (is (= 4 (count (t/distinct-molecules day19-sample1))))
-    (is (= 7 (count (t/distinct-molecules day19-sample2))))))
+    (is (= 4 (count (t/distinct-molecules d19-s00))))
+    (is (= 7 (count (t/distinct-molecules d19-s01))))))
 
 (deftest fabrication-steps-test
   (testing "Can count the minimum number of steps to fabricate the molecule"
-    (is (= 3 (count (t/fabrication-steps day19-sample1))))
-    (is (= 6 (count (t/fabrication-steps day19-sample2))))))
+    (is (= 3 (count (t/fabrication-steps d19-s00))))
+    (is (= 6 (count (t/fabrication-steps d19-s01))))))
+
+(def day19-input (u/parse-puzzle-input t/parse 2015 19))
 
 (deftest day19-part1-soln
   (testing "Reproduces the answer for day19, part1"
-    (is (= 518 (t/day19-part1-soln)))))
+    (is (= 518 (t/day19-part1-soln day19-input)))))
 
 (deftest day19-part2-soln
   (testing "Reproduces the answer for day19, part2"
-    (is (= 200 (t/day19-part2-soln)))))
+    (is (= 200 (t/day19-part2-soln day19-input)))))

--- a/test/aoc_clj/2015/day20_test.clj
+++ b/test/aoc_clj/2015/day20_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2015.day20-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day20 :as t]))
 
 (deftest presents-test
@@ -7,10 +8,12 @@
     (is (= [10 30 40 70 60 120 80 150 130]
            (map t/house-presents (range 1 10))))))
 
+(def day20-input (u/parse-puzzle-input t/parse 2015 20))
+
 (deftest day20-part1-soln
   (testing "Reproduces the answer for day20, part1"
-    (is (= 776160 (t/day20-part1-soln)))))
+    (is (= 776160 (t/day20-part1-soln day20-input)))))
 
 (deftest day20-part2-soln
   (testing "Reproduces the answer for day20, part2"
-    (is (= 786240 (t/day20-part2-soln)))))
+    (is (= 786240 (t/day20-part2-soln day20-input)))))

--- a/test/aoc_clj/2015/day21_test.clj
+++ b/test/aoc_clj/2015/day21_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2015.day21-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day21 :as t]))
 
 (deftest combo-total-test
@@ -12,10 +13,12 @@
     (is (t/player-wins? {:hit-points 12 :damage 7 :armor 2}
                         {:hit-points  8 :damage 5 :armor 5}))))
 
+(def day21-input (u/parse-puzzle-input t/parse 2015 21))
+
 (deftest day21-part1-soln
   (testing "Reproduces the answer for day21, part1"
-    (is (= 78 (t/day21-part1-soln)))))
+    (is (= 78 (t/day21-part1-soln day21-input)))))
 
 (deftest day21-part2-soln
   (testing "Reproduces the answer for day21, part2"
-    (is (= 148 (t/day21-part2-soln)))))
+    (is (= 148 (t/day21-part2-soln day21-input)))))

--- a/test/aoc_clj/2015/day22_test.clj
+++ b/test/aoc_clj/2015/day22_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2015.day22-test
   (:require [clojure.test :refer [deftest testing is]]
+            ;; [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day22 :as t]))
 
 (def day22-sample1
@@ -25,6 +26,8 @@
             :boss   {:hit-points -1 :damage 8}
             :effects {:poison 3}}
            (reduce t/combat-round day22-sample2 day22-sample2-moves)))))
+
+;; (def day22-input (u/parse-puzzle-input t/parse 2015 22))
 
 (deftest day22-part1-soln
   (testing "Reproduces the answer for day22, part1"

--- a/test/aoc_clj/2015/day23_test.clj
+++ b/test/aoc_clj/2015/day23_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2015.day23-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day23 :as t]))
 
-(def day23-sample
+(def d23-s00
   (t/parse
    ["inc a"
     "jio a, +2"
@@ -11,12 +12,15 @@
 
 (deftest run-program-test
   (testing "Runs on the simple input"
-    (is (= {:a 2 :b 0 :next-inst 4} (t/run-program day23-sample {:a 0 :b 0 :next-inst 0})))))
+    (is (= {:a 2 :b 0 :next-inst 4}
+           (t/run-program d23-s00 {:a 0 :b 0 :next-inst 0})))))
+
+(def day23-input (u/parse-puzzle-input t/parse 2015 23))
 
 (deftest day23-part1-soln
   (testing "Reproduces the answer for day23, part1"
-    (is (= 184 (t/day23-part1-soln)))))
+    (is (= 184 (t/day23-part1-soln day23-input)))))
 
 (deftest day23-part2-soln
   (testing "Reproduces the answer for day23, part2"
-    (is (= 231 (t/day23-part2-soln)))))
+    (is (= 231 (t/day23-part2-soln day23-input)))))

--- a/test/aoc_clj/2015/day24_test.clj
+++ b/test/aoc_clj/2015/day24_test.clj
@@ -1,18 +1,21 @@
 (ns aoc-clj.2015.day24-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day24 :as t]))
 
-(def day24-sample (concat (range 1 6) (range 7 12)))
+(def d24-s00 (concat (range 1 6) (range 7 12)))
 
 (deftest best-qe-test
   (testing "Correctly computes the lowest quantum entanglement for the sample data"
-    (is (= 99 (t/best-qe-thirds day24-sample)))
-    (is (= 44 (t/best-qe-fourths day24-sample)))))
+    (is (= 99 (t/best-qe-thirds d24-s00)))
+    (is (= 44 (t/best-qe-fourths d24-s00)))))
+
+(def day24-input (u/parse-puzzle-input t/parse 2015 24))
 
 (deftest day24-part1-soln
   (testing "Reproduces the answer for day24, part1"
-    (is (= 11846773891 (t/day24-part1-soln)))))
+    (is (= 11846773891 (t/day24-part1-soln day24-input)))))
 
 (deftest day24-part2-soln
   (testing "Reproduces the answer for day24, part1"
-    (is (= 80393059 (t/day24-part2-soln)))))
+    (is (= 80393059 (t/day24-part2-soln day24-input)))))

--- a/test/aoc_clj/2015/day25_test.clj
+++ b/test/aoc_clj/2015/day25_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2015.day25-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2015.day25 :as t]))
 
 (deftest code-num-test
@@ -25,6 +26,8 @@
     (is (= 33511524 (t/code 1 6)))
     (is (= 27995004 (t/code 6 6)))))
 
+(def day25-input (u/parse-puzzle-input t/parse 2015 25))
+
 (deftest day25-part1-soln
   (testing "Reproduces the answer for day25, part1"
-    (is (= 9132360 (t/day25-part1-soln)))))
+    (is (= 9132360 (t/day25-part1-soln day25-input)))))

--- a/test/aoc_clj/2016/day01_test.clj
+++ b/test/aoc_clj/2016/day01_test.clj
@@ -1,34 +1,37 @@
 (ns aoc-clj.2016.day01-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2016.day01 :as t]))
 
-(def day01-sample1 (t/parse "R2, L3"))
-(def day01-sample2 (t/parse "R2, R2, R2"))
-(def day01-sample3 (t/parse "R5, L5, R5, R3"))
-(def day01-sample4 (t/parse "R8, R4, R4, R8"))
+(def d01-s00 (t/parse ["R2, L3"]))
+(def d01-s01 (t/parse ["R2, R2, R2"]))
+(def d01-s02 (t/parse ["R5, L5, R5, R3"]))
+(def d01-s03 (t/parse ["R8, R4, R4, R8"]))
 
 (deftest move-test
   (testing "Moves to the correct location on sample data"
-    (is (= [2 3] (:pos (t/move day01-sample1))))
-    (is (= [0 -2] (:pos (t/move day01-sample2))))
-    (is (= [10 2] (:pos (t/move day01-sample3))))))
+    (is (= [2 3]  (:pos (t/move d01-s00))))
+    (is (= [0 -2] (:pos (t/move d01-s01))))
+    (is (= [10 2] (:pos (t/move d01-s02))))))
 
 (deftest distance-test
   (testing "Moves to the correct location on sample data"
-    (is (= 5  (t/distance day01-sample1)))
-    (is (= 2 (t/distance day01-sample2)))
-    (is (= 12  (t/distance day01-sample3)))))
+    (is (= 5  (t/distance d01-s00)))
+    (is (= 2  (t/distance d01-s01)))
+    (is (= 12 (t/distance d01-s02)))))
 
 (deftest first-location-visited-twice-test
   (testing "Finds the first location visited twice"
-    (is (= [4 0] (t/first-duplicate (:visited (t/all-visited day01-sample4))))))
+    (is (= [4 0] (t/first-duplicate (:visited (t/all-visited d01-s03))))))
   (testing "Finds distance to the first location visited twice"
-    (is (= 4 (t/distance-to-first-duplicate day01-sample4)))))
+    (is (= 4 (t/distance-to-first-duplicate d01-s03)))))
+
+(def day01-input (u/parse-puzzle-input t/parse 2016 1))
 
 (deftest day01-part1-soln
   (testing "Reproduces the answer for day01, part1"
-    (is (= 241 (t/day01-part1-soln)))))
+    (is (= 241 (t/day01-part1-soln day01-input)))))
 
 (deftest day01-part2-soln
   (testing "Reproduces the answer for day01, part2"
-    (is (= 116 (t/day01-part2-soln)))))
+    (is (= 116 (t/day01-part2-soln day01-input)))))

--- a/test/aoc_clj/2016/day02_test.clj
+++ b/test/aoc_clj/2016/day02_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2016.day02-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2016.day02 :as t]))
 
-(def day02-sample
+(def d02-s00
   ["ULL"
    "RRDDD"
    "LURDL"
@@ -10,14 +11,16 @@
 
 (deftest bathroom-code
   (testing "Computes the bathroom code on a square 9-digit keypad"
-    (is (= "1985" (t/square-bathroom-code day02-sample))))
+    (is (= "1985" (t/square-bathroom-code d02-s00))))
   (testing "Computes the bathroom code on a diagonal keypad"
-    (is (= "5DB3" (t/diagonal-bathroom-code day02-sample)))))
+    (is (= "5DB3" (t/diagonal-bathroom-code d02-s00)))))
+
+(def day02-input (u/parse-puzzle-input t/parse 2016 2))
 
 (deftest day02-part1-soln
   (testing "Reproduces the answer for day02, part1"
-    (is (= "18843" (t/day02-part1-soln)))))
+    (is (= "18843" (t/day02-part1-soln day02-input)))))
 
 (deftest day02-part2-soln
   (testing "Reproduces the answer for day02, part2"
-    (is (= "67BB9" (t/day02-part2-soln)))))
+    (is (= "67BB9" (t/day02-part2-soln day02-input)))))

--- a/test/aoc_clj/2016/day03_test.clj
+++ b/test/aoc_clj/2016/day03_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2016.day03-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2016.day03 :as t]))
 
-(def day03-sample
+(def d03-s00
   [[101 301 501]
    [102 302 502]
    [103 303 503]
@@ -18,12 +19,14 @@
              (401 402 403)
              (501 502 503)
              (601 602 603))
-           (t/group-by-columns day03-sample)))))
+           (t/group-by-columns d03-s00)))))
+
+(def day03-input (u/parse-puzzle-input t/parse 2016 3))
 
 (deftest day03-part1-soln
   (testing "Reproduces the answer for day03, part1"
-    (is (= 869 (t/day03-part1-soln)))))
+    (is (= 869 (t/day03-part1-soln day03-input)))))
 
 (deftest day03-part2-soln
   (testing "Reproduces the answer for day03, part2"
-    (is (= 1544 (t/day03-part2-soln)))))
+    (is (= 1544 (t/day03-part2-soln day03-input)))))

--- a/test/aoc_clj/2016/day04_test.clj
+++ b/test/aoc_clj/2016/day04_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2016.day04-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2016.day04 :as t]))
 
-(def day04-sample
+(def d04-s00
   (map t/parse-line
        ["aaaaa-bbb-z-y-x-123[abxyz]"
         "a-b-c-d-e-f-g-h-987[abcde]"
@@ -12,16 +13,18 @@
 (deftest real-room?
   (testing "Identifies which rooms are real (not decoys)"
     (is (= [true true true false]
-           (map t/real-room? day04-sample)))))
+           (map t/real-room? d04-s00)))))
 
 (deftest real-room-sector-id-sum
   (testing "Adds up the sector ids of all the real rooms"
-    (is (= 1514 (t/real-room-sector-id-sum day04-sample)))))
+    (is (= 1514 (t/real-room-sector-id-sum d04-s00)))))
+
+(def day04-input (u/parse-puzzle-input t/parse 2016 4))
 
 (deftest day04-part1-soln
   (testing "Reproduces the answer for day04, part1"
-    (is (= 361724 (t/day04-part1-soln)))))
+    (is (= 361724 (t/day04-part1-soln day04-input)))))
 
 (deftest day04-part2-soln
   (testing "Reproduces the answer for day04, part2"
-    (is (= 482 (t/day04-part2-soln)))))
+    (is (= 482 (t/day04-part2-soln day04-input)))))

--- a/test/aoc_clj/2016/day05_test.clj
+++ b/test/aoc_clj/2016/day05_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2016.day05-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2016.day05 :as t]))
 
-(def day05-sample "abc")
+(def d05-s00 "abc")
 
 (def day05-sample-valid-offsets
   "Found by calling (valid-hash-offsets day05-sample) and waiting a long time!"
@@ -13,16 +14,18 @@
 
 (deftest password
   (testing "Identifies the password using part1 logic"
-    (is (= "18f47a30" (t/password day05-sample day05-sample-valid-offsets)))))
+    (is (= "18f47a30" (t/password d05-s00 day05-sample-valid-offsets)))))
 
 (deftest password-part2
   (testing "Identifies the password using part2 logic"
-    (is (= "05ace8e3" (t/password-part2 day05-sample day05-sample-valid-offsets)))))
+    (is (= "05ace8e3" (t/password-part2 d05-s00 day05-sample-valid-offsets)))))
+
+(def day05-input (u/parse-puzzle-input t/parse 2016 5))
 
 (deftest day05-part1-soln
   (testing "Reproduces the answer for day05, part1"
-    (is (= "f97c354d" (t/day05-part1-soln)))))
+    (is (= "f97c354d" (t/day05-part1-soln day05-input)))))
 
 (deftest day05-part2-soln
   (testing "Reproduces the answer for day05, part2"
-    (is (= "863dde27" (t/day05-part2-soln)))))
+    (is (= "863dde27" (t/day05-part2-soln day05-input)))))

--- a/test/aoc_clj/2016/day06_test.clj
+++ b/test/aoc_clj/2016/day06_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2016.day06-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2016.day06 :as t]))
 
-(def day06-sample
+(def d06-s00
   ["eedadn"
    "drvtee"
    "eandsr"
@@ -22,16 +23,18 @@
 
 (deftest most-frequent-chars
   (testing "Decodes the most frequent character in each position"
-    (is (= "easter" (t/most-frequent-chars day06-sample)))))
+    (is (= "easter" (t/most-frequent-chars d06-s00)))))
 
 (deftest least-frequent-chars
   (testing "Decodes the least frequent character in each position"
-    (is (= "advent" (t/least-frequent-chars day06-sample)))))
+    (is (= "advent" (t/least-frequent-chars d06-s00)))))
+
+(def day06-input (u/parse-puzzle-input t/parse 2016 6))
 
 (deftest day06-part1-soln
   (testing "Reproduces the answer for day06, part1"
-    (is (= "agmwzecr" (t/day06-part1-soln)))))
+    (is (= "agmwzecr" (t/day06-part1-soln day06-input)))))
 
 (deftest day06-part2-soln
   (testing "Reproduces the answer for day06, part2"
-    (is (= "owlaxqvq" (t/day06-part2-soln)))))
+    (is (= "owlaxqvq" (t/day06-part2-soln day06-input)))))

--- a/test/aoc_clj/2016/day07_test.clj
+++ b/test/aoc_clj/2016/day07_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2016.day07-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2016.day07 :as t]))
 
 (def day07-sample1
@@ -33,10 +34,12 @@
     (is (= [true false true true]
            (map t/supports-ssl? day07-sample2)))))
 
+(def day07-input (u/parse-puzzle-input t/parse 2016 7))
+
 (deftest day07-part1-soln
   (testing "Reproduces the answer for day07, part1"
-    (is (= 110 (t/day07-part1-soln)))))
+    (is (= 110 (t/day07-part1-soln day07-input)))))
 
 (deftest day07-part2-soln
   (testing "Reproduces the answer for day07, part2"
-    (is (= 242 (t/day07-part2-soln)))))
+    (is (= 242 (t/day07-part2-soln day07-input)))))

--- a/test/aoc_clj/2016/day08_test.clj
+++ b/test/aoc_clj/2016/day08_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2016.day08-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2016.day08 :as t]))
 
-(def day08-sample
+(def d08-s00
   (map t/parse-line
        ["rect 3x2"
         "rotate column x=1 by 1"
@@ -12,16 +13,18 @@
 (deftest apply-instructions
   (testing "Can apply the instructions for the sample data"
     (is (= #{[1 0] [4 0] [6 0] [0 1] [2 1] [1 2]}
-           (->>  (t/apply-instructions 7 3 day08-sample)
+           (->>  (t/apply-instructions 7 3 d08-s00)
                  :grid
                  (filter #(= :on (val %)))
                  keys
                  set)))))
 
+(def day08-input (u/parse-puzzle-input t/parse 2016 8))
+
 (deftest day08-part1-soln
   (testing "Reproduces the answer for day08, part1"
-    (is (= 128 (t/day08-part1-soln)))))
+    (is (= 128 (t/day08-part1-soln day08-input)))))
 
 (deftest day08-part2-soln
   (testing "Reproduces the answer for day08, part2"
-    (is (= "EOARGPHYAO" (t/day08-part2-soln)))))
+    (is (= "EOARGPHYAO" (t/day08-part2-soln day08-input)))))

--- a/test/aoc_clj/2016/day09_test.clj
+++ b/test/aoc_clj/2016/day09_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2016.day09-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2016.day09 :as t]))
 
 (deftest decompress
@@ -18,10 +19,12 @@
     (is (= 241920 (t/decompress-count "(27x12)(20x12)(13x14)(7x10)(1x12)A")))
     (is (= 445 (t/decompress-count "(25x3)(3x3)ABC(2x3)XY(5x2)PQRSTX(18x9)(3x2)TWO(5x7)SEVEN")))))
 
+(def day09-input (u/parse-puzzle-input t/parse 2016 9))
+
 (deftest day09-part1-soln
   (testing "Reproduces the answer for day09, part1"
-    (is (= 112830 (t/day09-part1-soln)))))
+    (is (= 112830 (t/day09-part1-soln day09-input)))))
 
 (deftest day09-part2-soln
   (testing "Reproduces the answer for day09, part2"
-    (is (= 10931789799 (t/day09-part2-soln)))))
+    (is (= 10931789799 (t/day09-part2-soln day09-input)))))

--- a/test/aoc_clj/2016/day10_test.clj
+++ b/test/aoc_clj/2016/day10_test.clj
@@ -1,9 +1,10 @@
 (ns aoc-clj.2016.day10-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2016.day10 :as t]))
 
-(def day10-sample
-  (t/initialize
+(def d10-s00
+  (t/parse
    ["value 5 goes to bot 2"
     "bot 2 gives low to bot 1 and high to bot 0"
     "value 3 goes to bot 1"
@@ -13,15 +14,16 @@
 
 (deftest bot-that-compares
   (testing "Find the bots that will compare the values in the sample data"
-    (is (= 2 (t/bot-that-compares day10-sample #{2 5})))
-    (is (= 1 (t/bot-that-compares day10-sample #{2 3})))
-    (is (= 0 (t/bot-that-compares day10-sample #{3 5})))))
+    (is (= 2 (t/bot-that-compares d10-s00 #{2 5})))
+    (is (= 1 (t/bot-that-compares d10-s00 #{2 3})))
+    (is (= 0 (t/bot-that-compares d10-s00 #{3 5})))))
 
+(def day10-input (u/parse-puzzle-input t/parse 2016 10))
 
 (deftest day10-part1-soln
   (testing "Reproduces the answer for day10, part1"
-    (is (= 93 (t/day10-part1-soln)))))
+    (is (= 93 (t/day10-part1-soln day10-input)))))
 
 (deftest day10-part2-soln
   (testing "Reproduces the answer for day10, part2"
-    (is (= 47101 (t/day10-part2-soln)))))
+    (is (= 47101 (t/day10-part2-soln day10-input)))))

--- a/test/aoc_clj/2016/day11_test.clj
+++ b/test/aoc_clj/2016/day11_test.clj
@@ -1,12 +1,13 @@
 (ns aoc-clj.2016.day11-test
   (:require [clojure.test :refer [deftest testing is]]
+            ;; [aoc-clj.utils.core :as u]
             [aoc-clj.2016.day11 :as t]))
 
 "The first floor contains a hydrogen-compatible microchip and a lithium-compatible microchip."
 "The second floor contains a hydrogen generator."
 "The third floor contains a lithium generator."
 "The fourth floor contains nothing relevant."
-(def day11-sample
+(def d11-s00
   {:e 1
    1 #{[:m "H"] [:m "Li"]}
    2 #{[:g "H"]}
@@ -15,14 +16,27 @@
 
 (deftest move-count
   (testing "Counts the minimum number of moves "
-    (is (= 11 (t/move-count day11-sample)))))
+    (is (= 11 (t/move-count d11-s00)))))
+
+"The first floor contains a thulium generator, a thulium-compatible microchip, a plutonium generator, and a strontium generator.
+The second floor contains a plutonium-compatible microchip and a strontium-compatible microchip.
+The third floor contains a promethium generator, a promethium-compatible microchip, a ruthenium generator, and a ruthenium-compatible microchip.
+The fourth floor contains nothing relevant."
+(def day11-input
+  {:e 1
+  ;;  :move 0
+   1 #{[:m "Tm"] [:g "Tm"] [:g "Pu"] [:g "Sr"]}
+   2 #{[:m "Pu"] [:m "Sr"]}
+   3 #{[:m "Pm"] [:m "Ru"] [:g "Pm"] [:g "Ru"]}
+   4 #{}})
+;; (def day11-input (u/parse-puzzle-input t/parse 2016 11))
 
 ;; FIXME: Implementation is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/31
 (deftest ^:slow day11-part1-soln
   (testing "Reproduces the answer for day11, part1"
-    (is (= 31 (t/day11-part1-soln)))))
+    (is (= 31 (t/day11-part1-soln day11-input)))))
 
 (deftest ^:slow day11-part2-soln
   (testing "Reproduces the answer for day11, part2"
-    (is (= 55 (t/day11-part2-soln)))))
+    (is (= 55 (t/day11-part2-soln day11-input)))))

--- a/test/aoc_clj/2016/day12_test.clj
+++ b/test/aoc_clj/2016/day12_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2016.day12-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2016.day12 :as t]))
 
 (def day12-sample
@@ -16,10 +17,12 @@
     (is (= {:a 42, :b 0, :c 0, :d 0, :inst 6}
            (t/execute t/init-state day12-sample)))))
 
+(def day12-input (u/parse-puzzle-input t/parse 2016 12))
+
 (deftest day12-part1-soln
   (testing "Reproduces the answer for day12, part1"
-    (is (= 318020 (t/day12-part1-soln)))))
+    (is (= 318020 (t/day12-part1-soln day12-input)))))
 
 (deftest ^:slow day12-part2-soln
   (testing "Reproduces the answer for day12, part2"
-    (is (= 9227674 (t/day12-part2-soln)))))
+    (is (= 9227674 (t/day12-part2-soln day12-input)))))

--- a/test/aoc_clj/2016/day13_test.clj
+++ b/test/aoc_clj/2016/day13_test.clj
@@ -1,6 +1,7 @@
 (ns aoc-clj.2016.day13-test
   (:require [aoc-clj.2016.day13 :as t]
             [aoc-clj.utils.grid :as grid]
+            ;; [aoc-clj.utils.core :as u]
             [clojure.test :refer [deftest is testing]]))
 
 (def d13-s1
@@ -18,6 +19,8 @@
            (grid/Grid2D->ascii
             t/charmap
             (t/construct-grid 10 10 7) :down true)))))
+
+;; (def day13-input (u/parse-puzzle-input t/parse 2016 13))
 
 ;; (deftest day13-part1-soln
 ;;   (testing "Reproduces the answer for day13, part1"

--- a/test/aoc_clj/2018/day01_test.clj
+++ b/test/aoc_clj/2018/day01_test.clj
@@ -1,11 +1,14 @@
 (ns aoc-clj.2018.day01-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2018.day01 :as t]))
+
+(def day01-input (u/parse-puzzle-input t/parse 2018 1))
 
 (deftest day01-part1-soln
   (testing "Reproduces the answer for day01, part1"
-    (is (= 543 (t/day01-part1-soln)))))
+    (is (= 543 (t/day01-part1-soln day01-input)))))
 
 (deftest day01-part2-soln
   (testing "Reproduces the answer for day01, part2"
-    (is (= 621 (t/day01-part2-soln)))))
+    (is (= 621 (t/day01-part2-soln day01-input)))))

--- a/test/aoc_clj/2018/day02_test.clj
+++ b/test/aoc_clj/2018/day02_test.clj
@@ -1,11 +1,14 @@
 (ns aoc-clj.2018.day02-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2018.day02 :as t]))
+
+(def day02-input (u/parse-puzzle-input t/parse 2018 2))
 
 (deftest day02-part1-soln
   (testing "Reproduces the answer for day02, part1"
-    (is (= 5478 (t/day02-part1-soln)))))
+    (is (= 5478 (t/day02-part1-soln day02-input)))))
 
 (deftest day02-part2-soln
   (testing "Reproduces the answer for day02, part2"
-    (is (= "qyzphxoiseldjrntfygvdmanu" (t/day02-part2-soln)))))
+    (is (= "qyzphxoiseldjrntfygvdmanu" (t/day02-part2-soln day02-input)))))

--- a/test/aoc_clj/2018/day03_test.clj
+++ b/test/aoc_clj/2018/day03_test.clj
@@ -1,11 +1,14 @@
 (ns aoc-clj.2018.day03-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2018.day03 :as t]))
+
+(def day03-input (u/parse-puzzle-input t/parse 2018 3))
 
 (deftest day03-part1-soln
   (testing "Reproduces the answer for day03, part1"
-    (is (= 116489 (t/day03-part1-soln)))))
+    (is (= 116489 (t/day03-part1-soln day03-input)))))
 
 (deftest day03-part2-soln
   (testing "Reproduces the answer for day03, part2"
-    (is (= "#1260" (t/day03-part2-soln)))))
+    (is (= "#1260" (t/day03-part2-soln day03-input)))))

--- a/test/aoc_clj/2018/day04_test.clj
+++ b/test/aoc_clj/2018/day04_test.clj
@@ -1,45 +1,48 @@
 (ns aoc-clj.2018.day04-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2018.day04 :as t]))
 
-(def day04-sample
-  "[1518-11-01 00:00] Guard #10 begins shift
-[1518-11-01 00:05] falls asleep
-[1518-11-01 00:25] wakes up
-[1518-11-01 00:30] falls asleep
-[1518-11-01 00:55] wakes up
-[1518-11-01 23:58] Guard #99 begins shift
-[1518-11-02 00:40] falls asleep
-[1518-11-02 00:50] wakes up
-[1518-11-03 00:05] Guard #10 begins shift
-[1518-11-03 00:24] falls asleep
-[1518-11-03 00:29] wakes up
-[1518-11-04 00:02] Guard #99 begins shift
-[1518-11-04 00:36] falls asleep
-[1518-11-04 00:46] wakes up
-[1518-11-05 00:03] Guard #99 begins shift
-[1518-11-05 00:45] falls asleep
-[1518-11-05 00:55] wakes up")
+(def d04-s00
+  ["[1518-11-01 00:00] Guard #10 begins shift"
+   "[1518-11-01 00:05] falls asleep"
+   "[1518-11-01 00:25] wakes up"
+   "[1518-11-01 00:30] falls asleep"
+   "[1518-11-01 00:55] wakes up"
+   "[1518-11-01 23:58] Guard #99 begins shift"
+   "[1518-11-02 00:40] falls asleep"
+   "[1518-11-02 00:50] wakes up"
+   "[1518-11-03 00:05] Guard #10 begins shift"
+   "[1518-11-03 00:24] falls asleep"
+   "[1518-11-03 00:29] wakes up"
+   "[1518-11-04 00:02] Guard #99 begins shift"
+   "[1518-11-04 00:36] falls asleep"
+   "[1518-11-04 00:46] wakes up"
+   "[1518-11-05 00:03] Guard #99 begins shift"
+   "[1518-11-05 00:45] falls asleep"
+   "[1518-11-05 00:55] wakes up"])
 
 (deftest parse-test
   (testing "Can identify the guard-id, and sleep windows"
     (is (= {10 '((5 25) (30 55) (24 29)), 99 '((40 50) (36 46) (45 55))}
-           (t/parse day04-sample)))))
+           (t/parse d04-s00)))))
 
 (deftest strategy1
   (testing "Identify the guard who sleeps the most and the minute they sleep the most"
     (is (= [10 24]
-           (t/sleepiest-guard-and-optimal-minute (t/parse day04-sample))))))
+           (t/sleepiest-guard-and-optimal-minute (t/parse d04-s00))))))
 
 (deftest strategy2
   (testing "Identify the guard who sleeps the most at any given minute"
     (is (= [99 45]
-           (t/guard-most-frequently-asleep-at-minute (t/parse day04-sample))))))
+           (t/guard-most-frequently-asleep-at-minute (t/parse d04-s00))))))
+
+(def day04-input (u/parse-puzzle-input t/parse 2018 4))
 
 (deftest day04-part1-soln
   (testing "Reproduces the answer for day04, part1"
-    (is (= 74743 (t/day04-part1-soln)))))
+    (is (= 74743 (t/day04-part1-soln day04-input)))))
 
 (deftest day04-part2-soln
   (testing "Reproduces the answer for day04, part2"
-    (is (= 132484 (t/day04-part2-soln)))))
+    (is (= 132484 (t/day04-part2-soln day04-input)))))

--- a/test/aoc_clj/2019/day01_test.clj
+++ b/test/aoc_clj/2019/day01_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2019.day01-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day01 :as t]))
 
 (deftest fuel-test
@@ -15,10 +16,12 @@
     (is (= 966 (t/total-fuel 1969)))
     (is (= 50346 (t/total-fuel 100756)))))
 
+(def day01-input (u/parse-puzzle-input t/parse 2019 1))
+
 (deftest day01-part1-soln-test
   (testing "Can reproduce the answer for part1"
-    (is (= 3152038 (t/day01-part1-soln)))))
+    (is (= 3152038 (t/day01-part1-soln day01-input)))))
 
 (deftest day01-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= 4725210 (t/day01-part2-soln)))))
+    (is (= 4725210 (t/day01-part2-soln day01-input)))))

--- a/test/aoc_clj/2019/day02_test.clj
+++ b/test/aoc_clj/2019/day02_test.clj
@@ -1,11 +1,14 @@
 (ns aoc-clj.2019.day02-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day02 :as t]))
+
+(def day02-input (u/parse-puzzle-input t/parse 2019 2))
 
 (deftest day02-part1-soln-test
   (testing "Can reproduce the answer for part1"
-    (is (= 3085697 (t/day02-part1-soln)))))
+    (is (= 3085697 (t/day02-part1-soln day02-input)))))
 
 (deftest day02-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= 9425 (t/day02-part2-soln)))))
+    (is (= 9425 (t/day02-part2-soln day02-input)))))

--- a/test/aoc_clj/2019/day03_test.clj
+++ b/test/aoc_clj/2019/day03_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2019.day03-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day03 :as t]))
 
 (def path1-segs (t/parse-segments ["R8","U5","L5","D3"]))
@@ -49,10 +50,12 @@
     (is (= steps2 (t/shortest-steps-to-intersection input2)))
     (is (= steps3 (t/shortest-steps-to-intersection input3)))))
 
+(def day03-input (u/parse-puzzle-input t/parse 2019 3))
+
 (deftest day03-part1-soln-test
   (testing "Can reproduce the answer for part1"
-    (is (= 375 (t/day03-part1-soln)))))
+    (is (= 375 (t/day03-part1-soln day03-input)))))
 
 (deftest day03-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= 14746 (t/day03-part2-soln)))))
+    (is (= 14746 (t/day03-part2-soln day03-input)))))

--- a/test/aoc_clj/2019/day04_test.clj
+++ b/test/aoc_clj/2019/day04_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2019.day04-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day04 :as t]))
 
 (deftest not-decreasing-condition
@@ -22,10 +23,12 @@
     (is (not (t/pair-not-in-larger-group? (t/digits 123444))))
     (is (t/pair-not-in-larger-group? (t/digits 111122)))))
 
+(def day04-input (u/parse-puzzle-input t/parse 2019 4))
+
 (deftest day04-part1-soln-test
   (testing "Can reproduce the answer for part1"
-    (is (= 1330 (t/day04-part1-soln)))))
+    (is (= 1330 (t/day04-part1-soln day04-input)))))
 
 (deftest day01-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= 876 (t/day04-part2-soln)))))
+    (is (= 876 (t/day04-part2-soln day04-input)))))

--- a/test/aoc_clj/2019/day05_test.clj
+++ b/test/aoc_clj/2019/day05_test.clj
@@ -1,11 +1,14 @@
 (ns aoc-clj.2019.day05-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day05 :as t]))
+
+(def day05-input (u/parse-puzzle-input t/parse 2019 5))
 
 (deftest day05-part1-soln-test
   (testing "Can reproduce the answer for part1"
-    (is (= 12234644 (t/day05-part1-soln)))))
+    (is (= 12234644 (t/day05-part1-soln day05-input)))))
 
 (deftest day05-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= 3508186 (t/day05-part2-soln)))))
+    (is (= 3508186 (t/day05-part2-soln day05-input)))))

--- a/test/aoc_clj/2019/day06_test.clj
+++ b/test/aoc_clj/2019/day06_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2019.day06-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day06 :as t]))
 
 (deftest orbit-count-test
@@ -32,10 +33,12 @@
                                  "YOU" "K"
                                  "SAN" "I"} "YOU" "SAN")))))
 
+(def day06-input (u/parse-puzzle-input t/parse 2019 6))
+
 (deftest day06-part1-soln-test
   (testing "Can reproduce the answer for part1"
-    (is (= 261306 (t/day06-part1-soln)))))
+    (is (= 261306 (t/day06-part1-soln day06-input)))))
 
 (deftest day06-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= 382 (t/day06-part2-soln)))))
+    (is (= 382 (t/day06-part2-soln day06-input)))))

--- a/test/aoc_clj/2019/day07_test.clj
+++ b/test/aoc_clj/2019/day07_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2019.day07-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day07 :as t]))
 
 (def p1 [3,15,3,16,1002,16,10,16,1,16,15,15,4,15,99,0,0])
@@ -49,10 +50,12 @@
     (is (= m4 (t/max-amplifier-loop-output p4)))
     (is (= m5 (t/max-amplifier-loop-output p5)))))
 
+(def day07-input (u/parse-puzzle-input t/parse 2019 7))
+
 (deftest day07-part1-soln-test
   (testing "Can reproduce the answer for part1"
-    (is (= 567045 (t/day07-part1-soln)))))
+    (is (= 567045 (t/day07-part1-soln day07-input)))))
 
 (deftest day07-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= 39016654 (t/day07-part2-soln)))))
+    (is (= 39016654 (t/day07-part2-soln day07-input)))))

--- a/test/aoc_clj/2019/day08_test.clj
+++ b/test/aoc_clj/2019/day08_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2019.day08-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day08 :as t]))
 
 (def decoded-output
@@ -10,15 +11,17 @@
       1 0 0 1 0 1 0 0 0 0 1 0 0 1 0 1 0 0 0 0 1 0 0 1 0
       1 0 0 1 0 1 1 1 1 0 0 1 1 0 0 1 1 1 1 0 0 1 1 0 0))
 
+(def day08-input (u/parse-puzzle-input t/parse 2019 8))
+
 (deftest space-image-decoder-test
   (testing "Can decode an image in space image format"
     (is (= '(0 1 1 0) (t/decode-image [0 2 2 2 1 1 2 2 2 2 1 2 0 0 0 0] 2 2)))
-    (is (= decoded-output (t/decode-image t/day08-input 25 6)))))
+    (is (= decoded-output (t/decode-image day08-input 25 6)))))
 
 (deftest day08-part1-soln-test
   (testing "Can reproduce the answer for part1"
-    (is (= 2016 (t/day08-part1-soln)))))
+    (is (= 2016 (t/day08-part1-soln day08-input)))))
 
 (deftest day08-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= "HZCZU" (t/day08-part2-soln)))))
+    (is (= "HZCZU" (t/day08-part2-soln day08-input)))))

--- a/test/aoc_clj/2019/day09_test.clj
+++ b/test/aoc_clj/2019/day09_test.clj
@@ -1,11 +1,14 @@
 (ns aoc-clj.2019.day09-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day09 :as t]))
+
+(def day09-input (u/parse-puzzle-input t/parse 2019 9))
 
 (deftest day09-part1-soln-test
   (testing "Can reproduce the answer for part1"
-    (is (= 3742852857 (t/day09-part1-soln)))))
+    (is (= 3742852857 (t/day09-part1-soln day09-input)))))
 
 (deftest day09-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= 73439 (t/day09-part2-soln)))))
+    (is (= 73439 (t/day09-part2-soln day09-input)))))

--- a/test/aoc_clj/2019/day10_test.clj
+++ b/test/aoc_clj/2019/day10_test.clj
@@ -1,15 +1,16 @@
 (ns aoc-clj.2019.day10-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day10 :as t]))
 
-(def d10-s1 (t/parse-map
+(def d10-s1 (t/parse
              [".#..#"
               "....."
               "#####"
               "....#"
               "...##"]))
 
-(def d10-s2 (t/parse-map
+(def d10-s2 (t/parse
              ["......#.#."
               "#..#.#...."
               "..#######."
@@ -21,7 +22,7 @@
               "##...#..#."
               ".#....####"]))
 
-(def d10-s3 (t/parse-map
+(def d10-s3 (t/parse
              ["#.#...#.#."
               ".###....#."
               ".#....#..."
@@ -33,7 +34,7 @@
               "......#..."
               ".####.###."]))
 
-(def d10-s4 (t/parse-map
+(def d10-s4 (t/parse
              [".#..#..###"
               "####.###.#"
               "....###.#."
@@ -45,7 +46,7 @@
               ".##...##.#"
               ".....#.#.."]))
 
-(def d10-s5 (t/parse-map
+(def d10-s5 (t/parse
              [".#..##.###...#######"
               "##.############..##."
               ".#.######.########.#"
@@ -67,7 +68,7 @@
               "#.#.#.#####.####.###"
               "###.##.####.##.#..##"]))
 
-(def d10-s6 (t/parse-map
+(def d10-s6 (t/parse
              [".#....#####...#.."
               "##...##.#####..##"
               "##...#...#.#####."
@@ -82,16 +83,11 @@
     (is (= '([6,3] 41) (t/best-location d10-s4)))
     (is (= '([11,13] 210) (t/best-location d10-s5)))))
 
-(deftest day10-part1-soln-test
-  (testing "Can reproduce the answer for part1"
-    (is (= 253 (second (t/day10-part1-soln))))))
-
 (def d10-s6-soln
   [[8,1] [9,0] [9,1] [10,0] [9,2] [11,1] [12,1] [11,2] [15,1]
    [12,2] [13,2] [14,2] [15,2] [12,3] [16,4] [15,4] [10,4] [4,4]
    [2,4] [2,3] [0,2] [1,2] [0,1] [1,1] [5,2] [1,0] [5,1]
    [6,1] [6,0] [7,0] [8,0] [10,1] [14,0] [16,1] [13,3] [14,3]])
-
 
 (deftest laser-test
   (testing "Laser hits the asteroids in the correct order"
@@ -109,6 +105,12 @@
       (is (= [10,9] (nth larger-test 200)))
       (is (= [11,1] (nth larger-test 298))))))
 
+(def day10-input (u/parse-puzzle-input t/parse 2019 10))
+
+(deftest day10-part1-soln-test
+  (testing "Can reproduce the answer for part1"
+    (is (= 253 (second (t/day10-part1-soln day10-input))))))
+
 (deftest day10-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= 815 (t/day10-part2-soln)))))
+    (is (= 815 (t/day10-part2-soln day10-input)))))

--- a/test/aoc_clj/2019/day11_test.clj
+++ b/test/aoc_clj/2019/day11_test.clj
@@ -1,11 +1,14 @@
 (ns aoc-clj.2019.day11-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day11 :as t]))
+
+(def day11-input (u/parse-puzzle-input t/parse 2019 11))
 
 (deftest day11-part1-soln-test
   (testing "Can reproduce the answer for part1"
-    (is (= 2539 (t/day11-part1-soln)))))
+    (is (= 2539 (t/day11-part1-soln day11-input)))))
 
 (deftest day11-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= "ZLEBKJRA" (t/day11-part2-soln)))))
+    (is (= "ZLEBKJRA" (t/day11-part2-soln day11-input)))))

--- a/test/aoc_clj/2019/day12_test.clj
+++ b/test/aoc_clj/2019/day12_test.clj
@@ -1,14 +1,15 @@
 (ns aoc-clj.2019.day12-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day12 :as t]))
 
-(def d12-s1
+(def d12-s00
   [[-1 0 2]
    [2 -10 -7]
    [4 -8 8]
    [3 5 -1]])
 
-(def d12-s2
+(def d12-s01
   [[-8 -10 0]
    [5 5 10]
    [2 -7 3]
@@ -16,20 +17,23 @@
 
 (deftest total-energy-test
   (testing "Can find the total energy after a number of time steps"
-    (is (= 179 (t/total-energy (nth (t/simulate d12-s1) 10))))
-    (is (= 1940 (t/total-energy (nth (t/simulate d12-s2) 100))))))
+    (is (= 179 (t/total-energy (nth (t/simulate d12-s00) 10))))
+    (is (= 1940 (t/total-energy (nth (t/simulate d12-s01) 100))))))
 
-(deftest day12-part1-soln-test
-  (testing "Can reproduce the answer for part1"
-    (is (= 8310 (t/day12-part1-soln)))))
 
 (deftest recurrence-period-test
   (testing "Can find the number of time steps until the orbital state recurs"
-    (is (= 2772 (t/recurrence-period d12-s1)))
-    (is (= 4686774924 (t/recurrence-period d12-s2)))))
+    (is (= 2772 (t/recurrence-period d12-s00)))
+    (is (= 4686774924 (t/recurrence-period d12-s01)))))
+
+(def day12-input (u/parse-puzzle-input t/parse 2019 12))
+
+(deftest day12-part1-soln-test
+  (testing "Can reproduce the answer for part1"
+    (is (= 8310 (t/day12-part1-soln day12-input)))))
 
 ;; FIXME: Test is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/15
 (deftest ^:slow day12-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= 319290382980408 (t/day12-part2-soln)))))
+    (is (= 319290382980408 (t/day12-part2-soln day12-input)))))

--- a/test/aoc_clj/2019/day13_test.clj
+++ b/test/aoc_clj/2019/day13_test.clj
@@ -1,11 +1,14 @@
 (ns aoc-clj.2019.day13-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day13 :as t]))
+
+(def day13-input (u/parse-puzzle-input t/parse 2019 13))
 
 (deftest day13-part1-soln-test
   (testing "Can reproduce the answer for part1"
-    (is (= 230 (t/day13-part1-soln)))))
+    (is (= 230 (t/day13-part1-soln day13-input)))))
 
 (deftest day13-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= 11140 (t/day13-part2-soln)))))
+    (is (= 11140 (t/day13-part2-soln day13-input)))))

--- a/test/aoc_clj/2019/day14_test.clj
+++ b/test/aoc_clj/2019/day14_test.clj
@@ -1,86 +1,94 @@
 (ns aoc-clj.2019.day14-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day14 :as t]))
 
-(def d14-s1 (t/reactions
-             ["10 ORE => 10 A"
-              "1 ORE => 1 B"
-              "7 A, 1 B => 1 C"
-              "7 A, 1 C => 1 D"
-              "7 A, 1 D => 1 E"
-              "7 A, 1 E => 1 FUEL"]))
+(def d14-s00
+  (t/parse
+   ["10 ORE => 10 A"
+    "1 ORE => 1 B"
+    "7 A, 1 B => 1 C"
+    "7 A, 1 C => 1 D"
+    "7 A, 1 D => 1 E"
+    "7 A, 1 E => 1 FUEL"]))
 
-(def d14-s2 (t/reactions
-             ["9 ORE => 2 A"
-              "8 ORE => 3 B"
-              "7 ORE => 5 C"
-              "3 A, 4 B => 1 AB"
-              "5 B, 7 C => 1 BC"
-              "4 C, 1 A => 1 CA"
-              "2 AB, 3 BC, 4 CA => 1 FUEL"]))
+(def d14-s01
+  (t/parse
+   ["9 ORE => 2 A"
+    "8 ORE => 3 B"
+    "7 ORE => 5 C"
+    "3 A, 4 B => 1 AB"
+    "5 B, 7 C => 1 BC"
+    "4 C, 1 A => 1 CA"
+    "2 AB, 3 BC, 4 CA => 1 FUEL"]))
 
-(def d14-s3 (t/reactions
-             ["157 ORE => 5 NZVS"
-              "165 ORE => 6 DCFZ"
-              "44 XJWVT, 5 KHKGT, 1 QDVJ, 29 NZVS, 9 GPVTF, 48 HKGWZ => 1 FUEL"
-              "12 HKGWZ, 1 GPVTF, 8 PSHF => 9 QDVJ"
-              "179 ORE => 7 PSHF"
-              "177 ORE => 5 HKGWZ"
-              "7 DCFZ, 7 PSHF => 2 XJWVT"
-              "165 ORE => 2 GPVTF"
-              "3 DCFZ, 7 NZVS, 5 HKGWZ, 10 PSHF => 8 KHKGT"]))
+(def d14-s02
+  (t/parse
+   ["157 ORE => 5 NZVS"
+    "165 ORE => 6 DCFZ"
+    "44 XJWVT, 5 KHKGT, 1 QDVJ, 29 NZVS, 9 GPVTF, 48 HKGWZ => 1 FUEL"
+    "12 HKGWZ, 1 GPVTF, 8 PSHF => 9 QDVJ"
+    "179 ORE => 7 PSHF"
+    "177 ORE => 5 HKGWZ"
+    "7 DCFZ, 7 PSHF => 2 XJWVT"
+    "165 ORE => 2 GPVTF"
+    "3 DCFZ, 7 NZVS, 5 HKGWZ, 10 PSHF => 8 KHKGT"]))
 
-(def d14-s4 (t/reactions
-             ["2 VPVL, 7 FWMGM, 2 CXFTF, 11 MNCFX => 1 STKFG"
-              "17 NVRVD, 3 JNWZP => 8 VPVL"
-              "53 STKFG, 6 MNCFX, 46 VJHF, 81 HVMC, 68 CXFTF, 25 GNMV => 1 FUEL"
-              "22 VJHF, 37 MNCFX => 5 FWMGM"
-              "139 ORE => 4 NVRVD"
-              "144 ORE => 7 JNWZP"
-              "5 MNCFX, 7 RFSQX, 2 FWMGM, 2 VPVL, 19 CXFTF => 3 HVMC"
-              "5 VJHF, 7 MNCFX, 9 VPVL, 37 CXFTF => 6 GNMV"
-              "145 ORE => 6 MNCFX"
-              "1 NVRVD => 8 CXFTF"
-              "1 VJHF, 6 MNCFX => 4 RFSQX"
-              "176 ORE => 6 VJHF"]))
+(def d14-s03
+  (t/parse
+   ["2 VPVL, 7 FWMGM, 2 CXFTF, 11 MNCFX => 1 STKFG"
+    "17 NVRVD, 3 JNWZP => 8 VPVL"
+    "53 STKFG, 6 MNCFX, 46 VJHF, 81 HVMC, 68 CXFTF, 25 GNMV => 1 FUEL"
+    "22 VJHF, 37 MNCFX => 5 FWMGM"
+    "139 ORE => 4 NVRVD"
+    "144 ORE => 7 JNWZP"
+    "5 MNCFX, 7 RFSQX, 2 FWMGM, 2 VPVL, 19 CXFTF => 3 HVMC"
+    "5 VJHF, 7 MNCFX, 9 VPVL, 37 CXFTF => 6 GNMV"
+    "145 ORE => 6 MNCFX"
+    "1 NVRVD => 8 CXFTF"
+    "1 VJHF, 6 MNCFX => 4 RFSQX"
+    "176 ORE => 6 VJHF"]))
 
-(def d14-s5 (t/reactions
-             ["171 ORE => 8 CNZTR"
-              "7 ZLQW, 3 BMBT, 9 XCVML, 26 XMNCP, 1 WPTQ, 2 MZWV, 1 RJRHP => 4 PLWSL"
-              "114 ORE => 4 BHXH"
-              "14 VRPVC => 6 BMBT"
-              "6 BHXH, 18 KTJDG, 12 WPTQ, 7 PLWSL, 31 FHTLT, 37 ZDVW => 1 FUEL"
-              "6 WPTQ, 2 BMBT, 8 ZLQW, 18 KTJDG, 1 XMNCP, 6 MZWV, 1 RJRHP => 6 FHTLT"
-              "15 XDBXC, 2 LTCX, 1 VRPVC => 6 ZLQW"
-              "13 WPTQ, 10 LTCX, 3 RJRHP, 14 XMNCP, 2 MZWV, 1 ZLQW => 1 ZDVW"
-              "5 BMBT => 4 WPTQ"
-              "189 ORE => 9 KTJDG"
-              "1 MZWV, 17 XDBXC, 3 XCVML => 2 XMNCP"
-              "12 VRPVC, 27 CNZTR => 2 XDBXC"
-              "15 KTJDG, 12 BHXH => 5 XCVML"
-              "3 BHXH, 2 VRPVC => 7 MZWV"
-              "121 ORE => 7 VRPVC"
-              "7 XCVML => 6 RJRHP"
-              "5 BHXH, 4 VRPVC => 5 LTCX"]))
+(def d14-s04
+  (t/parse
+   ["171 ORE => 8 CNZTR"
+    "7 ZLQW, 3 BMBT, 9 XCVML, 26 XMNCP, 1 WPTQ, 2 MZWV, 1 RJRHP => 4 PLWSL"
+    "114 ORE => 4 BHXH"
+    "14 VRPVC => 6 BMBT"
+    "6 BHXH, 18 KTJDG, 12 WPTQ, 7 PLWSL, 31 FHTLT, 37 ZDVW => 1 FUEL"
+    "6 WPTQ, 2 BMBT, 8 ZLQW, 18 KTJDG, 1 XMNCP, 6 MZWV, 1 RJRHP => 6 FHTLT"
+    "15 XDBXC, 2 LTCX, 1 VRPVC => 6 ZLQW"
+    "13 WPTQ, 10 LTCX, 3 RJRHP, 14 XMNCP, 2 MZWV, 1 ZLQW => 1 ZDVW"
+    "5 BMBT => 4 WPTQ"
+    "189 ORE => 9 KTJDG"
+    "1 MZWV, 17 XDBXC, 3 XCVML => 2 XMNCP"
+    "12 VRPVC, 27 CNZTR => 2 XDBXC"
+    "15 KTJDG, 12 BHXH => 5 XCVML"
+    "3 BHXH, 2 VRPVC => 7 MZWV"
+    "121 ORE => 7 VRPVC"
+    "7 XCVML => 6 RJRHP"
+    "5 BHXH, 4 VRPVC => 5 LTCX"]))
 
 (deftest ore-amount-test
   (testing "Can find the amount of ore to generate 1 unit of fuel"
-    (is (= 31 (t/ore-amount d14-s1)))
-    (is (= 165 (t/ore-amount d14-s2)))
-    (is (= 13312 (t/ore-amount d14-s3)))
-    (is (= 180697 (t/ore-amount d14-s4)))
-    (is (= 2210736 (t/ore-amount d14-s5)))))
-
-(deftest day14-part1-soln-test
-  (testing "Can reproduce the solution to part 1"
-    (is (= 278404 (t/day14-part1-soln)))))
+    (is (= 31 (t/ore-amount d14-s00)))
+    (is (= 165 (t/ore-amount d14-s01)))
+    (is (= 13312 (t/ore-amount d14-s02)))
+    (is (= 180697 (t/ore-amount d14-s03)))
+    (is (= 2210736 (t/ore-amount d14-s04)))))
 
 (deftest max-fuel-test
   (testing "Can find the maximum amount of fuel that can be made from a fixed amount of ore"
-    (is (= 82892753 (t/max-fuel d14-s3)))
-    (is (= 5586022 (t/max-fuel d14-s4)))
-    (is (= 460664 (t/max-fuel d14-s5)))))
+    (is (= 82892753 (t/max-fuel d14-s02)))
+    (is (= 5586022 (t/max-fuel d14-s03)))
+    (is (= 460664 (t/max-fuel d14-s04)))))
+
+(def day14-input (u/parse-puzzle-input t/parse 2019 14))
+
+(deftest day14-part1-soln-test
+  (testing "Can reproduce the solution to part 1"
+    (is (= 278404 (t/day14-part1-soln day14-input)))))
 
 (deftest day14-part2-soln-test
   (testing "Can reproduce the solution to part 2"
-    (is (= 4436981 (t/day14-part2-soln)))))
+    (is (= 4436981 (t/day14-part2-soln day14-input)))))

--- a/test/aoc_clj/2019/day15_test.clj
+++ b/test/aoc_clj/2019/day15_test.clj
@@ -1,11 +1,14 @@
 (ns aoc-clj.2019.day15-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day15 :as t]))
+
+(def day15-input (u/parse-puzzle-input t/parse 2019 15))
 
 (deftest day15-part1-soln-test
   (testing "Can reproduce the answer for part1"
-    (is (= 280 (t/day15-part1-soln)))))
+    (is (= 280 (t/day15-part1-soln day15-input)))))
 
 (deftest day15-part2-soln-test
   (testing "Can reproduce the answer for part1"
-    (is (= 400 (t/day15-part2-soln)))))
+    (is (= 400 (t/day15-part2-soln day15-input)))))

--- a/test/aoc_clj/2019/day16_test.clj
+++ b/test/aoc_clj/2019/day16_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2019.day16-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day16 :as t]))
 
 (deftest phase-test
@@ -25,10 +26,6 @@
                   (t/run-phases
                    (t/str->nums "69317163492948606335995924319873") 100)))))))
 
-(deftest day16-part1-soln-test
-  (testing "Can reproduce the answer for part1"
-    (is (= "70856418" (t/day16-part1-soln)))))
-
 (deftest real-signal-test
   (testing "Can compute handle the `real signal` challenge in part 2"
     (is (= "84462026"
@@ -44,8 +41,14 @@
             (t/real-signal
              (t/str->nums "03081770884921959731165446850517") 100))))))
 
+(def day16-input (u/parse-puzzle-input t/parse 2019 16))
+
+(deftest day16-part1-soln-test
+  (testing "Can reproduce the answer for part1"
+    (is (= "70856418" (t/day16-part1-soln day16-input)))))
+
 ;; FIXME: test is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/17
 (deftest ^:slow day16-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= "87766336" (t/day16-part2-soln)))))
+    (is (= "87766336" (t/day16-part2-soln day16-input)))))

--- a/test/aoc_clj/2019/day17_test.clj
+++ b/test/aoc_clj/2019/day17_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2019.day17-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day17 :as t]))
 
-(def d17-s1
+(def d17-s00
   (str
    "..#..........\n"
    "..#..........\n"
@@ -15,12 +16,14 @@
 (deftest intersection-test
   (testing "Can find the intersections of the scaffolding"
     (is (= [[2 2] [6 4] [2 4] [10 4]]
-           (t/intersections (t/scaffold-map d17-s1))))))
+           (t/intersections (t/scaffold-map d17-s00))))))
+
+(def day17-input (u/parse-puzzle-input t/parse 2019 17))
 
 (deftest day17-part1-soln-test
   (testing "Can reproduce the answer for part1"
-    (is (= 7584 (t/day17-part1-soln)))))
+    (is (= 7584 (t/day17-part1-soln day17-input)))))
 
 (deftest day17-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= 1016738 (t/day17-part2-soln)))))
+    (is (= 1016738 (t/day17-part2-soln day17-input)))))

--- a/test/aoc_clj/2019/day18_test.clj
+++ b/test/aoc_clj/2019/day18_test.clj
@@ -1,27 +1,28 @@
 (ns aoc-clj.2019.day18-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day18 :as t]))
 
-(def d18-s1
+(def d18-s00
   ["#########"
    "#b.A.@.a#"
    "#########"])
 
-(def d18-s2
+(def d18-s01
   ["########################"
    "#f.D.E.e.C.b.A.@.a.B.c.#"
    "######################.#"
    "#d.....................#"
    "########################"])
 
-(def d18-s3
+(def d18-s02
   ["########################"
    "#...............b.C.D.f#"
    "#.######################"
    "#.....@.a.B.c.d.A.e.F.g#"
    "########################"])
 
-(def d18-s4
+(def d18-s03
   ["#################"
    "#i.G..c...e..H.p#"
    "########.########"
@@ -32,7 +33,7 @@
    "#l.F..d...h..C.m#"
    "#################"])
 
-(def d18-s5
+(def d18-s04
   ["########################"
    "#@..............ac.GI.b#"
    "###d#e#f################"
@@ -42,12 +43,12 @@
 
 (deftest shortest-path-test
   (testing "Can find the shortest path to clear the maze"
-    (is (= 8   (t/shortest-path (t/load-graph (t/load-maze d18-s1)))))
-    (is (= 86  (t/shortest-path (t/load-graph (t/load-maze d18-s2)))))
-    (is (= 132 (t/shortest-path (t/load-graph (t/load-maze d18-s3)))))
-    (is (= 81  (t/shortest-path (t/load-graph (t/load-maze d18-s5)))))))
+    (is (= 8   (t/shortest-path (t/load-graph (t/load-maze d18-s00)))))
+    (is (= 86  (t/shortest-path (t/load-graph (t/load-maze d18-s01)))))
+    (is (= 132 (t/shortest-path (t/load-graph (t/load-maze d18-s02)))))
+    (is (= 81  (t/shortest-path (t/load-graph (t/load-maze d18-s04)))))))
 
-(def d18-s6
+(def d18-s05
   ["#######"
    "#a.#Cd#"
    "##@#@##"
@@ -56,7 +57,7 @@
    "#cB#Ab#"
    "#######"])
 
-(def d18-s7
+(def d18-s06
   ["###############"
    "#d.ABC.#.....a#"
    "######@#@######"
@@ -65,7 +66,7 @@
    "#b.....#.....c#"
    "###############"])
 
-(def d18-s8
+(def d18-s07
   ["#############"
    "#DcBa.#.GhKl#"
    "#.###@#@#I###"
@@ -74,7 +75,7 @@
    "#fEbA.#.FgHi#"
    "#############"])
 
-(def d18-s9
+(def d18-s08
   ["#############"
    "#g#f.D#..h#l#"
    "#F###e#E###.#"
@@ -87,22 +88,24 @@
 
 (deftest shortest-robot-path-test
   (testing "Can find the shortest four-robot path to clear the maze"
-    (is (= 8  (t/shortest-path (t/load-graph (t/load-maze d18-s6)))))
-    (is (= 24 (t/shortest-path (t/load-graph (t/load-maze d18-s7)))))
-    (is (= 32 (t/shortest-path (t/load-graph (t/load-maze d18-s8)))))
-    (is (= 72 (t/shortest-path (t/load-graph (t/load-maze d18-s9)))))))
+    (is (= 8  (t/shortest-path (t/load-graph (t/load-maze d18-s05)))))
+    (is (= 24 (t/shortest-path (t/load-graph (t/load-maze d18-s06)))))
+    (is (= 32 (t/shortest-path (t/load-graph (t/load-maze d18-s07)))))
+    (is (= 72 (t/shortest-path (t/load-graph (t/load-maze d18-s08)))))))
 
 
 ;; FIXME: Day 18 solutions are too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/18
 (deftest ^:slow shortest-path-hard-test
   (testing "Finds the shortest path on the difficult d18-s4 case"
-    (is (= 136 (t/shortest-path (t/load-graph (t/load-maze d18-s4)))))))
+    (is (= 136 (t/shortest-path (t/load-graph (t/load-maze d18-s03)))))))
+
+(def day18-input (u/parse-puzzle-input t/parse 2019 18))
 
 (deftest ^:slow day18-part1-test
   (testing "Can reproduce the solution for part1"
-    (is (= 7048 (t/day18-part1-soln)))))
+    (is (= 7048 (t/day18-part1-soln day18-input)))))
 
 (deftest ^:slow day18-part2-test
   (testing "Can reproduce the solution for part2"
-    (is (= 1836 (t/day18-part2-soln)))))
+    (is (= 1836 (t/day18-part2-soln day18-input)))))

--- a/test/aoc_clj/2019/day19_test.clj
+++ b/test/aoc_clj/2019/day19_test.clj
@@ -1,11 +1,14 @@
 (ns aoc-clj.2019.day19-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day19 :as t]))
+
+(def day19-input (u/parse-puzzle-input t/parse 2019 19))
 
 (deftest day19-part1-test
   (testing "Can reproduce the solution for part1"
-    (is (= 150 (t/day19-part1-soln)))))
+    (is (= 150 (t/day19-part1-soln day19-input)))))
 
 (deftest day19-part2-test
   (testing "Can reproduce the solution for part2"
-    (is (= 12201460 (t/day19-part2-soln)))))
+    (is (= 12201460 (t/day19-part2-soln day19-input)))))

--- a/test/aoc_clj/2019/day20_test.clj
+++ b/test/aoc_clj/2019/day20_test.clj
@@ -1,9 +1,10 @@
 (ns aoc-clj.2019.day20-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.utils.graph :as g :refer [edges]]
             [aoc-clj.2019.day20 :as t]))
 
-(def d20-s1
+(def d20-s00
   ["         A           "
    "         A           "
    "  #######.#########  "
@@ -24,7 +25,7 @@
    "             Z       "
    "             Z       "])
 
-(def d20-s2
+(def d20-s01
   ["                   A               "
    "                   A               "
    "  #################.#############  "
@@ -71,7 +72,7 @@
             [4 8] ["DE" :inner],
             [9 10] ["FG" :inner],
             [11 14] ["ZZ" :outer]}
-           (t/label-locations d20-s1)))
+           (t/label-locations d20-s00)))
     (is (= {[17 0] ["AA" :outer]
             [0 13] ["DI" :outer], [0 17] ["JO" :outer], [0 21] ["YN" :outer],
             [9 32] ["BU" :outer], [13 32] ["JP" :outer], [17 32] ["CP" :outer],
@@ -81,26 +82,22 @@
             [11 26] ["JO" :inner], [13 26] ["LF" :inner], [19 26] ["JP" :inner],
             [24 11] ["YN" :inner], [24 15] ["QG" :inner], [24 19] ["BU" :inner], [24 21] ["VT" :inner],
             [0 15] ["ZZ" :outer]}
-           (t/label-locations d20-s2)))))
+           (t/label-locations d20-s01)))))
 
 
 (deftest neighbor-coords-test
   (testing "Neighbor lookup follows portals"
-    (let [graph (:graph (t/maze-with-portals (t/load-maze d20-s1)))]
+    (let [graph (:graph (t/maze-with-portals (t/load-maze d20-s00)))]
       (is (= [[7 1] [0 6]] (edges graph [7 4])))
       (is (= [[0 6] [0 11]] (edges graph [4 8])))
       (is (= [[0 11] [9 10]] (edges graph [0 13]))))))
 
 (deftest shortest-path-test
   (testing "Can find the shortest path when using portals"
-    (is (= 23 (t/solve-maze d20-s1)))
-    (is (= 58 (t/solve-maze d20-s2)))))
+    (is (= 23 (t/solve-maze d20-s00)))
+    (is (= 58 (t/solve-maze d20-s01)))))
 
-(deftest day20-part1-soln-test
-  (testing "Can reproduce the solution for part1"
-    (is (= 578 (t/day20-part1-soln)))))
-
-(def d20-s3
+(def d20-s02
   ["             Z L X W       C                 "
    "             Z P Q B       K                 "
    "  ###########.#.#.#.#######.###############  "
@@ -141,9 +138,15 @@
 
 (deftest shortest-path-3d-test
   (testing "Can find the shortest path through the recursive maze"
-    (is (= 26 (t/solve-recursive-maze d20-s1)))
-    (is (= 396 (t/solve-recursive-maze d20-s3)))))
+    (is (= 26 (t/solve-recursive-maze d20-s00)))
+    (is (= 396 (t/solve-recursive-maze d20-s02)))))
+
+(def day20-input (u/parse-puzzle-input t/parse 2019 20))
+
+(deftest day20-part1-soln-test
+  (testing "Can reproduce the solution for part1"
+    (is (= 578 (t/day20-part1-soln day20-input)))))
 
 (deftest day20-part2-soln-test
   (testing "Can reproduce the solution for part2"
-    (is (= 6592 (t/day20-part2-soln)))))
+    (is (= 6592 (t/day20-part2-soln day20-input)))))

--- a/test/aoc_clj/2019/day21_test.clj
+++ b/test/aoc_clj/2019/day21_test.clj
@@ -1,11 +1,14 @@
 (ns aoc-clj.2019.day21-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day21 :as t]))
+
+(def day21-input (u/parse-puzzle-input t/parse 2019 21))
 
 (deftest day21-part1-soln-test
   (testing "Can reproduce the answer for part1"
-    (is (= 19352864 (t/day21-part1-soln)))))
+    (is (= 19352864 (t/day21-part1-soln day21-input)))))
 
 (deftest day21-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= 1142488337 (t/day21-part2-soln)))))
+    (is (= 1142488337 (t/day21-part2-soln day21-input)))))

--- a/test/aoc_clj/2019/day22_test.clj
+++ b/test/aoc_clj/2019/day22_test.clj
@@ -1,23 +1,24 @@
 (ns aoc-clj.2019.day22-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day22 :as t]))
 
-(def d22-s1
+(def d22-s00
   [[:increment 7]
    [:deal]
    [:deal]])
 
-(def d22-s2
+(def d22-s01
   [[:cut 6]
    [:increment 7]
    [:deal]])
 
-(def d22-s3
+(def d22-s02
   [[:increment 7]
    [:increment 9]
    [:cut -2]])
 
-(def d22-s4
+(def d22-s03
   [[:deal]
    [:cut -2]
    [:increment 7]
@@ -31,21 +32,23 @@
 
 (deftest shuffle-test
   (testing "Shuffle operations work on small decks"
-    (is (= [0 3 6 9 2 5 8 1 4 7] (t/shuffle-deck 10 d22-s1)))
-    (is (= [3 0 7 4 1 8 5 2 9 6] (t/shuffle-deck 10 d22-s2)))
-    (is (= [6 3 0 7 4 1 8 5 2 9] (t/shuffle-deck 10 d22-s3)))
-    (is (= [9 2 5 8 1 4 7 0 3 6] (t/shuffle-deck 10 d22-s4)))))
-
-(deftest day22-part1-soln-test
-  (testing "Can reproduce the answer for part1"
-    (is (= 2306 (t/day22-part1-soln)))))
+    (is (= [0 3 6 9 2 5 8 1 4 7] (t/shuffle-deck 10 d22-s00)))
+    (is (= [3 0 7 4 1 8 5 2 9 6] (t/shuffle-deck 10 d22-s01)))
+    (is (= [6 3 0 7 4 1 8 5 2 9] (t/shuffle-deck 10 d22-s02)))
+    (is (= [9 2 5 8 1 4 7 0 3 6] (t/shuffle-deck 10 d22-s03)))))
 
 (deftest multiple-shuffle-test
   (testing "Correctly identify the card in given position after many repeated shuffles"
-    (is (= 9 (t/card-after-multiple-shuffles 10 d22-s1 5 3)))
-    (is (= 8 (t/card-after-multiple-shuffles 10 d22-s2 5 5)))
-    (is (= 8 (t/card-after-multiple-shuffles 10 d22-s3 10 0)))))
+    (is (= 9 (t/card-after-multiple-shuffles 10 d22-s00 5 3)))
+    (is (= 8 (t/card-after-multiple-shuffles 10 d22-s01 5 5)))
+    (is (= 8 (t/card-after-multiple-shuffles 10 d22-s02 10 0)))))
+
+(def day22-input (u/parse-puzzle-input t/parse 2019 22))
+
+(deftest day22-part1-soln-test
+  (testing "Can reproduce the answer for part1"
+    (is (= 2306 (t/day22-part1-soln day22-input)))))
 
 (deftest day22-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= 12545532223512 (t/day22-part2-soln)))))
+    (is (= 12545532223512 (t/day22-part2-soln day22-input)))))

--- a/test/aoc_clj/2019/day23_test.clj
+++ b/test/aoc_clj/2019/day23_test.clj
@@ -1,11 +1,14 @@
 (ns aoc-clj.2019.day23-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day23 :as t]))
+
+(def day23-input (u/parse-puzzle-input t/parse 2019 23))
 
 (deftest day23-part1-soln-test
   (testing "Can reproduce the answer for part1"
-    (is (= 23886 (t/day23-part1-soln)))))
+    (is (= 23886 (t/day23-part1-soln day23-input)))))
 
 (deftest day21-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= 18333 (t/day23-part2-soln)))))
+    (is (= 18333 (t/day23-part2-soln day23-input)))))

--- a/test/aoc_clj/2019/day24_test.clj
+++ b/test/aoc_clj/2019/day24_test.clj
@@ -1,30 +1,27 @@
 (ns aoc-clj.2019.day24-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day24 :as t]))
 
 
-(def d24-s1       (t/parse ["....#" "#..#." "#..##" "..#.." "#...."]))
-(def d24-s1-step1 (t/parse ["#..#." "####." "###.#" "##.##" ".##.."]))
-(def d24-s1-step2 (t/parse ["#####" "....#" "....#" "...#." "#.###"]))
-(def d24-s1-step3 (t/parse ["#...." "####." "...##" "#.##." ".##.#"]))
-(def d24-s1-step4 (t/parse ["####." "....#" "##..#" "....." "##..."]))
+(def d24-s00       (t/parse ["....#" "#..#." "#..##" "..#.." "#...."]))
+(def d24-s00-step1 (t/parse ["#..#." "####." "###.#" "##.##" ".##.."]))
+(def d24-s00-step2 (t/parse ["#####" "....#" "....#" "...#." "#.###"]))
+(def d24-s00-step3 (t/parse ["#...." "####." "...##" "#.##." ".##.#"]))
+(def d24-s00-step4 (t/parse ["####." "....#" "##..#" "....." "##..."]))
 
-(def d24-s2 (t/parse ["....." "....." "....." "#...." ".#..."]))
+(def d24-s01 (t/parse ["....." "....." "....." "#...." ".#..."]))
 
 (deftest conway-step-test
   (testing "Can properly execute the rules for Conway's game of life"
-    (is (= d24-s1-step1 (t/conway-step-2d d24-s1)))
-    (is (= d24-s1-step2 (t/conway-step-2d d24-s1-step1)))
-    (is (= d24-s1-step3 (t/conway-step-2d d24-s1-step2)))
-    (is (= d24-s1-step4 (t/conway-step-2d d24-s1-step3)))))
+    (is (= d24-s00-step1 (t/conway-step-2d d24-s00)))
+    (is (= d24-s00-step2 (t/conway-step-2d d24-s00-step1)))
+    (is (= d24-s00-step3 (t/conway-step-2d d24-s00-step2)))
+    (is (= d24-s00-step4 (t/conway-step-2d d24-s00-step3)))))
 
 (deftest biodiversity-test
   (testing "Can properly compute biodiversity"
-    (is (= 2129920 (t/biodiversity d24-s2)))))
-
-(deftest day24-part1-soln-test
-  (testing "Can reproduce the answer for part1"
-    (is (= 17863711 (t/day24-part1-soln)))))
+    (is (= 2129920 (t/biodiversity d24-s01)))))
 
 (deftest neighbors3d-coords-test
   (testing "Can correctly determine the right neighbors in 3d recursive space"
@@ -39,37 +36,43 @@
     (is (= [[3 1 1] [2 2 1] [3 3 1] [4 2 1] [4 0 0] [4 1 0] [4 2 0] [4 3 0] [4 4 0]]
            (t/neighbors3d-coords [3 2 1])))))
 
-(def d24-s3         (t/parse ["....#" "#..#." "#.?##" "..#.." "#...."]))
-(def d24-s3-level-5 (t/parse ["..#.." ".#.#." "..?.#" ".#.#." "..#.."]))
-(def d24-s3-level-4 (t/parse ["...#." "...##" "..?.." "...##" "...#."]))
-(def d24-s3-level-3 (t/parse ["#.#.." ".#..." "..?.." ".#..." "#.#.."]))
-(def d24-s3-level-2 (t/parse [".#.##" "....#" "..?.#" "...##" ".###."]))
-(def d24-s3-level-1 (t/parse ["#..##" "...##" "..?.." "...#." ".####"]))
-(def d24-s3-level0  (t/parse [".#..." ".#.##" ".#?.." "....." "....."]))
-(def d24-s3-level+1 (t/parse [".##.." "#..##" "..?.#" "##.##" "#####"]))
-(def d24-s3-level+2 (t/parse ["###.." "##.#." "#.?.." ".#.##" "#.#.."]))
-(def d24-s3-level+3 (t/parse ["..###" "....." "#.?.." "#...." "#...#"]))
-(def d24-s3-level+4 (t/parse [".###." "#..#." "#.?.." "##.#." "....."]))
-(def d24-s3-level+5 (t/parse ["####." "#..#." "#.?#." "####." "....."]))
+(def d24-s02         (t/parse ["....#" "#..#." "#.?##" "..#.." "#...."]))
+(def d24-s02-level-5 (t/parse ["..#.." ".#.#." "..?.#" ".#.#." "..#.."]))
+(def d24-s02-level-4 (t/parse ["...#." "...##" "..?.." "...##" "...#."]))
+(def d24-s02-level-3 (t/parse ["#.#.." ".#..." "..?.." ".#..." "#.#.."]))
+(def d24-s02-level-2 (t/parse [".#.##" "....#" "..?.#" "...##" ".###."]))
+(def d24-s02-level-1 (t/parse ["#..##" "...##" "..?.." "...#." ".####"]))
+(def d24-s02-level0  (t/parse [".#..." ".#.##" ".#?.." "....." "....."]))
+(def d24-s02-level+1 (t/parse [".##.." "#..##" "..?.#" "##.##" "#####"]))
+(def d24-s02-level+2 (t/parse ["###.." "##.#." "#.?.." ".#.##" "#.#.."]))
+(def d24-s02-level+3 (t/parse ["..###" "....." "#.?.." "#...." "#...#"]))
+(def d24-s02-level+4 (t/parse [".###." "#..#." "#.?.." "##.#." "....."]))
+(def d24-s02-level+5 (t/parse ["####." "#..#." "#.?#." "####." "....."]))
 
 (deftest simulate-test
   (testing "Simulation works correctly in 3d"
-    (let [sim (t/simulate d24-s3 10)]
-      (is (= d24-s3-level-5 (t/space3d-level sim 5)))
-      (is (= d24-s3-level-4 (t/space3d-level sim 4)))
-      (is (= d24-s3-level-3 (t/space3d-level sim 3)))
-      (is (= d24-s3-level-2 (t/space3d-level sim 2)))
-      (is (= d24-s3-level-1 (t/space3d-level sim 1)))
-      (is (= d24-s3-level0  (t/space3d-level sim 0)))
-      (is (= d24-s3-level+1 (t/space3d-level sim -1)))
-      (is (= d24-s3-level+2 (t/space3d-level sim -2)))
-      (is (= d24-s3-level+3 (t/space3d-level sim -3)))
-      (is (= d24-s3-level+4 (t/space3d-level sim -4)))
-      (is (= d24-s3-level+5 (t/space3d-level sim -5)))
+    (let [sim (t/simulate d24-s02 10)]
+      (is (= d24-s02-level-5 (t/space3d-level sim 5)))
+      (is (= d24-s02-level-4 (t/space3d-level sim 4)))
+      (is (= d24-s02-level-3 (t/space3d-level sim 3)))
+      (is (= d24-s02-level-2 (t/space3d-level sim 2)))
+      (is (= d24-s02-level-1 (t/space3d-level sim 1)))
+      (is (= d24-s02-level0  (t/space3d-level sim 0)))
+      (is (= d24-s02-level+1 (t/space3d-level sim -1)))
+      (is (= d24-s02-level+2 (t/space3d-level sim -2)))
+      (is (= d24-s02-level+3 (t/space3d-level sim -3)))
+      (is (= d24-s02-level+4 (t/space3d-level sim -4)))
+      (is (= d24-s02-level+5 (t/space3d-level sim -5)))
       (is (= 99 (t/bug-count sim))))))
+
+(def day24-input (u/parse-puzzle-input t/parse 2019 24))
+
+(deftest day24-part1-soln-test
+  (testing "Can reproduce the answer for part1"
+    (is (= 17863711 (t/day24-part1-soln day24-input)))))
 
 ;; FIXME: 2019 Day 24 part 2 solutiion is a bit slow to test
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/24
 (deftest ^:slow day24-part2-soln-test
   (testing "Can reproduce the answer for part2"
-    (is (= 1937 (t/day24-part2-soln)))))
+    (is (= 1937 (t/day24-part2-soln day24-input)))))

--- a/test/aoc_clj/2019/day25_test.clj
+++ b/test/aoc_clj/2019/day25_test.clj
@@ -1,7 +1,11 @@
 (ns aoc-clj.2019.day25-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2019.day25 :as t]))
+
+(def day25-input (u/parse-puzzle-input t/parse 2019 25))
+(def day25-cmds  (u/puzzle-input "inputs/2019/day25-cmds.txt"))
 
 (deftest day25-part1-soln-test
   (testing "Can reproduce the answer for part1"
-    (is (= 16410 (t/day25-part1-soln)))))
+    (is (= 16410 (t/day25-part1-soln day25-input day25-cmds)))))

--- a/test/aoc_clj/2020/day01_test.clj
+++ b/test/aoc_clj/2020/day01_test.clj
@@ -1,21 +1,24 @@
 (ns aoc-clj.2020.day01-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day01 :as t]))
 
-(def day01-example [1721 979 366 299 675 1456])
+(def d01-s00 [1721 979 366 299 675 1456])
 
 (deftest find-pairs-that-sum
   (testing "Finds pair in a list that sums to 2020"
-    (is (= '(299 1721) (t/find-pair-that-sums-to-total 2020 day01-example)))))
+    (is (= '(299 1721) (t/find-pair-that-sums-to-total 2020 d01-s00)))))
 
 (deftest find-triples-that-sum
   (testing "Finds a triple in a list that sums to 2020"
-    (is (= '(979 366 675) (t/find-triple-that-sums-to-total 2020 day01-example)))))
+    (is (= '(979 366 675) (t/find-triple-that-sums-to-total 2020 d01-s00)))))
+
+(def day01-input (u/parse-puzzle-input t/parse 2020 1))
 
 (deftest day01-part1-soln
   (testing "Reproduces the answer for day01, part1"
-    (is (= 989824 (t/day01-part1-soln)))))
+    (is (= 989824 (t/day01-part1-soln day01-input)))))
 
 (deftest day01-part2-soln
   (testing "Reproduces the answer for day01, part2"
-    (is (= 66432240 (t/day02-part2-soln)))))
+    (is (= 66432240 (t/day02-part2-soln day01-input)))))

--- a/test/aoc_clj/2020/day02_test.clj
+++ b/test/aoc_clj/2020/day02_test.clj
@@ -1,32 +1,35 @@
 (ns aoc-clj.2020.day02-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day02 :as t]))
 
-(def day02-sample ["1-3 a: abcde"
-                   "1-3 b: cdefg"
-                   "2-9 c: ccccccccc"])
+(def d02-s00 ["1-3 a: abcde"
+              "1-3 b: cdefg"
+              "2-9 c: ccccccccc"])
 
 (deftest parser
   (testing "Testing the parser works correctly on the input"
     (is (= {:min 1 :max 3 :char \a :pass "abcde"}
-           (t/parse (first day02-sample))))))
+           (t/parse-line (first d02-s00))))))
 
 (deftest part1-validator
   (testing "Correctly validates per the rules in part1"
-    (is (= true (t/part1-valid? (t/parse (first day02-sample)))))
-    (is (= false (t/part1-valid? (t/parse (second day02-sample)))))
-    (is (= true (t/part1-valid? (t/parse (last day02-sample)))))))
+    (is (= true  (t/part1-valid? (t/parse-line (first d02-s00)))))
+    (is (= false (t/part1-valid? (t/parse-line (second d02-s00)))))
+    (is (= true  (t/part1-valid? (t/parse-line (last d02-s00)))))))
 
 (deftest part2-validator
   (testing "Correctly validates per the rules in part2"
-    (is (= true (t/part2-valid? (t/parse (first day02-sample)))))
-    (is (= false (t/part2-valid? (t/parse (second day02-sample)))))
-    (is (= false (t/part2-valid? (t/parse (last day02-sample)))))))
+    (is (= true  (t/part2-valid? (t/parse-line (first d02-s00)))))
+    (is (= false (t/part2-valid? (t/parse-line (second d02-s00)))))
+    (is (= false (t/part2-valid? (t/parse-line (last d02-s00)))))))
+
+(def day02-input (u/parse-puzzle-input t/parse 2020 2))
 
 (deftest day02-part1-soln
   (testing "Reproduces the answer for day02, part1"
-    (is (= 418 (t/day02-part1-soln)))))
+    (is (= 418 (t/day02-part1-soln day02-input)))))
 
 (deftest day02-part2-soln
   (testing "Reproduces the answer for day02, part2"
-    (is (= 616 (t/day02-part2-soln)))))
+    (is (= 616 (t/day02-part2-soln day02-input)))))

--- a/test/aoc_clj/2020/day03_test.clj
+++ b/test/aoc_clj/2020/day03_test.clj
@@ -1,21 +1,22 @@
 (ns aoc-clj.2020.day03-test
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day03 :as t]))
 
-(def day03-sample "..##.......
-#...#...#..
-.#....#..#.
-..#.#...#.#
-.#...##..#.
-..#.##.....
-.#.#.#....#
-.#........#
-#.##...#...
-#...##....#
-.#..#...#.#")
+(def d03-s00
+  ["..##......."
+   "#...#...#.."
+   ".#....#..#."
+   "..#.#...#.#"
+   ".#...##..#."
+   "..#.##....."
+   ".#.#.#....#"
+   ".#........#"
+   "#.##...#..."
+   "#...##....#"
+   ".#..#...#.#"])
 
-(def sample-basemap (t/forest-basemap (str/split day03-sample #"\n")))
+(def sample-basemap (t/forest-basemap d03-s00))
 
 (deftest items-along-slope
   (testing "Correctly determines the items along a slope"
@@ -27,10 +28,12 @@
     (is (= '(2 7 3 4 2)
            (t/trees-along-slopes sample-basemap [[1 1] [3 1] [5 1] [7 1] [1 2]])))))
 
+(def day03-input (u/parse-puzzle-input t/parse 2020 3))
+
 (deftest day03-part1-soln
   (testing "Reproduces the answer for day03, part1"
-    (is (= 191 (t/day03-part1-soln)))))
+    (is (= 191 (t/day03-part1-soln day03-input)))))
 
 (deftest day03-part2-soln
   (testing "Reproduces the answer for day03, part2"
-    (is (= 1478615040 (t/day03-part2-soln)))))
+    (is (= 1478615040 (t/day03-part2-soln day03-input)))))

--- a/test/aoc_clj/2020/day04_test.clj
+++ b/test/aoc_clj/2020/day04_test.clj
@@ -1,55 +1,56 @@
 (ns aoc-clj.2020.day04-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day04 :as t]))
 
-(def day04-sample
-  "ecl:gry pid:860033327 eyr:2020 hcl:#fffffd
-byr:1937 iyr:2017 cid:147 hgt:183cm
+(def d04-s00
+  ["ecl:gry pid:860033327 eyr:2020 hcl:#fffffd"
+   "byr:1937 iyr:2017 cid:147 hgt:183cm"
+   ""
+   "iyr:2013 ecl:amb cid:350 eyr:2023 pid:028048884"
+   "hcl:#cfa07d byr:1929"
+   ""
+   "hcl:#ae17e1 iyr:2013"
+   "eyr:2024"
+   "ecl:brn pid:760753108 byr:1931"
+   "hgt:179cm"
+   ""
+   "hcl:#cfa07d eyr:2025 pid:166559648"
+   "iyr:2011 ecl:brn hgt:59in"])
 
-iyr:2013 ecl:amb cid:350 eyr:2023 pid:028048884
-hcl:#cfa07d byr:1929
+(def d04-s00-invalid
+  ["eyr:1972 cid:100"
+   "hcl:#18171d ecl:amb hgt:170 pid:186cm iyr:2018 byr:1926"
+   ""
+   "iyr:2019"
+   "hcl:#602927 eyr:1967 hgt:170cm"
+   "ecl:grn pid:012533040 byr:1946"
+   ""
+   "hcl:dab227 iyr:2012"
+   "ecl:brn hgt:182cm pid:021572410 eyr:2020 byr:1992 cid:277"
+   ""
+   "hgt:59cm ecl:zzz"
+   "eyr:2038 hcl:74454a iyr:2023"
+   "pid:3556412378 byr:2007"])
 
-hcl:#ae17e1 iyr:2013
-eyr:2024
-ecl:brn pid:760753108 byr:1931
-hgt:179cm
-
-hcl:#cfa07d eyr:2025 pid:166559648
-iyr:2011 ecl:brn hgt:59in")
-
-(def day04-invalid-samples
-  "eyr:1972 cid:100
-hcl:#18171d ecl:amb hgt:170 pid:186cm iyr:2018 byr:1926
-
-iyr:2019
-hcl:#602927 eyr:1967 hgt:170cm
-ecl:grn pid:012533040 byr:1946
-
-hcl:dab227 iyr:2012
-ecl:brn hgt:182cm pid:021572410 eyr:2020 byr:1992 cid:277
-
-hgt:59cm ecl:zzz
-eyr:2038 hcl:74454a iyr:2023
-pid:3556412378 byr:2007")
-
-(def day04-valid-samples
-  "pid:087499704 hgt:74in ecl:grn iyr:2012 eyr:2030 byr:1980
-hcl:#623a2f
-
-eyr:2029 ecl:blu cid:129 byr:1989
-iyr:2014 pid:896056539 hcl:#a97842 hgt:165cm
-
-hcl:#888785
-hgt:164cm byr:2001 iyr:2015 cid:88
-pid:545766238 ecl:hzl
-eyr:2022
-
-iyr:2010 hgt:158cm hcl:#b6652a ecl:blu byr:1944 eyr:2021 pid:093154719")
+(def d04-s00-valid
+  ["pid:087499704 hgt:74in ecl:grn iyr:2012 eyr:2030 byr:1980"
+   "hcl:#623a2f"
+   ""
+   "eyr:2029 ecl:blu cid:129 byr:1989"
+   "iyr:2014 pid:896056539 hcl:#a97842 hgt:165cm"
+   ""
+   "hcl:#888785"
+   "hgt:164cm byr:2001 iyr:2015 cid:88"
+   "pid:545766238 ecl:hzl"
+   "eyr:2022"
+   ""
+   "iyr:2010 hgt:158cm hcl:#b6652a ecl:blu byr:1944 eyr:2021 pid:093154719"])
 
 (deftest keys-valid
   (testing "Correctly determines that passports have the correct keys"
     (is (= '(true false true false)
-           (map t/keys-valid? (t/parse day04-sample))))))
+           (map t/keys-valid? (t/parse d04-s00))))))
 
 (deftest byr-valid
   (testing "Correctly determines that birth years are valid"
@@ -101,14 +102,16 @@ iyr:2010 hgt:158cm hcl:#b6652a ecl:blu byr:1944 eyr:2021 pid:093154719")
 (deftest all-valid
   (testing "All validators combined work correctly"
     (is (= '(true true true true)
-           (map t/passport-valid? (t/parse day04-valid-samples))))
+           (map t/passport-valid? (t/parse d04-s00-valid))))
     (is (= '(false false false false)
-           (map t/passport-valid? (t/parse day04-invalid-samples))))))
+           (map t/passport-valid? (t/parse d04-s00-invalid))))))
+
+(def day04-input (u/parse-puzzle-input t/parse 2020 4))
 
 (deftest day04-part1-soln
   (testing "Reproduces the answer for day04, part1"
-    (is (= 192 (t/day04-part1-soln)))))
+    (is (= 192 (t/day04-part1-soln day04-input)))))
 
 (deftest day04-part2-soln
   (testing "Reproduces the answer for day04, part2"
-    (is (= 101 (t/day04-part2-soln)))))
+    (is (= 101 (t/day04-part2-soln day04-input)))))

--- a/test/aoc_clj/2020/day05_test.clj
+++ b/test/aoc_clj/2020/day05_test.clj
@@ -1,23 +1,26 @@
 (ns aoc-clj.2020.day05-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day05 :as t]))
 
-(def day05-sample1 "FBFBBFFRLR")
-(def day05-sample2 "BFFFBBFRRR")
-(def day05-sample3 "FFFBBBFRRR")
-(def day05-sample4 "BBFFBBFRLL")
+(def d05-s00 "FBFBBFFRLR")
+(def d05-s01 "BFFFBBFRRR")
+(def d05-s02 "FFFBBBFRRR")
+(def d05-s03 "BBFFBBFRLL")
 
 (deftest seatid-parser
   (testing "Correctly parses the seat-id from the string")
-  (is (= 357 (t/seat-id day05-sample1)))
-  (is (= 567 (t/seat-id day05-sample2)))
-  (is (= 119 (t/seat-id day05-sample3)))
-  (is (= 820 (t/seat-id day05-sample4))))
+  (is (= 357 (t/seat-id d05-s00)))
+  (is (= 567 (t/seat-id d05-s01)))
+  (is (= 119 (t/seat-id d05-s02)))
+  (is (= 820 (t/seat-id d05-s03))))
+
+(def day05-input (u/parse-puzzle-input t/parse 2020 5))
 
 (deftest day05-part1-soln
   (testing "Reproduces the answer for day05, part1"
-    (is (= 858 (t/day05-part1-soln)))))
+    (is (= 858 (t/day05-part1-soln day05-input)))))
 
 (deftest day05-part2-soln
   (testing "Reproduces the answer for day05, part2"
-    (is (= 557 (t/day05-part2-soln)))))
+    (is (= 557 (t/day05-part2-soln day05-input)))))

--- a/test/aoc_clj/2020/day06_test.clj
+++ b/test/aoc_clj/2020/day06_test.clj
@@ -1,43 +1,48 @@
 (ns aoc-clj.2020.day06-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day06 :as t]))
 
-(def day06-sample
-  "abc
+(def d06-s00-raw
+  ["abc"
+   ""
+   "a"
+   "b"
+   "c"
+   ""
+   "ab"
+   "ac"
+   ""
+   "a"
+   "a"
+   "a"
+   "a"
+   ""
+   "b"])
 
-a
-b
-c
-
-ab
-ac
-
-a
-a
-a
-a
-
-b")
+(def d06-s00
+  [["abc"] ["a" "b" "c"] ["ab" "ac"] ["a" "a" "a" "a"] ["b"]])
 
 (deftest parse-test
   (testing "Correctly parses the input format"
-    (is (= '(["abc"] ["a" "b" "c"] ["ab" "ac"] ["a" "a" "a" "a"] ["b"])
-           (t/parse day06-sample)))))
+    (is (= d06-s00 (t/parse d06-s00-raw)))))
 
 (deftest unique-items-in-group
   (testing "Correct identifies the sets of unique items in a group"
     (is (= '(#{\a \b \c} #{\a \b \c} #{\a \b \c} #{\a} #{\b})
-           (map t/unique-answers-in-group (t/parse day06-sample))))))
+           (map t/unique-answers-in-group d06-s00)))))
 
 (deftest common-items-in-group
   (testing "Correct identifies the sets of common items in a group"
     (is (= '(#{\a \b \c} #{} #{\a} #{\a} #{\b})
-           (map t/common-answers-in-group (t/parse day06-sample))))))
+           (map t/common-answers-in-group d06-s00)))))
+
+(def day06-input (u/parse-puzzle-input t/parse 2020 6))
 
 (deftest day06-part1-soln
   (testing "Reproduces the answer for day06, part1"
-    (is (= 6170 (t/day06-part1-soln)))))
+    (is (= 6170 (t/day06-part1-soln day06-input)))))
 
 (deftest day06-part2-soln
   (testing "Reproduces the answer for day06, part2"
-    (is (= 2947 (t/day06-part2-soln)))))
+    (is (= 2947 (t/day06-part2-soln day06-input)))))

--- a/test/aoc_clj/2020/day07_test.clj
+++ b/test/aoc_clj/2020/day07_test.clj
@@ -1,47 +1,46 @@
 (ns aoc-clj.2020.day07-test
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day07 :as t]))
 
-(def day07-sample
-  (map t/parse-rule
-       (str/split
-        "light red bags contain 1 bright white bag, 2 muted yellow bags.
-dark orange bags contain 3 bright white bags, 4 muted yellow bags.
-bright white bags contain 1 shiny gold bag.
-muted yellow bags contain 2 shiny gold bags, 9 faded blue bags.
-shiny gold bags contain 1 dark olive bag, 2 vibrant plum bags.
-dark olive bags contain 3 faded blue bags, 4 dotted black bags.
-vibrant plum bags contain 5 faded blue bags, 6 dotted black bags.
-faded blue bags contain no other bags.
-dotted black bags contain no other bags." #"\n")))
+(def d07-s00
+  (t/parse
+   ["light red bags contain 1 bright white bag, 2 muted yellow bags."
+    "dark orange bags contain 3 bright white bags, 4 muted yellow bags."
+    "bright white bags contain 1 shiny gold bag."
+    "muted yellow bags contain 2 shiny gold bags, 9 faded blue bags."
+    "shiny gold bags contain 1 dark olive bag, 2 vibrant plum bags."
+    "dark olive bags contain 3 faded blue bags, 4 dotted black bags."
+    "vibrant plum bags contain 5 faded blue bags, 6 dotted black bags."
+    "faded blue bags contain no other bags."
+    "dotted black bags contain no other bags."]))
 
-(def day07-sample2
-  (map t/parse-rule
-       (str/split
-        "shiny gold bags contain 2 dark red bags.
-dark red bags contain 2 dark orange bags.
-dark orange bags contain 2 dark yellow bags.
-dark yellow bags contain 2 dark green bags.
-dark green bags contain 2 dark blue bags.
-dark blue bags contain 2 dark violet bags.
-dark violet bags contain no other bags." #"\n")))
-
+(def d07-s01
+  (t/parse
+   ["shiny gold bags contain 2 dark red bags."
+    "dark red bags contain 2 dark orange bags."
+    "dark orange bags contain 2 dark yellow bags."
+    "dark yellow bags contain 2 dark green bags."
+    "dark green bags contain 2 dark blue bags."
+    "dark blue bags contain 2 dark violet bags."
+    "dark violet bags contain no other bags."]))
 
 (deftest part1-sample
   (testing "Identifies the possible outer bags given the rules"
     (is (= #{:bright-white :muted-yellow :dark-orange :light-red}
-           (t/all-outer-bags day07-sample :shiny-gold)))))
+           (t/all-outer-bags d07-s00 :shiny-gold)))))
 
 (deftest part2-sample
   (testing "Counts the number of inner bags required to satisfy the rules"
-    (is (= 32  (t/count-inner-bags day07-sample  :shiny-gold)))
-    (is (= 126 (t/count-inner-bags day07-sample2 :shiny-gold)))))
+    (is (= 32  (t/count-inner-bags d07-s00  :shiny-gold)))
+    (is (= 126 (t/count-inner-bags d07-s01 :shiny-gold)))))
+
+(def day07-input (u/parse-puzzle-input t/parse 2020 7))
 
 (deftest day07-part1-soln
   (testing "Reproduces the answer for day07, part1"
-    (is (= 372 (t/day07-part1-soln)))))
+    (is (= 372 (t/day07-part1-soln day07-input)))))
 
 (deftest day07-part2-soln
   (testing "Reproduces the answer for day07, part2"
-    (is (= 8015 (t/day07-part2-soln)))))
+    (is (= 8015 (t/day07-part2-soln day07-input)))))

--- a/test/aoc_clj/2020/day08_test.clj
+++ b/test/aoc_clj/2020/day08_test.clj
@@ -1,34 +1,34 @@
 (ns aoc-clj.2020.day08-test
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day08 :as t]))
 
-(def day08-sample
-  (map t/parse
-       (str/split
-        "nop +0
-acc +1
-jmp +4
-acc +3
-jmp -3
-acc -99
-acc +1
-jmp -4
-acc +6" #"\n")))
-
+(def d08-s00
+  (t/parse
+   ["nop +0"
+    "acc +1"
+    "jmp +4"
+    "acc +3"
+    "jmp -3"
+    "acc -99"
+    "acc +1"
+    "jmp -4"
+    "acc +6"]))
 
 (deftest part1-sample
   (testing "Can return accumulator value at beginning of second loop"
-    (is (= 5 (t/acc-value-at-second-loop day08-sample)))))
+    (is (= 5 (t/acc-value-at-second-loop d08-s00)))))
 
 (deftest part2-sample
   (testing "Returns the accumulator after fixing the invalid instruction"
-    (is (= 8 (t/acc-value-for-finite-loop day08-sample)))))
+    (is (= 8 (t/acc-value-for-finite-loop d08-s00)))))
+
+(def day08-input (u/parse-puzzle-input t/parse 2020 8))
 
 (deftest day08-part1-soln
   (testing "Reproduces the answer for day08, part1"
-    (is (= 1451 (t/day08-part1-soln)))))
+    (is (= 1451 (t/day08-part1-soln day08-input)))))
 
 (deftest day08-part2-soln
   (testing "Reproduces the answer for day08, part2"
-    (is (= 1160 (t/day08-part2-soln)))))
+    (is (= 1160 (t/day08-part2-soln day08-input)))))

--- a/test/aoc_clj/2020/day09_test.clj
+++ b/test/aoc_clj/2020/day09_test.clj
@@ -1,44 +1,45 @@
 (ns aoc-clj.2020.day09-test
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day09 :as t]))
 
-(def day09-sample
-  (map read-string
-       (str/split
-        "35
-20
-15
-25
-47
-40
-62
-55
-65
-95
-102
-117
-150
-182
-127
-219
-299
-277
-309
-576" #"\n")))
+(def d09-s00
+  (t/parse
+   ["35"
+    "20"
+    "15"
+    "25"
+    "47"
+    "40"
+    "62"
+    "55"
+    "65"
+    "95"
+    "102"
+    "117"
+    "150"
+    "182"
+    "127"
+    "219"
+    "299"
+    "277"
+    "309"
+    "576"]))
 
 (deftest part1-sample
   (testing "Can find the first value not a sum of previous values in window"
-    (is (= 127 (t/first-non-sum day09-sample 5)))))
+    (is (= 127 (t/first-non-sum d09-s00 5)))))
 
 (deftest part2-sample
   (testing "Can find the limits of the continuous range that sums to invalid number"
-    (is (= [15 47] (t/contiguous-range-to-sum day09-sample 127)))))
+    (is (= [15 47] (t/contiguous-range-to-sum d09-s00 127)))))
+
+(def day09-input (u/parse-puzzle-input t/parse 2020 9))
 
 (deftest day09-part1-soln
   (testing "Reproduces the answer for day09, part1"
-    (is (= 22406676 (t/day09-part1-soln)))))
+    (is (= 22406676 (t/day09-part1-soln day09-input)))))
 
 (deftest day09-part2-soln
   (testing "Reproduces the answer for day09, part2"
-    (is (= 2942387 (t/day09-part2-soln)))))
+    (is (= 2942387 (t/day09-part2-soln day09-input)))))

--- a/test/aoc_clj/2020/day10_test.clj
+++ b/test/aoc_clj/2020/day10_test.clj
@@ -1,72 +1,72 @@
 (ns aoc-clj.2020.day10-test
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day10 :as t]))
 
-(def day10-sample
-  (map read-string
-       (str/split
-        "16
-10
-15
-5
-1
-11
-7
-19
-6
-12
-4" #"\n")))
+(def d10-s00
+  (t/parse
+   ["16"
+    "10"
+    "15"
+    "5"
+    "1"
+    "11"
+    "7"
+    "19"
+    "6"
+    "12"
+    "4"]))
 
-(def day10-sample2
-  (map read-string
-       (str/split
-        "28
-33
-18
-42
-31
-14
-46
-20
-48
-47
-24
-23
-49
-45
-19
-38
-39
-11
-1
-32
-25
-35
-8
-17
-7
-9
-4
-2
-34
-10
-3" #"\n")))
+(def d10-s01
+  (t/parse
+   ["28"
+    "33"
+    "18"
+    "42"
+    "31"
+    "14"
+    "46"
+    "20"
+    "48"
+    "47"
+    "24"
+    "23"
+    "49"
+    "45"
+    "19"
+    "38"
+    "39"
+    "11"
+    "1"
+    "32"
+    "25"
+    "35"
+    "8"
+    "17"
+    "7"
+    "9"
+    "4"
+    "2"
+    "34"
+    "10"
+    "3"]))
 
 (deftest jolt-diff-counts
   (testing "Correctly determines the number of 1-jolt and 3-jolt differences"
-    (is (= [7 5]   (t/freq-steps day10-sample)))
-    (is (= [22 10] (t/freq-steps day10-sample2)))))
+    (is (= [7 5]   (t/freq-steps d10-s00)))
+    (is (= [22 10] (t/freq-steps d10-s01)))))
 
 (deftest combination-counts
   (testing "Correctly determines the number of unique valid combinations of adapters"
-    (is (= 8     (t/combination-count day10-sample)))
-    (is (= 19208 (t/combination-count day10-sample2)))))
+    (is (= 8     (t/combination-count d10-s00)))
+    (is (= 19208 (t/combination-count d10-s01)))))
+
+(def day10-input (u/parse-puzzle-input t/parse 2020 10))
 
 (deftest day10-part1-soln
   (testing "Reproduces the answer for day10, part1"
-    (is (= 2760 (t/day10-part1-soln)))))
+    (is (= 2760 (t/day10-part1-soln day10-input)))))
 
 (deftest day10-part2-soln
   (testing "Reproduces the answer for day10, part2"
-    (is (= 13816758796288 (t/day10-part2-soln)))))
+    (is (= 13816758796288 (t/day10-part2-soln day10-input)))))

--- a/test/aoc_clj/2020/day11_test.clj
+++ b/test/aoc_clj/2020/day11_test.clj
@@ -1,21 +1,20 @@
 (ns aoc-clj.2020.day11-test
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day11 :as t]))
 
 (def day11-sample
-  (t/ferry-seatmap
-   (str/split
-    "L.LL.LL.LL
-LLLLLLL.LL
-L.L.L..L..
-LLLL.LL.LL
-L.LL.LL.LL
-L.LLLLL.LL
-..L.L.....
-LLLLLLLLLL
-L.LLLLLL.L
-L.LLLLL.LL" #"\n")))
+  (t/parse
+   ["L.LL.LL.LL"
+    "LLLLLLL.LL"
+    "L.L.L..L.."
+    "LLLL.LL.LL"
+    "L.LL.LL.LL"
+    "L.LLLLL.LL"
+    "..L.L....."
+    "LLLLLLLLLL"
+    "L.LLLLLL.L"
+    "L.LLLLL.LL"]))
 
 (deftest part1-sample
   (testing "Reproduces the answer for part1 on the sample input"
@@ -25,12 +24,14 @@ L.LLLLL.LL" #"\n")))
   (testing "Reproduces the answer for part2 on the sample input"
     (is (= 26 (t/occupied-seats-when-static day11-sample 5 t/visibility)))))
 
+(def day11-input (u/parse-puzzle-input t/parse 2020 11))
+
 ;; FIXME: 2020.day11 too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/12
 (deftest ^:slow day11-part1-soln
   (testing "Reproduces the answer for day11, part1"
-    (is (= 2222 (t/day11-part1-soln)))))
+    (is (= 2222 (t/day11-part1-soln day11-input)))))
 
 (deftest ^:slow day11-part2-soln
   (testing "Reproduces the answer for day11, part2"
-    (is (= 2032 (t/day11-part2-soln)))))
+    (is (= 2032 (t/day11-part2-soln day11-input)))))

--- a/test/aoc_clj/2020/day12_test.clj
+++ b/test/aoc_clj/2020/day12_test.clj
@@ -1,16 +1,10 @@
 (ns aoc-clj.2020.day12-test
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day12 :as t]))
 
 (def day12-sample
-  (map t/parse
-       (str/split
-        "F10
-N3
-F7
-R90
-F11" #"\n")))
+  (t/parse ["F10" "N3" "F7" "R90" "F11"]))
 
 (deftest part1-sample
   (testing "Reproduces the answer for part1 on the sample input"
@@ -20,10 +14,12 @@ F11" #"\n")))
   (testing "Reproduces the answer for part2 on the sample input"
     (is (= 286 (t/final-distance day12-sample t/exec-cmd2)))))
 
+(def day12-input (u/parse-puzzle-input t/parse 2020 12))
+
 (deftest day12-part1-soln
   (testing "Reproduces the answer for day12, part1"
-    (is (= 1533 (t/day12-part1-soln)))))
+    (is (= 1533 (t/day12-part1-soln day12-input)))))
 
 (deftest day12-part2-soln
   (testing "Reproduces the answer for day12, part2"
-    (is (= 25235 (t/day12-part2-soln)))))
+    (is (= 25235 (t/day12-part2-soln day12-input)))))

--- a/test/aoc_clj/2020/day13_test.clj
+++ b/test/aoc_clj/2020/day13_test.clj
@@ -1,32 +1,34 @@
 (ns aoc-clj.2020.day13-test
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day13 :as t]))
 
-(def day13-sample1 (t/parse (str/split "939\n7,13,x,x,59,x,31,19" #"\n")))
-(def day13-sample2 {:buses '(17,x,13,19)})
-(def day13-sample3 {:buses '(67,7,59,61)})
-(def day13-sample4 {:buses '(67,x,7,59,61)})
-(def day13-sample5 {:buses '(67,7,x,59,61)})
-(def day13-sample6 {:buses '(1789,37,47,1889)})
+(def d13-s00 (t/parse ["939" "7,13,x,x,59,x,31,19"]))
+(def d13-s01 {:buses '(17,x,13,19)})
+(def d13-s02 {:buses '(67,7,59,61)})
+(def d13-s03 {:buses '(67,x,7,59,61)})
+(def d13-s04 {:buses '(67,7,x,59,61)})
+(def d13-s05 {:buses '(1789,37,47,1889)})
 
 (deftest earliest-bus-and-wait-time
   (testing "Can find the earliest bus available after time t"
-    (is (= [59 5] (t/earliest-bus-and-wait-time day13-sample1)))))
+    (is (= [59 5] (t/earliest-bus-and-wait-time d13-s00)))))
 
 (deftest earliest-time-for-consecutive-buses
   (testing "Can find the earliest time for consecutive buses to depart"
-    (is (= 1068781    (t/earliest-consecutive-buses day13-sample1)))
-    (is (= 3417       (t/earliest-consecutive-buses day13-sample2)))
-    (is (= 754018     (t/earliest-consecutive-buses day13-sample3)))
-    (is (= 779210     (t/earliest-consecutive-buses day13-sample4)))
-    (is (= 1261476    (t/earliest-consecutive-buses day13-sample5)))
-    (is (= 1202161486 (t/earliest-consecutive-buses day13-sample6)))))
+    (is (= 1068781    (t/earliest-consecutive-buses d13-s00)))
+    (is (= 3417       (t/earliest-consecutive-buses d13-s01)))
+    (is (= 754018     (t/earliest-consecutive-buses d13-s02)))
+    (is (= 779210     (t/earliest-consecutive-buses d13-s03)))
+    (is (= 1261476    (t/earliest-consecutive-buses d13-s04)))
+    (is (= 1202161486 (t/earliest-consecutive-buses d13-s05)))))
+
+(def day13-input (u/parse-puzzle-input t/parse 2020 13))
 
 (deftest day13-part1-soln
   (testing "Reproduces the answer for day13, part1"
-    (is (= 104 (t/day13-part1-soln)))))
+    (is (= 104 (t/day13-part1-soln day13-input)))))
 
 (deftest day13-part2-soln
   (testing "Reproduces the answer for day13, part2"
-    (is (= 842186186521918N (t/day13-part2-soln)))))
+    (is (= 842186186521918N (t/day13-part2-soln day13-input)))))

--- a/test/aoc_clj/2020/day14_test.clj
+++ b/test/aoc_clj/2020/day14_test.clj
@@ -1,11 +1,28 @@
 (ns aoc-clj.2020.day14-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day14 :as t]))
+
+;; (def d14-s00
+;;   (t/parse
+;;    ["mask = XXXXXXXXXXXXXXXXXXXXXXXXXXXXX1XXXX0X"
+;;     "mem[8] = 11"
+;;     "mem[7] = 101"
+;;     "mem[8] = 0"]))
+
+;; (def d14-s01
+;;   (t/parse
+;;    ["mask = 000000000000000000000000000000X1001X"
+;;     "mem[42] = 100"
+;;     "mask = 00000000000000000000000000000000X0XX"
+;;     "mem[26] = 1"]))
+
+(def day14-input (u/parse-puzzle-input t/parse 2020 14))
 
 (deftest day14-part1-soln
   (testing "Reproduces the answer for day14, part1"
-    (is (= 6631883285184 (t/day14-part1-soln)))))
+    (is (= 6631883285184 (t/day14-part1-soln day14-input)))))
 
-;; (deftest day14-part2-soln
-;;   (testing "Reproduces the answer for day14, part2"
-;;     (is (= 2 (t/day14-part2-soln)))))
+(deftest day14-part2-soln
+  (testing "Reproduces the answer for day14, part2"
+    (is (= 3161838538691 (t/day14-part2-soln day14-input)))))

--- a/test/aoc_clj/2020/day15_test.clj
+++ b/test/aoc_clj/2020/day15_test.clj
@@ -1,15 +1,15 @@
 (ns aoc-clj.2020.day15-test
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day15 :as t]))
 
-(def day15-sample1 (map read-string (str/split "0,3,6" #",")))
-(def day15-sample2 (map read-string (str/split "1,3,2" #",")))
-(def day15-sample3 (map read-string (str/split "2,1,3" #",")))
-(def day15-sample4 (map read-string (str/split "1,2,3" #",")))
-(def day15-sample5 (map read-string (str/split "2,3,1" #",")))
-(def day15-sample6 (map read-string (str/split "3,2,1" #",")))
-(def day15-sample7 (map read-string (str/split "3,1,2" #",")))
+(def day15-sample1 (t/parse ["0,3,6"]))
+(def day15-sample2 (t/parse ["1,3,2"]))
+(def day15-sample3 (t/parse ["2,1,3"]))
+(def day15-sample4 (t/parse ["1,2,3"]))
+(def day15-sample5 (t/parse ["2,3,1"]))
+(def day15-sample6 (t/parse ["3,2,1"]))
+(def day15-sample7 (t/parse ["3,1,2"]))
 
 (deftest find-2020th-number
   (testing "Can find the 2020th number in the sequence for sample data"
@@ -21,11 +21,12 @@
     (is (= 438  (last (t/memory-seq day15-sample6 2020))))
     (is (= 1836 (last (t/memory-seq day15-sample7 2020))))))
 
+(def day15-input (u/parse-puzzle-input t/parse 2020 15))
+
 (deftest day15-part1-soln
   (testing "Reproduces the answer for day15, part1"
-    (is (= 1428 (t/day15-part1-soln)))))
+    (is (= 1428 (t/day15-part1-soln day15-input)))))
 
-; Test is too slow with current implementation to run every time
-;; (deftest day15-part2-soln
-;;   (testing "Reproduces the answer for day15, part2"
-;;     (is (= 3718541 (t/day15-part2-soln)))))
+(deftest ^:slow day15-part2-soln
+  (testing "Reproduces the answer for day15, part2"
+    (is (= 3718541 (t/day15-part2-soln day15-input)))))

--- a/test/aoc_clj/2020/day16_test.clj
+++ b/test/aoc_clj/2020/day16_test.clj
@@ -1,11 +1,43 @@
 (ns aoc-clj.2020.day16-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day16 :as t]))
+
+;; (def day16-sample
+;;   (t/parse
+;;    "class: 1-3 or 5-7
+;; row: 6-11 or 33-44
+;; seat: 13-40 or 45-50
+
+;; your ticket:
+;; 7,1,14
+
+;; nearby tickets:
+;; 7,3,47
+;; 40,4,50
+;; 55,2,20
+;; 38,6,12"))
+
+;; (def day16-sample2
+;;   (t/parse
+;;    "class: 0-1 or 4-19
+;; row: 0-5 or 8-19
+;; seat: 0-13 or 16-19
+
+;; your ticket:
+;; 11,12,13
+
+;; nearby tickets:
+;; 3,9,18
+;; 15,1,5
+;; 5,14,9"))
+
+(def day16-input (u/parse-puzzle-input t/parse 2020 16))
 
 (deftest day16-part1-soln
   (testing "Reproduces the answer for day16, part1"
-    (is (= 25961 (t/day16-part1-soln)))))
+    (is (= 25961 (t/day16-part1-soln day16-input)))))
 
 (deftest day16-part2-soln
   (testing "Reproduces the answer for day16, part2"
-    (is (= 603409823791 (t/day16-part2-soln)))))
+    (is (= 603409823791 (t/day16-part2-soln day16-input)))))

--- a/test/aoc_clj/2020/day17_test.clj
+++ b/test/aoc_clj/2020/day17_test.clj
@@ -1,0 +1,20 @@
+(ns aoc-clj.2020.day17-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
+            [aoc-clj.2020.day17 :as t]))
+
+;; (def d17-s00
+;;   (t/parse
+;;    [".#."
+;;     "..#"
+;;     "###"]))
+
+(def day17-input (u/parse-puzzle-input t/parse 2020 17))
+
+(deftest day17-part1-soln
+  (testing "Reproduces the answer for day17, part1"
+    (is (= 267 (t/day17-part1-soln day17-input)))))
+
+(deftest ^:slow day17-part2-soln
+  (testing "Reproduces the answer for day17, part2"
+    (is (= 1812 (t/day17-part2-soln day17-input)))))

--- a/test/aoc_clj/2020/day18_test.clj
+++ b/test/aoc_clj/2020/day18_test.clj
@@ -1,38 +1,39 @@
 (ns aoc-clj.2020.day18-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day18 :as t]))
 
-(def day18-sample1 "1 + 2 * 3 + 4 * 5 + 6")
-(def day18-sample2 "1 + (2 * 3) + (4 * (5 + 6))")
-(def day18-sample3 "2 * 3 + (4 * 5)")
-(def day18-sample4 "5 + (8 * 3 + 9 + 3 * 4 * 3)")
-(def day18-sample5
-  "5 * 9 * (7 * 3 * 3 + 9 * 3 + (8 + 6 * 4))")
-(def day18-sample6
-  "((2 + 4 * 9) * (6 + 9 * 8 + 6) + 6) + 2 + 4 * 2")
+(def d18-s00 "1 + 2 * 3 + 4 * 5 + 6")
+(def d18-s01 "1 + (2 * 3) + (4 * (5 + 6))")
+(def d18-s02 "2 * 3 + (4 * 5)")
+(def d18-s03 "5 + (8 * 3 + 9 + 3 * 4 * 3)")
+(def d18-s04 "5 * 9 * (7 * 3 * 3 + 9 * 3 + (8 + 6 * 4))")
+(def d18-s05 "((2 + 4 * 9) * (6 + 9 * 8 + 6) + 6) + 2 + 4 * 2")
 
 (deftest infix-test
   (testing "Can correctly compute infix expressions"
-    (is (= 71    (t/infix (t/parse day18-sample1))))
-    (is (= 51    (t/infix (t/parse day18-sample2))))
-    (is (= 26    (t/infix (t/parse day18-sample3))))
-    (is (= 437   (t/infix (t/parse day18-sample4))))
-    (is (= 12240 (t/infix (t/parse day18-sample5))))
-    (is (= 13632 (t/infix (t/parse day18-sample6))))))
+    (is (= 71    (t/infix (t/interpret d18-s00))))
+    (is (= 51    (t/infix (t/interpret d18-s01))))
+    (is (= 26    (t/infix (t/interpret d18-s02))))
+    (is (= 437   (t/infix (t/interpret d18-s03))))
+    (is (= 12240 (t/infix (t/interpret d18-s04))))
+    (is (= 13632 (t/infix (t/interpret d18-s05))))))
 
 (deftest infix-test2
   (testing "Infix expressions with operator precedence"
-    (is (= 231    (t/infix (t/parse2 day18-sample1))))
-    (is (= 51     (t/infix (t/parse2 day18-sample2))))
-    (is (= 46     (t/infix (t/parse2 day18-sample3))))
-    (is (= 1445   (t/infix (t/parse2 day18-sample4))))
-    (is (= 669060 (t/infix (t/parse2 day18-sample5))))
-    (is (= 23340  (t/infix (t/parse2 day18-sample6))))))
+    (is (= 231    (t/infix (t/interpret2 d18-s00))))
+    (is (= 51     (t/infix (t/interpret2 d18-s01))))
+    (is (= 46     (t/infix (t/interpret2 d18-s02))))
+    (is (= 1445   (t/infix (t/interpret2 d18-s03))))
+    (is (= 669060 (t/infix (t/interpret2 d18-s04))))
+    (is (= 23340  (t/infix (t/interpret2 d18-s05))))))
+
+(def day18-input (u/parse-puzzle-input t/parse 2020 18))
 
 (deftest day18-part1-soln
   (testing "Reproduces the answer for day18, part1"
-    (is (= 69490582260 (t/day18-part1-soln)))))
+    (is (= 69490582260 (t/day18-part1-soln day18-input)))))
 
 (deftest day18-part2-soln
   (testing "Reproduces the answer for day18, part2"
-    (is (= 362464596624526 (t/day18-part2-soln)))))
+    (is (= 362464596624526 (t/day18-part2-soln day18-input)))))

--- a/test/aoc_clj/2020/day19_test.clj
+++ b/test/aoc_clj/2020/day19_test.clj
@@ -1,85 +1,88 @@
 (ns aoc-clj.2020.day19-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day19 :as t]))
 
-(def day19-sample1
+(def d19-s00
   (t/parse
-   "0: 4 1 5
-1: 2 3 | 3 2
-2: 4 4 | 5 5
-3: 4 5 | 5 4
-4: \"a\"
-5: \"b\"
+   ["0: 4 1 5"
+    "1: 2 3 | 3 2"
+    "2: 4 4 | 5 5"
+    "3: 4 5 | 5 4"
+    "4: \"a\""
+    "5: \"b\""
+    ""
+    "ababbb"
+    "bababa"
+    "abbbab"
+    "aaabbb"
+    "aaaabbb"]))
 
-ababbb
-bababa
-abbbab
-aaabbb
-aaaabbb"))
-
-(def day19-sample2
+(def d19-s01
   (t/parse
-   "42: 9 14 | 10 1
-9: 14 27 | 1 26
-10: 23 14 | 28 1
-1: \"a\"
-11: 42 31
-5: 1 14 | 15 1
-19: 14 1 | 14 14
-12: 24 14 | 19 1
-16: 15 1 | 14 14
-31: 14 17 | 1 13
-6: 14 14 | 1 14
-2: 1 24 | 14 4
-0: 8 11
-13: 14 3 | 1 12
-15: 1 | 14
-17: 14 2 | 1 7
-23: 25 1 | 22 14
-28: 16 1
-4: 1 1
-20: 14 14 | 1 15
-3: 5 14 | 16 1
-27: 1 6 | 14 18
-14: \"b\"
-21: 14 1 | 1 14
-25: 1 1 | 1 14
-22: 14 14
-8: 42
-26: 14 22 | 1 20
-18: 15 15
-7: 14 5 | 1 21
-24: 14 1
-
-abbbbbabbbaaaababbaabbbbabababbbabbbbbbabaaaa
-bbabbbbaabaabba
-babbbbaabbbbbabbbbbbaabaaabaaa
-aaabbbbbbaaaabaababaabababbabaaabbababababaaa
-bbbbbbbaaaabbbbaaabbabaaa
-bbbababbbbaaaaaaaabbababaaababaabab
-ababaaaaaabaaab
-ababaaaaabbbaba
-baabbaaaabbaaaababbaababb
-abbbbabbbbaaaababbbbbbaaaababb
-aaaaabbaabaaaaababaa
-aaaabbaaaabbaaa
-aaaabbaabbaaaaaaabbbabbbaaabbaabaaa
-babaaabbbaaabaababbaabababaaab
-aabbbbbaabbbaaaaaabbbbbababaaaaabbaaabba"))
+   ["42: 9 14 | 10 1"
+    "9: 14 27 | 1 26"
+    "10: 23 14 | 28 1"
+    "1: \"a\""
+    "11: 42 31"
+    "5: 1 14 | 15 1"
+    "19: 14 1 | 14 14"
+    "12: 24 14 | 19 1"
+    "16: 15 1 | 14 14"
+    "31: 14 17 | 1 13"
+    "6: 14 14 | 1 14"
+    "2: 1 24 | 14 4"
+    "0: 8 11"
+    "13: 14 3 | 1 12"
+    "15: 1 | 14"
+    "17: 14 2 | 1 7"
+    "23: 25 1 | 22 14"
+    "28: 16 1"
+    "4: 1 1"
+    "20: 14 14 | 1 15"
+    "3: 5 14 | 16 1"
+    "27: 1 6 | 14 18"
+    "14: \"b\""
+    "21: 14 1 | 1 14"
+    "25: 1 1 | 1 14"
+    "22: 14 14"
+    "8: 42"
+    "26: 14 22 | 1 20"
+    "18: 15 15"
+    "7: 14 5 | 1 21"
+    "24: 14 1"
+    ""
+    "abbbbbabbbaaaababbaabbbbabababbbabbbbbbabaaaa"
+    "bbabbbbaabaabba"
+    "babbbbaabbbbbabbbbbbaabaaabaaa"
+    "aaabbbbbbaaaabaababaabababbabaaabbababababaaa"
+    "bbbbbbbaaaabbbbaaabbabaaa"
+    "bbbababbbbaaaaaaaabbababaaababaabab"
+    "ababaaaaaabaaab"
+    "ababaaaaabbbaba"
+    "baabbaaaabbaaaababbaababb"
+    "abbbbabbbbaaaababbbbbbaaaababb"
+    "aaaaabbaabaaaaababaa"
+    "aaaabbaaaabbaaa"
+    "aaaabbaabbaaaaaaabbbabbbaaabbaabaaa"
+    "babaaabbbaaabaababbaabababaaab"
+    "aabbbbbaabbbaaaaaabbbbbababaaaaabbaaabba"]))
 
 (deftest straightforward-match
   (testing "The straightforward regexes match"
-    (is (= 2 (t/count-matches day19-sample1)))
-    (is (= 3 (t/count-matches day19-sample2)))))
+    (is (= 2 (t/count-matches d19-s00)))
+    (is (= 3 (t/count-matches d19-s01)))))
 
 (deftest special-match
   (testing "Regex matches with special part2 overrides"
-    (is (= 12 (t/count-matches day19-sample2 true)))))
+    (is (= 12 (t/count-matches d19-s01 true)))))
+
+(def day19-input (u/parse-puzzle-input t/parse 2020 19))
 
 (deftest day19-part1-soln
   (testing "Reproduces the answer for day19, part1"
-    (is (= 220 (t/day19-part1-soln)))))
+    (is (= 220 (t/day19-part1-soln day19-input)))))
 
 (deftest day19-part2-soln
   (testing "Reproduces the answer for day19, part2"
-    (is (= 439 (t/day19-part2-soln)))))
+    (is (= 439 (t/day19-part2-soln day19-input)))))

--- a/test/aoc_clj/2020/day20_test.clj
+++ b/test/aoc_clj/2020/day20_test.clj
@@ -1,9 +1,10 @@
 (ns aoc-clj.2020.day20-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day20 :as t]))
 
 (def day20-sample
-  (t/parse
+  (t/intermediate-parse
    "Tile 2311:
 ..##.#..#.
 ##..#.....
@@ -205,10 +206,12 @@ Tile 3079:
   (testing "Can find the correct number of sea monsters in a reassembled image"
     (is (= 2 (t/sea-monster-count (t/flipv (t/rotate (t/reassembled-image day20-sample))))))))
 
+(def day20-input (u/parse-puzzle-input t/parse 2020 20))
+
 (deftest day20-part1-soln
   (testing "Reproduces the answer for day20, part1"
-    (is (= 79412832860579 (t/day20-part1-soln)))))
+    (is (= 79412832860579 (t/day20-part1-soln day20-input)))))
 
 (deftest day20-part2-soln
   (testing "Reproduces the answer for day20, part2"
-    (is (= 2155 (t/day20-part2-soln)))))
+    (is (= 2155 (t/day20-part2-soln day20-input)))))

--- a/test/aoc_clj/2020/day21_test.clj
+++ b/test/aoc_clj/2020/day21_test.clj
@@ -1,0 +1,22 @@
+(ns aoc-clj.2020.day21-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
+            [aoc-clj.2020.day21 :as t]))
+
+;; (def d21-s00
+;;   (t/parse
+;;    ["mxmxvkd kfcds sqjhc nhms (contains dairy, fish)"
+;;     "trh fvjkl sbzzf mxmxvkd (contains dairy)"
+;;     "sqjhc fvjkl (contains soy)"
+;;     "sqjhc mxmxvkd sbzzf (contains fish)"]))
+
+(def day21-input (u/parse-puzzle-input t/parse 2020 21))
+
+(deftest day21-part1-soln
+  (testing "Reproduces the answer for day21, part1"
+    (is (= 2280 (t/day21-part1-soln day21-input)))))
+
+(deftest day21-part2-soln
+  (testing "Reproduces the answer for day21, part2"
+    (is (= "vfvvnm,bvgm,rdksxt,xknb,hxntcz,bktzrz,srzqtccv,gbtmdb"
+           (t/day21-part2-soln day21-input)))))

--- a/test/aoc_clj/2020/day22_test.clj
+++ b/test/aoc_clj/2020/day22_test.clj
@@ -1,9 +1,10 @@
 (ns aoc-clj.2020.day22-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day22 :as t]))
 
 (def day22-sample
-  (t/parse "Player 1:
+  (t/intermediate-parse "Player 1:
 9
 2
 6
@@ -18,7 +19,7 @@ Player 2:
 10"))
 
 (def day22-infinite-sample
-  (t/parse "Player 1:
+  (t/intermediate-parse "Player 1:
 43
 19
 
@@ -46,12 +47,14 @@ Player 2:
             :deck [7 5 6 2 4 1 10 8 9 3]}
            (t/recursive-combat day22-sample)))))
 
+(def day22-input (u/parse-puzzle-input t/parse 2020 22))
+
 (deftest day22-part1-soln
   (testing "Reproduces the answer for day22, part1"
-    (is (= 33772 (t/day22-part1-soln)))))
+    (is (= 33772 (t/day22-part1-soln day22-input)))))
 
 ;; FIXME: 2020.day22 part 2 too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/13
 (deftest ^:slow day22-part2-soln
   (testing "Reproduces the answer for day22, part2"
-    (is (= 35070 (t/day22-part2-soln)))))
+    (is (= 35070 (t/day22-part2-soln day22-input)))))

--- a/test/aoc_clj/2020/day23_test.clj
+++ b/test/aoc_clj/2020/day23_test.clj
@@ -1,33 +1,35 @@
 (ns aoc-clj.2020.day23-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day23 :as t]))
 
-(def day23-sample         [3 8 9 1 2 5 4 6 7])
-(def day23-sample-move001 [2 8 9 1 5 4 6 7 3])
-(def day23-sample-move002 [5 4 6 7 8 9 1 3 2])
-(def day23-sample-move003 [8 9 1 3 4 6 7 2 5])
-(def day23-sample-move004 [4 6 7 9 1 3 2 5 8])
-(def day23-sample-move010 [8 3 7 4 1 9 2 6 5])
-(def day23-sample-move100 [1 6 7 3 8 4 5 2 9])
+(def d23-s00         [3 8 9 1 2 5 4 6 7])
+(def d23-s00-move001 [2 8 9 1 5 4 6 7 3])
+(def d23-s00-move002 [5 4 6 7 8 9 1 3 2])
+(def d23-s00-move003 [8 9 1 3 4 6 7 2 5])
+(def d23-s00-move004 [4 6 7 9 1 3 2 5 8])
+(def d23-s00-move010 [8 3 7 4 1 9 2 6 5])
+(def d23-s00-move100 [1 6 7 3 8 4 5 2 9])
 
 (deftest moves
   (testing "Crab moves"
-    (is (= day23-sample-move001 (t/representation (t/n-moves day23-sample 1))))
-    (is (= day23-sample-move002 (t/representation (t/n-moves day23-sample 2))))
-    (is (= day23-sample-move003 (t/representation (t/n-moves day23-sample 3))))
-    (is (= day23-sample-move004 (t/representation (t/n-moves day23-sample 4))))
-    (is (= day23-sample-move010 (t/representation (t/n-moves day23-sample 10))))
-    (is (= day23-sample-move100 (t/representation (t/n-moves day23-sample 100))))))
+    (is (= d23-s00-move001 (t/representation (t/n-moves d23-s00 1))))
+    (is (= d23-s00-move002 (t/representation (t/n-moves d23-s00 2))))
+    (is (= d23-s00-move003 (t/representation (t/n-moves d23-s00 3))))
+    (is (= d23-s00-move004 (t/representation (t/n-moves d23-s00 4))))
+    (is (= d23-s00-move010 (t/representation (t/n-moves d23-s00 10))))
+    (is (= d23-s00-move100 (t/representation (t/n-moves d23-s00 100))))))
 
 ;; Too slow
 ;; (deftest big-moves
-;;   (is (= '(934001 159792) (take 2 (drop 1 (t/star-cups day23-sample 10000000))))))
+;;   (is (= '(934001 159792) (take 2 (drop 1 (t/star-cups d23-s00 10000000))))))
+
+(def day23-input (u/parse-puzzle-input t/parse 2020 23))
 
 (deftest day23-part1-soln
   (testing "Reproduces the answer for day23, part1"
-    (is (= "62934785" (t/day23-part1-soln)))))
+    (is (= "62934785" (t/day23-part1-soln day23-input)))))
 
-;; Too slow
-;; (deftest day23-part2-soln
-;;   (testing "Reproduces the answer for day23, part2"
-;;     (is (= 693659135400 (t/day23-part2-soln)))))
+(deftest ^:slow day23-part2-soln
+  (testing "Reproduces the answer for day23, part2"
+    (is (= 693659135400 (t/day23-part2-soln day23-input)))))

--- a/test/aoc_clj/2020/day24_test.clj
+++ b/test/aoc_clj/2020/day24_test.clj
@@ -1,30 +1,30 @@
 (ns aoc-clj.2020.day24-test
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day24 :as t]))
 
-(def day24-sample
-  (map t/parse-line
-       (str/split "sesenwnenenewseeswwswswwnenewsewsw
-neeenesenwnwwswnenewnwwsewnenwseswesw
-seswneswswsenwwnwse
-nwnwneseeswswnenewneswwnewseswneseene
-swweswneswnenwsewnwneneseenw
-eesenwseswswnenwswnwnwsewwnwsene
-sewnenenenesenwsewnenwwwse
-wenwwweseeeweswwwnwwe
-wsweesenenewnwwnwsenewsenwwsesesenwne
-neeswseenwwswnwswswnw
-nenwswwsewswnenenewsenwsenwnesesenew
-enewnwewneswsewnwswenweswnenwsenwsw
-sweneswneswneneenwnewenewwneswswnese
-swwesenesewenwneswnwwneseswwne
-enesenwswwswneneswsenwnewswseenwsese
-wnwnesenesenenwwnenwsewesewsesesew
-nenewswnwewswnenesenwnesewesw
-eneswnwswnwsenenwnwnwwseeswneewsenese
-neswnwewnwnwseenwseesewsenwsweewe
-wseweeenwnesenwwwswnew" #"\n")))
+(def d24-s00
+  (t/parse
+   ["sesenwnenenewseeswwswswwnenewsewsw"
+    "neeenesenwnwwswnenewnwwsewnenwseswesw"
+    "seswneswswsenwwnwse"
+    "nwnwneseeswswnenewneswwnewseswneseene"
+    "swweswneswnenwsewnwneneseenw"
+    "eesenwseswswnenwswnwnwsewwnwsene"
+    "sewnenenenesenwsewnenwwwse"
+    "wenwwweseeeweswwwnwwe"
+    "wsweesenenewnwwnwsenewsenwwsesesenwne"
+    "neeswseenwwswnwswswnw"
+    "nenwswwsewswnenenewsenwsenwnesesenew"
+    "enewnwewneswsewnwswenweswnenwsenwsw"
+    "sweneswneswneneenwnewenewwneswswnese"
+    "swwesenesewenwneswnwwneseswwne"
+    "enesenwswwswneneswsenwnewswseenwsese"
+    "wnwnesenesenenwwnenwsewesewsesesew"
+    "nenewswnwewswnenesenwnesewesw"
+    "eneswnwswnwsenenwnwnwwseeswneewsenese"
+    "neswnwewnwnwseenwseesewsenwsweewe"
+    "wseweeenwnesenwwwswnew "]))
 
 (deftest parser
   (testing "The parser tokenizes the strings correctly"
@@ -34,27 +34,29 @@ wseweeenwnesenwwwswnew" #"\n")))
         (t/parse-line "wseweeenwnesenwwwswnew"))))
 
 (deftest identify-black-tiles
-  (is (= 10 (count (t/black-tiles day24-sample)))))
+  (is (= 10 (count (t/black-tiles d24-s00)))))
 
 (deftest evolution
   (testing "Can correctly apply the neighbor rules to evolve the tiles"
-    (is (= 15 (count (t/black-tiles-on-day day24-sample 1))))
-    (is (= 12 (count (t/black-tiles-on-day day24-sample 2))))
-    (is (= 25 (count (t/black-tiles-on-day day24-sample 3))))
-    (is (= 14 (count (t/black-tiles-on-day day24-sample 4))))
-    (is (= 23 (count (t/black-tiles-on-day day24-sample 5))))
-    (is (= 28 (count (t/black-tiles-on-day day24-sample 6))))
-    (is (= 41 (count (t/black-tiles-on-day day24-sample 7))))
-    (is (= 37 (count (t/black-tiles-on-day day24-sample 8))))
-    (is (= 49 (count (t/black-tiles-on-day day24-sample 9))))
-    (is (= 37 (count (t/black-tiles-on-day day24-sample 10))))))
+    (is (= 15 (count (t/black-tiles-on-day d24-s00 1))))
+    (is (= 12 (count (t/black-tiles-on-day d24-s00 2))))
+    (is (= 25 (count (t/black-tiles-on-day d24-s00 3))))
+    (is (= 14 (count (t/black-tiles-on-day d24-s00 4))))
+    (is (= 23 (count (t/black-tiles-on-day d24-s00 5))))
+    (is (= 28 (count (t/black-tiles-on-day d24-s00 6))))
+    (is (= 41 (count (t/black-tiles-on-day d24-s00 7))))
+    (is (= 37 (count (t/black-tiles-on-day d24-s00 8))))
+    (is (= 49 (count (t/black-tiles-on-day d24-s00 9))))
+    (is (= 37 (count (t/black-tiles-on-day d24-s00 10))))))
+
+(def day24-input (u/parse-puzzle-input t/parse 2020 24))
 
 (deftest day24-part1-soln
   (testing "Reproduces the answer for day24, part1"
-    (is (= 436 (t/day24-part1-soln)))))
+    (is (= 436 (t/day24-part1-soln day24-input)))))
 
 ;; FIXME: 2020.day24 part 2 too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/14
 (deftest ^:slow day24-part2-soln
   (testing "Reproduces the answer for day24, part2"
-    (is (= 4133 (t/day24-part2-soln)))))
+    (is (= 4133 (t/day24-part2-soln day24-input)))))

--- a/test/aoc_clj/2020/day25_test.clj
+++ b/test/aoc_clj/2020/day25_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2020.day25-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2020.day25 :as t]))
 
 (def day25-sample [5764801 17807724])
@@ -10,6 +11,8 @@
     (is (= 11 (t/loop-size (second day25-sample))))
     (is (= 14897079 (t/encryption-key day25-sample)))))
 
+(def day25-input (u/parse-puzzle-input t/parse 2020 25))
+
 (deftest day25-part1-soln
   (testing "Reproduces the answer for day25, part1"
-    (is (= 6421487 (t/day25-part1-soln)))))
+    (is (= 6421487 (t/day25-part1-soln day25-input)))))

--- a/test/aoc_clj/2021/day01_test.clj
+++ b/test/aoc_clj/2021/day01_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2021.day01-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day01 :as t]))
 
-(def day01-sample
+(def d01-s00
   [199
    200
    208
@@ -16,7 +17,7 @@
 
 (deftest number-of-increases
   (testing "Finds the number of times the depth increases relative to the previous value"
-    (is (= 7 (t/increases day01-sample)))))
+    (is (= 7 (t/increases d01-s00)))))
 
 (deftest sliding-window-sums
   (testing "Correctly adds up each triplet of 3 values in a sliding window"
@@ -28,12 +29,14 @@
          716
          769
          792]
-        (t/sliding-window-sum day01-sample))))
+        (t/sliding-window-sum d01-s00))))
+
+(def day01-input (u/parse-puzzle-input t/parse 2021 1))
 
 (deftest day01-part1-soln
   (testing "Reproduces the answer for day01, part1"
-    (is (= 1292 (t/day01-part1-soln)))))
+    (is (= 1292 (t/day01-part1-soln day01-input)))))
 
 (deftest day01-part2-soln
   (testing "Reproduces the answer for day01, part2"
-    (is (= 1262 (t/day01-part2-soln)))))
+    (is (= 1262 (t/day01-part2-soln day01-input)))))

--- a/test/aoc_clj/2021/day02_test.clj
+++ b/test/aoc_clj/2021/day02_test.clj
@@ -1,28 +1,31 @@
 (ns aoc-clj.2021.day02-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day02 :as t]))
 
-(def day02-example
-  (map t/parse-line
-       ["forward 5"
-        "down 5"
-        "forward 8"
-        "up 3"
-        "down 8"
-        "forward 2"]))
+(def d02-s00
+  (t/parse
+   ["forward 5"
+    "down 5"
+    "forward 8"
+    "up 3"
+    "down 8"
+    "forward 2"]))
 
 (deftest sub-moves-correctly-part1
   (testing "Sub ends up in the correct location following the part 1 rules"
-    (is (= [15 10] (t/sub-end-state day02-example t/part1-rules)))))
+    (is (= [15 10] (t/sub-end-state d02-s00 t/part1-rules)))))
 
 (deftest sub-moves-correctly-part2
   (testing "Sub ends up in the correct location following the part 2 rules"
-    (is (= [15 60 10] (t/sub-end-state day02-example t/part2-rules)))))
+    (is (= [15 60 10] (t/sub-end-state d02-s00 t/part2-rules)))))
+
+(def day02-input (u/parse-puzzle-input t/parse 2021 2))
 
 (deftest day02-part1-soln
   (testing "Reproduces the answer for day02, part1"
-    (is (= 2272262 (t/day02-part1-soln)))))
+    (is (= 2272262 (t/day02-part1-soln day02-input)))))
 
 (deftest day02-part2-soln
   (testing "Reproduces the answer for day02, part2"
-    (is (= 2134882034 (t/day02-part2-soln)))))
+    (is (= 2134882034 (t/day02-part2-soln day02-input)))))

--- a/test/aoc_clj/2021/day03_test.clj
+++ b/test/aoc_clj/2021/day03_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2021.day03-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day03 :as t]))
 
-(def day03-sample
+(def d03-s00
   ["00100"
    "11110"
    "10110"
@@ -18,16 +19,18 @@
 
 (deftest power-consumption
   (testing "Computes gamma and epsilon values from sample data"
-    (is (= [22 9] (t/power-consumption day03-sample)))))
+    (is (= [22 9] (t/power-consumption d03-s00)))))
 
 (deftest gamma-and-epsilon
   (testing "Computes oxygen and co2 values from sample data"
-    (is (= [23 10] (t/life-support day03-sample)))))
+    (is (= [23 10] (t/life-support d03-s00)))))
+
+(def day03-input (u/parse-puzzle-input t/parse 2021 3))
 
 (deftest day03-part1-soln
   (testing "Reproduces the answer for day03, part1"
-    (is (= 3959450 (t/day03-part1-soln)))))
+    (is (= 3959450 (t/day03-part1-soln day03-input)))))
 
 (deftest day03-part2-soln
   (testing "Reproduces the answer for day03, part2"
-    (is (= 7440311 (t/day03-part2-soln)))))
+    (is (= 7440311 (t/day03-part2-soln day03-input)))))

--- a/test/aoc_clj/2021/day04_test.clj
+++ b/test/aoc_clj/2021/day04_test.clj
@@ -1,9 +1,10 @@
 (ns aoc-clj.2021.day04-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day04 :as t]))
 
 (def day04-sample
-  (t/parse-input
+  (t/parse
    ["7,4,9,5,11,17,23,2,0,14,21,24,10,16,13,6,15,25,12,22,18,20,8,19,3,26,1"
     ""
     "22 13 17 11  0"
@@ -32,10 +33,12 @@
   (testing "Computes the board score of the last winning bingo card"
     (is (= 1924 (t/last-winning-board-score day04-sample)))))
 
+(def day04-input (u/parse-puzzle-input t/parse 2021 4))
+
 (deftest day04-part1-soln
   (testing "Reproduces the answer for day04, part1"
-    (is (= 23177 (t/day04-part1-soln)))))
+    (is (= 23177 (t/day04-part1-soln day04-input)))))
 
 (deftest day04-part2-soln
   (testing "Reproduces the answer for day04, part2"
-    (is (= 6804 (t/day04-part2-soln)))))
+    (is (= 6804 (t/day04-part2-soln day04-input)))))

--- a/test/aoc_clj/2021/day05_test.clj
+++ b/test/aoc_clj/2021/day05_test.clj
@@ -1,43 +1,46 @@
 (ns aoc-clj.2021.day05-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day05 :as t]))
 
-(def day05-sample
-  (map t/parse-line
-       ["0,9 -> 5,9"
-        "8,0 -> 0,8"
-        "9,4 -> 3,4"
-        "2,2 -> 2,1"
-        "7,0 -> 7,4"
-        "6,4 -> 2,0"
-        "0,9 -> 2,9"
-        "3,4 -> 1,4"
-        "0,0 -> 8,8"
-        "5,5 -> 8,2"]))
+(def d05-s00
+  (t/parse
+   ["0,9 -> 5,9"
+    "8,0 -> 0,8"
+    "9,4 -> 3,4"
+    "2,2 -> 2,1"
+    "7,0 -> 7,4"
+    "6,4 -> 2,0"
+    "0,9 -> 2,9"
+    "3,4 -> 1,4"
+    "0,0 -> 8,8"
+    "5,5 -> 8,2"]))
 
 (deftest non-diagonal-overlapping-points
   (testing "Computes the number of overlapping points in sample data"
-    (is (= 5 (t/overlapping-points day05-sample false)))))
+    (is (= 5 (t/overlapping-points d05-s00 false)))))
 
 (deftest diagonal-line-points
   (testing "Computes the points along a line for diagonals"
     (is (= [[8 0] [7 1] [6 2] [5 3] [4 4] [3 5] [2 6] [1 7] [0 8]]
-           (t/line-points (nth day05-sample 1))))
+           (t/line-points (nth d05-s00 1))))
     (is (= [[6 4] [5 3] [4 2] [3 1] [2 0]]
-           (t/line-points (nth day05-sample 5))))
+           (t/line-points (nth d05-s00 5))))
     (is (= [[0 0] [1 1] [2 2] [3 3] [4 4] [5 5] [6 6] [7 7] [8 8]]
-           (t/line-points (nth day05-sample 8))))
+           (t/line-points (nth d05-s00 8))))
     (is (= [[5 5] [6 4] [7 3] [8 2]]
-           (t/line-points (nth day05-sample 9))))))
+           (t/line-points (nth d05-s00 9))))))
 
 (deftest all-overlapping-points
   (testing "Counts the number of overlapping points in sample data, including diagonals"
-    (is (= 12 (t/overlapping-points day05-sample true)))))
+    (is (= 12 (t/overlapping-points d05-s00 true)))))
+
+(def day05-input (u/parse-puzzle-input t/parse 2021 5))
 
 (deftest day05-part1-soln
   (testing "Reproduces the answer for day05, part1"
-    (is (= 7674 (t/day05-part1-soln)))))
+    (is (= 7674 (t/day05-part1-soln day05-input)))))
 
 (deftest day05-part2-soln
   (testing "Reproduces the answer for day05, part2"
-    (is (= 20898 (t/day05-part2-soln)))))
+    (is (= 20898 (t/day05-part2-soln day05-input)))))

--- a/test/aoc_clj/2021/day06_test.clj
+++ b/test/aoc_clj/2021/day06_test.clj
@@ -1,22 +1,23 @@
 (ns aoc-clj.2021.day06-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day06 :as t]))
 
-(def day06-sample
+(def d06-s00
   (t/parse ["3,4,3,1,2"]))
 
 (deftest fish-after-n-days
   (testing "Computes the number of fish after n days with sample data"
-    (is (= 26   (t/fish-after-n-days day06-sample 18)))
-    (is (= 5934 (t/fish-after-n-days day06-sample 80)))
-    (is (= 26984457539 (t/fish-after-n-days day06-sample 256)))))
+    (is (= 26   (t/fish-after-n-days d06-s00 18)))
+    (is (= 5934 (t/fish-after-n-days d06-s00 80)))
+    (is (= 26984457539 (t/fish-after-n-days d06-s00 256)))))
+
+(def day06-input (u/parse-puzzle-input t/parse 2021 6))
 
 (deftest day06-part1-soln
   (testing "Reproduces the answer for day06, part1"
-    (is (= 386755 (t/day06-part1-soln)))))
+    (is (= 386755 (t/day06-part1-soln day06-input)))))
 
 (deftest day06-part2-soln
   (testing "Reproduces the answer for day06, part2"
-    (is (= 1732731810807 (t/day06-part2-soln)))))
-
-
+    (is (= 1732731810807 (t/day06-part2-soln day06-input)))))

--- a/test/aoc_clj/2021/day07_test.clj
+++ b/test/aoc_clj/2021/day07_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2021.day07-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day07 :as t]))
 
 (def day07-sample (t/parse ["16,1,2,0,4,2,7,1,2,14"]))
@@ -12,10 +13,12 @@
   (testing "Computes minimum fuel for sample data in part2 rules"
     (is (= 168 (t/min-fuel-part2 day07-sample)))))
 
+(def day07-input (u/parse-puzzle-input t/parse 2021 7))
+
 (deftest day07-part1-soln
   (testing "Reproduces the answer for day07, part1"
-    (is (= 349769 (t/day07-part1-soln)))))
+    (is (= 349769 (t/day07-part1-soln day07-input)))))
 
 (deftest day07-part2-soln
   (testing "Reproduces the answer for day07, part2"
-    (is (= 99540554 (t/day07-part2-soln)))))
+    (is (= 99540554 (t/day07-part2-soln day07-input)))))

--- a/test/aoc_clj/2021/day08_test.clj
+++ b/test/aoc_clj/2021/day08_test.clj
@@ -1,41 +1,44 @@
 (ns aoc-clj.2021.day08-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day08 :as t]))
 
-(def day08-sample1
+(def d08-s00
   (t/parse-line "acedgfb cdfbe gcdfa fbcad dab cefabd cdfgeb eafb cagedb ab | cdfeb fcadb cdfeb cdbaf"))
 
-(def day08-sample2
-  (map t/parse-line
-       ["be cfbegad cbdgef fgaecd cgeb fdcge agebfd fecdb fabcd edb | fdgacbe cefdb cefbgd gcbe"
-        "edbfga begcd cbg gc gcadebf fbgde acbgfd abcde gfcbed gfec | fcgedb cgb dgebacf gc"
-        "fgaebd cg bdaec gdafb agbcfd gdcbef bgcad gfac gcb cdgabef | cg cg fdcagb cbg"
-        "fbegcd cbd adcefb dageb afcb bc aefdc ecdab fgdeca fcdbega | efabcd cedba gadfec cb"
-        "aecbfdg fbg gf bafeg dbefa fcge gcbea fcaegb dgceab fcbdga | gecf egdcabf bgf bfgea"
-        "fgeab ca afcebg bdacfeg cfaedg gcfdb baec bfadeg bafgc acf | gebdcfa ecba ca fadegcb"
-        "dbcfg fgd bdegcaf fgec aegbdf ecdfab fbedc dacgb gdcebf gf | cefg dcbef fcge gbcadfe"
-        "bdfegc cbegaf gecbf dfcage bdacg ed bedf ced adcbefg gebcd | ed bcgafe cdgba cbgef"
-        "egadfb cdbfeg cegd fecab cgb gbdefca cg fgcdab egfdb bfceg | gbdfcae bgc cg cgb"
-        "gcafb gcf dcaebfg ecagb gf abcdeg gaef cafbge fdbac fegbdc | fgae cfgab fg bagce"]))
+(def d08-s01
+  (t/parse
+   ["be cfbegad cbdgef fgaecd cgeb fdcge agebfd fecdb fabcd edb | fdgacbe cefdb cefbgd gcbe"
+    "edbfga begcd cbg gc gcadebf fbgde acbgfd abcde gfcbed gfec | fcgedb cgb dgebacf gc"
+    "fgaebd cg bdaec gdafb agbcfd gdcbef bgcad gfac gcb cdgabef | cg cg fdcagb cbg"
+    "fbegcd cbd adcefb dageb afcb bc aefdc ecdab fgdeca fcdbega | efabcd cedba gadfec cb"
+    "aecbfdg fbg gf bafeg dbefa fcge gcbea fcaegb dgceab fcbdga | gecf egdcabf bgf bfgea"
+    "fgeab ca afcebg bdacfeg cfaedg gcfdb baec bfadeg bafgc acf | gebdcfa ecba ca fadegcb"
+    "dbcfg fgd bdegcaf fgec aegbdf ecdfab fbedc dacgb gdcebf gf | cefg dcbef fcge gbcadfe"
+    "bdfegc cbegaf gecbf dfcage bdacg ed bedf ced adcbefg gebcd | ed bcgafe cdgba cbgef"
+    "egadfb cdbfeg cegd fecab cgb gbdefca cg fgcdab egfdb bfceg | gbdfcae bgc cg cgb"
+    "gcafb gcf dcaebfg ecagb gf abcdeg gaef cafbge fdbac fegbdc | fgae cfgab fg bagce"]))
 
 (deftest total-easy-digits-count
   (testing "Counts all easy digit codes in sample data"
-    (is (= 26 (t/total-easy-digits-count day08-sample2)))))
+    (is (= 26 (t/total-easy-digits-count d08-s01)))))
 
 (deftest decode-notes
   (testing "Can decode the digit codes in sample data"
-    (is (= 5353 (t/decode-notes day08-sample1)))
+    (is (= 5353 (t/decode-notes d08-s00)))
     (is (= [8394 9781 1197 9361 4873 8418 4548 1625 8717 4315]
-           (map t/decode-notes day08-sample2))))
+           (map t/decode-notes d08-s01))))
 
   (deftest sum-of-decoded-digits
     (testing "Can add up all the decoded digits from the sample data"
-      (is (= 61229 (t/sum-of-decoded-digits day08-sample2))))))
+      (is (= 61229 (t/sum-of-decoded-digits d08-s01))))))
+
+(def day08-input (u/parse-puzzle-input t/parse 2021 8))
 
 (deftest day08-part1-soln
   (testing "Reproduces the answer for day08, part1"
-    (is (= 493 (t/day08-part1-soln)))))
+    (is (= 493 (t/day08-part1-soln day08-input)))))
 
 (deftest day08-part2-soln
   (testing "Reproduces the answer for day08, part2"
-    (is (= 1010460 (t/day08-part2-soln)))))
+    (is (= 1010460 (t/day08-part2-soln day08-input)))))

--- a/test/aoc_clj/2021/day09_test.clj
+++ b/test/aoc_clj/2021/day09_test.clj
@@ -1,17 +1,15 @@
 (ns aoc-clj.2021.day09-test
   (:require [clojure.test :refer [deftest testing is]]
-            [aoc-clj.utils.grid.mapgrid :as mapgrid]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day09 :as t]))
 
 (def day09-sample
-  (:grid
-   (mapgrid/lists->MapGrid2D
-    (map t/parse-line
-         ["2199943210"
-          "3987894921"
-          "9856789892"
-          "8767896789"
-          "9899965678"]))))
+  (t/parse
+   ["2199943210"
+    "3987894921"
+    "9856789892"
+    "8767896789"
+    "9899965678"]))
 
 (deftest risk-level-sum
   (testing "Adds up the 'risk levels' of the lowest points in sample"
@@ -21,10 +19,12 @@
   (testing "multiplies the basin size of the three largest basins in sample"
     (is (= 1134 (t/three-largest-basins-product day09-sample)))))
 
+(def day09-input (u/parse-puzzle-input t/parse 2021 9))
+
 (deftest day09-part1-soln
   (testing "Reproduces the answer for day09, part1"
-    (is (= 588 (t/day09-part1-soln)))))
+    (is (= 588 (t/day09-part1-soln day09-input)))))
 
 (deftest day09-part2-soln
   (testing "Reproduces the answer for day09, part2"
-    (is (= 964712 (t/day09-part2-soln)))))
+    (is (= 964712 (t/day09-part2-soln day09-input)))))

--- a/test/aoc_clj/2021/day10_test.clj
+++ b/test/aoc_clj/2021/day10_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2021.day10-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day10 :as t]))
 
-(def day10-sample
+(def d10-s00
   ["[({(<(())[]>[[{[]{<()<>>"
    "[(()[<>])]({[<{<<[]>>("
    "{([(<{}[<>[]}>{[]{[(<()>"
@@ -16,21 +17,23 @@
 
 (deftest syntax-error-score
   (testing "Sum of illegal char scores in sample"
-    (is (= 26397 (t/syntax-error-score day10-sample)))))
+    (is (= 26397 (t/syntax-error-score d10-s00)))))
 
 (deftest completion-scores
   (testing "Computes completion scores for sample data"
     (is (= '(288957 5566 1480781 995444 294)
-           (t/completion-scores day10-sample)))))
+           (t/completion-scores d10-s00)))))
 
 (deftest middle-completion-score
   (testing "Finds the median completion score for sample data"
-    (is (= 288957 (t/middle-completion-score day10-sample)))))
+    (is (= 288957 (t/middle-completion-score d10-s00)))))
+
+(def day10-input (u/parse-puzzle-input t/parse 2021 10))
 
 (deftest day10-part1-soln
   (testing "Reproduces the answer for day10, part1"
-    (is (= 394647 (t/day10-part1-soln)))))
+    (is (= 394647 (t/day10-part1-soln day10-input)))))
 
 (deftest day10-part2-soln
   (testing "Reproduces the answer for day10, part2"
-    (is (= 2380061249 (t/day10-part2-soln)))))
+    (is (= 2380061249 (t/day10-part2-soln day10-input)))))

--- a/test/aoc_clj/2021/day11_test.clj
+++ b/test/aoc_clj/2021/day11_test.clj
@@ -1,10 +1,10 @@
 (ns aoc-clj.2021.day11-test
   (:require [clojure.test :refer [deftest testing is]]
-            [aoc-clj.utils.grid.mapgrid :as mapgrid]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day11 :as t]))
 
 (def day11-sample
-  (->>
+  (t/parse
    ["5483143223"
     "2745854711"
     "5264556173"
@@ -14,10 +14,7 @@
     "2176841721"
     "6882881134"
     "4846848554"
-    "5283751526"]
-   (map t/parse-line)
-   mapgrid/lists->MapGrid2D
-   :grid))
+    "5283751526"]))
 
 (deftest flashes-after-100-steps
   (testing "Counts total number of flashes after 100 steps in sample data"
@@ -27,10 +24,12 @@
   (testing "Counts number of steps before all flashes are synchronized"
     (is (= 195 (t/steps-until-sync day11-sample)))))
 
+(def day11-input (u/parse-puzzle-input t/parse 2021 11))
+
 (deftest day11-part1-soln
   (testing "Reproduces the answer for day11, part1"
-    (is (= 1634 (t/day11-part1-soln)))))
+    (is (= 1634 (t/day11-part1-soln day11-input)))))
 
 (deftest day11-part2-soln
   (testing "Reproduces the answer for day11, part2"
-    (is (= 210 (t/day11-part2-soln)))))
+    (is (= 210 (t/day11-part2-soln day11-input)))))

--- a/test/aoc_clj/2021/day12_test.clj
+++ b/test/aoc_clj/2021/day12_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2021.day12-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day12 :as t]))
 
-(def day12-sample1
+(def d12-s00
   (t/parse
    ["start-A"
     "start-b"
@@ -12,7 +13,7 @@
     "A-end"
     "b-end"]))
 
-(def day12-sample2
+(def d12-s01
   (t/parse
    ["dc-end"
     "HN-start"
@@ -25,7 +26,7 @@
     "kj-HN"
     "kj-dc"]))
 
-(def day12-sample3
+(def d12-s02
   (t/parse
    ["fs-end"
     "he-DX"
@@ -48,21 +49,22 @@
 
 (deftest count-of-map-paths
   (testing "Correctly counts the number of unique paths in sample data"
-    (is (= 10  (count (t/map-cave day12-sample1))))
-    (is (= 19  (count (t/map-cave day12-sample2))))
-    (is (= 226 (count (t/map-cave day12-sample3))))))
+    (is (= 10  (count (t/map-cave d12-s00))))
+    (is (= 19  (count (t/map-cave d12-s01))))
+    (is (= 226 (count (t/map-cave d12-s02))))))
 
 (deftest count-of-map-paths-part2
   (testing "Correctly counts the number of unique paths in sample data with part2 logic"
-    (is (= 36   (count (t/map-cave day12-sample1 t/allowed-part2?))))
-    (is (= 103  (count (t/map-cave day12-sample2 t/allowed-part2?))))
-    (is (= 3509 (count (t/map-cave day12-sample3 t/allowed-part2?))))))
+    (is (= 36   (count (t/map-cave d12-s00 t/allowed-part2?))))
+    (is (= 103  (count (t/map-cave d12-s01 t/allowed-part2?))))
+    (is (= 3509 (count (t/map-cave d12-s02 t/allowed-part2?))))))
+
+(def day12-input (u/parse-puzzle-input t/parse 2021 12))
 
 (deftest day12-part1-soln
   (testing "Reproduces the answer for day12, part1"
-    (is (= 5874 (t/day12-part1-soln)))))
+    (is (= 5874 (t/day12-part1-soln day12-input)))))
 
-;; Test validated but too slow to run regularly
-;; (deftest day12-part2-soln
-;;   (testing "Reproduces the answer for day12, part2"
-;;     (is (= 153592 (t/day12-part2-soln)))))
+(deftest ^:slow day12-part2-soln
+  (testing "Reproduces the answer for day12, part2"
+    (is (= 153592 (t/day12-part2-soln day12-input)))))

--- a/test/aoc_clj/2021/day13_test.clj
+++ b/test/aoc_clj/2021/day13_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2021.day13-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day13 :as t]))
 
-(def day13-sample
+(def d13-s00
   (t/parse
    ["6,10"
     "0,14"
@@ -28,7 +29,7 @@
 
 (deftest dots-after-first-fold
   (testing "Counts the dots after only one fold in sample data"
-    (is (= 17 (t/dots-after-first-fold day13-sample)))))
+    (is (= 17 (t/dots-after-first-fold d13-s00)))))
 
 (deftest complete-folds
   (testing "Returns the 16 dots after all folds in sample data"
@@ -37,15 +38,14 @@
              [0 2]                   [4 2]
              [0 3]                   [4 3]
              [0 4] [1 4] [2 4] [3 4] [4 4]}
-           (t/complete-folds day13-sample)))))
+           (t/complete-folds d13-s00)))))
+
+(def day13-input (u/parse-puzzle-input t/parse 2021 13))
 
 (deftest day13-part1-soln
   (testing "Reproduces the answer for day13, part1"
-    (is (= 621 (t/day13-part1-soln)))))
+    (is (= 621 (t/day13-part1-soln day13-input)))))
 
-;; Day 13 Part 2 solution emits a string that
-;; when printed, can be read as a set of upper-case
-;; letters
-;; (deftest day13-part2-soln
-;;   (testing "Reproduces the answer for day13, part2"
-;;     (is (= "HKUJGAJZ" (t/day13-part2-soln)))))
+(deftest day13-part2-soln
+  (testing "Reproduces the answer for day13, part2"
+    (is (= "HKUJGAJZ" (t/day13-part2-soln day13-input)))))

--- a/test/aoc_clj/2021/day14_test.clj
+++ b/test/aoc_clj/2021/day14_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2021.day14-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day14 :as t]))
 
-(def day14-sample
+(def d14-s00
   (t/parse
    ["NNCB"
     ""
@@ -26,27 +27,29 @@
 (deftest substitution-rule
   (testing "The pair-insert substitution rule works on sample"
     (is (= "NCNBCHB"
-           (:template (t/step day14-sample))))
+           (:template (t/step d14-s00))))
     (is (= "NBCCNBBBCBHCB"
-           (:template (t/step (t/step day14-sample)))))
+           (:template (t/step (t/step d14-s00)))))
     (is (= "NBBBCNCCNBBNBNBBCHBHHBCHB"
-           (:template (t/step (t/step (t/step day14-sample))))))
+           (:template (t/step (t/step (t/step d14-s00))))))
     (is (= "NBBNBNBBCCNBCNCCNBBNBBNBBBNBBNBBCBHCBHHNHCBBCBHCB"
-           (:template (t/step (t/step (t/step (t/step day14-sample)))))))))
+           (:template (t/step (t/step (t/step (t/step d14-s00)))))))))
 
 (deftest direct-most-minus-least-common-at-ten
   (testing "Most frequent element minus least common after 10 steps using direct impl"
-    (is (= 1588 (t/direct-most-minus-least-common-at-n day14-sample 10)))))
+    (is (= 1588 (t/direct-most-minus-least-common-at-n d14-s00 10)))))
 
 (deftest most-minus-least-common-at-ten
   (testing "Most frequent element minus least common after 10 steps using efficient impl"
-    (is (= 1588 (t/most-minus-least-common-at-n day14-sample 10)))
-    (is (= 2188189693529 (t/most-minus-least-common-at-n day14-sample 40)))))
+    (is (= 1588 (t/most-minus-least-common-at-n d14-s00 10)))
+    (is (= 2188189693529 (t/most-minus-least-common-at-n d14-s00 40)))))
+
+(def day14-input (u/parse-puzzle-input t/parse 2021 14))
 
 (deftest day14-part1-soln
   (testing "Reproduces the answer for day14, part1"
-    (is (= 2712 (t/day14-part1-soln)))))
+    (is (= 2712 (t/day14-part1-soln day14-input)))))
 
 (deftest day14-part2-soln
   (testing "Reproduces the answer for day14, part2"
-    (is (= 8336623059567 (t/day14-part2-soln)))))
+    (is (= 8336623059567 (t/day14-part2-soln day14-input)))))

--- a/test/aoc_clj/2021/day15_test.clj
+++ b/test/aoc_clj/2021/day15_test.clj
@@ -1,21 +1,20 @@
 (ns aoc-clj.2021.day15-test
   (:require [clojure.test :refer [deftest testing is]]
-            [aoc-clj.utils.grid.mapgrid :as mapgrid]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day15 :as t]))
 
 (def day15-sample
-  (mapgrid/lists->MapGrid2D
-   (t/parse
-    ["1163751742"
-     "1381373672"
-     "2136511328"
-     "3694931569"
-     "7463417111"
-     "1319128137"
-     "1359912421"
-     "3125421639"
-     "1293138521"
-     "2311944581"])))
+  (t/parse
+   ["1163751742"
+    "1381373672"
+    "2136511328"
+    "3694931569"
+    "7463417111"
+    "1319128137"
+    "1359912421"
+    "3125421639"
+    "1293138521"
+    "2311944581"]))
 
 (deftest find-path-vals
   (testing "Finds the risk values along the safest path in sample data"
@@ -30,10 +29,12 @@
   (testing "Finds the risk when the values have been tiled per part2 rules"
     (is (= 315 (t/path-risk (t/tile day15-sample 5))))))
 
+(def day15-input (u/parse-puzzle-input t/parse 2021 15))
+
 (deftest day15-part1-soln
   (testing "Reproduces the answer for day15, part1"
-    (is (= 508 (t/day15-part1-soln)))))
+    (is (= 508 (t/day15-part1-soln day15-input)))))
 
 (deftest day15-part2-soln
   (testing "Reproduces the answer for day15, part2"
-    (is (= 2872 (t/day15-part2-soln)))))
+    (is (= 2872 (t/day15-part2-soln day15-input)))))

--- a/test/aoc_clj/2021/day16_test.clj
+++ b/test/aoc_clj/2021/day16_test.clj
@@ -1,61 +1,64 @@
 (ns aoc-clj.2021.day16-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day16 :as t]))
 
-(def day16-sample1 (t/parse "D2FE28"))
-(def day16-sample2 (t/parse "38006F45291200"))
-(def day16-sample3 (t/parse "EE00D40C823060"))
+(def d16-s00 (t/parse ["D2FE28"]))
+(def d16-s01 (t/parse ["38006F45291200"]))
+(def d16-s02 (t/parse ["EE00D40C823060"]))
 
-(def day16-sample4 (t/parse "8A004A801A8002F478"))
-(def day16-sample5 (t/parse "620080001611562C8802118E34"))
-(def day16-sample6 (t/parse "C0015000016115A2E0802F182340"))
-(def day16-sample7 (t/parse "A0016C880162017C3686B18A3D4780"))
+(def d16-s03 (t/parse ["8A004A801A8002F478"]))
+(def d16-s04 (t/parse ["620080001611562C8802118E34"]))
+(def d16-s05 (t/parse ["C0015000016115A2E0802F182340"]))
+(def d16-s06 (t/parse ["A0016C880162017C3686B18A3D4780"]))
 
-(def day16-sample8 (t/parse "C200B40A82"))
-(def day16-sample9 (t/parse "04005AC33890"))
-(def day16-sample10 (t/parse "880086C3E88112"))
-(def day16-sample11 (t/parse "CE00C43D881120"))
-(def day16-sample12 (t/parse "D8005AC2A8F0"))
-(def day16-sample13 (t/parse "F600BC2D8F"))
-(def day16-sample14 (t/parse "9C005AC2F8F0"))
-(def day16-sample15 (t/parse "9C0141080250320F1802104A08"))
+(def d16-s07 (t/parse ["C200B40A82"]))
+(def d16-s08 (t/parse ["04005AC33890"]))
+(def d16-s09 (t/parse ["880086C3E88112"]))
+(def d16-s10 (t/parse ["CE00C43D881120"]))
+(def d16-s11 (t/parse ["D8005AC2A8F0"]))
+(def d16-s12 (t/parse ["F600BC2D8F"]))
+(def d16-s13 (t/parse ["9C005AC2F8F0"]))
+(def d16-s14 (t/parse ["9C0141080250320F1802104A08"]))
 
 (deftest decode
   (testing "Can decode all of the samples"
     (is (= {:version 6, :type 4, :bits 21, :value 2021}
-           (t/decode day16-sample1)))
+           (t/decode d16-s00)))
     (is (= {:version 1, :type 6, :bits 49 :length 27
             :subpackets [{:version 6, :type 4, :bits 11, :value 10}
                          {:version 2, :type 4, :bits 16, :value 20}]}
-           (t/decode day16-sample2)))
+           (t/decode d16-s01)))
     (is (= {:version 7, :type 3, :bits 51, :count 3
             :subpackets [{:version 2, :type 4, :bits 11, :value 1}
                          {:version 4, :type 4, :bits 11, :value 2}
                          {:version 1, :type 4, :bits 11, :value 3}]}
-           (t/decode day16-sample3)))))
+           (t/decode d16-s02)))))
 
 (deftest version-sum
   (testing "Computes the version code sum for all packets"
-    (is (= 16 (t/version-sum 0 (t/decode day16-sample4))))
-    (is (= 12 (t/version-sum 0 (t/decode day16-sample5))))
-    (is (= 23 (t/version-sum 0 (t/decode day16-sample6))))
-    (is (= 31 (t/version-sum 0 (t/decode day16-sample7))))))
+    (is (= 16 (t/version-sum 0 (t/decode d16-s03))))
+    (is (= 12 (t/version-sum 0 (t/decode d16-s04))))
+    (is (= 23 (t/version-sum 0 (t/decode d16-s05))))
+    (is (= 31 (t/version-sum 0 (t/decode d16-s06))))))
 
 (deftest apply-operator
   (testing "Applies the operator logic to compute a value"
-    (is (= 3  (t/apply-operator (t/decode day16-sample8))))
-    (is (= 54 (t/apply-operator (t/decode day16-sample9))))
-    (is (= 7  (t/apply-operator (t/decode day16-sample10))))
-    (is (= 9  (t/apply-operator (t/decode day16-sample11))))
-    (is (= 1  (t/apply-operator (t/decode day16-sample12))))
-    (is (= 0  (t/apply-operator (t/decode day16-sample13))))
-    (is (= 0  (t/apply-operator (t/decode day16-sample14))))
-    (is (= 1  (t/apply-operator (t/decode day16-sample15))))))
+    (is (= 3  (t/apply-operator (t/decode d16-s07))))
+    (is (= 54 (t/apply-operator (t/decode d16-s08))))
+    (is (= 7  (t/apply-operator (t/decode d16-s09))))
+    (is (= 9  (t/apply-operator (t/decode d16-s10))))
+    (is (= 1  (t/apply-operator (t/decode d16-s11))))
+    (is (= 0  (t/apply-operator (t/decode d16-s12))))
+    (is (= 0  (t/apply-operator (t/decode d16-s13))))
+    (is (= 1  (t/apply-operator (t/decode d16-s14))))))
+
+(def day16-input (u/parse-puzzle-input t/parse 2021 16))
 
 (deftest day16-part1-soln
   (testing "Reproduces the answer for day16, part1"
-    (is (= 981 (t/day16-part1-soln)))))
+    (is (= 981 (t/day16-part1-soln day16-input)))))
 
 (deftest day16-part2-soln
   (testing "Reproduces the answer for day16, part2"
-    (is (= 299227024091 (t/day16-part2-soln)))))
+    (is (= 299227024091 (t/day16-part2-soln day16-input)))))

--- a/test/aoc_clj/2021/day17_test.clj
+++ b/test/aoc_clj/2021/day17_test.clj
@@ -1,30 +1,29 @@
 (ns aoc-clj.2021.day17-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day17 :as t]))
 
-;; target area: x=20..30, y=-10..-5
-(def day17-sample
-  {:xmin 20
-   :xmax 30
-   :ymin -10
-   :ymax -5})
+(def d17-s00
+  (t/parse ["target area: x=20..30, y=-10..-5"]))
 
 (deftest hits-target?
   (testing "Correctly identifies whether probe ever hits target"
-    (is (= true  (t/will-hit-target? day17-sample [7 2])))
-    (is (= true  (t/will-hit-target? day17-sample [6 3])))
-    (is (= true  (t/will-hit-target? day17-sample [9 0])))
-    (is (= true  (t/will-hit-target? day17-sample [6 9])))
-    (is (= false (t/will-hit-target? day17-sample [17 -4])))))
+    (is (= true  (t/will-hit-target? d17-s00 [7 2])))
+    (is (= true  (t/will-hit-target? d17-s00 [6 3])))
+    (is (= true  (t/will-hit-target? d17-s00 [9 0])))
+    (is (= true  (t/will-hit-target? d17-s00 [6 9])))
+    (is (= false (t/will-hit-target? d17-s00 [17 -4])))))
 
 (deftest viable-init-vels
   (testing "Identifies the viable initial velocities that hit the sample target"
-    (is (= 112 (t/viable-init-vels day17-sample 10)))))
+    (is (= 112 (t/viable-init-vels d17-s00 10)))))
+
+(def day17-input (u/parse-puzzle-input t/parse 2021 17))
 
 (deftest day17-part1-soln
   (testing "Reproduces the answer for day17, part1"
-    (is (= 2701 (t/day17-part1-soln)))))
+    (is (= 2701 (t/day17-part1-soln day17-input)))))
 
 (deftest day17-part2-soln
   (testing "Reproduces the answer for day17, part2"
-    (is (= 1070 (t/day17-part2-soln)))))
+    (is (= 1070 (t/day17-part2-soln day17-input)))))

--- a/test/aoc_clj/2021/day18_test.clj
+++ b/test/aoc_clj/2021/day18_test.clj
@@ -1,82 +1,83 @@
 (ns aoc-clj.2021.day18-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day18 :as t]))
 
-(def day18-sample1-in  [[[[[9,8],1],2],3],4])
-(def day18-sample1-out [[[[0,9],2],3],4])
+(def d18-s00-in  [[[[[9,8],1],2],3],4])
+(def d18-s00-out [[[[0,9],2],3],4])
 
-(def day18-sample2-in  [7,[6,[5,[4,[3,2]]]]])
-(def day18-sample2-out [7,[6,[5,[7,0]]]])
+(def d18-s02-in  [7,[6,[5,[4,[3,2]]]]])
+(def d18-s02-out [7,[6,[5,[7,0]]]])
 
-(def day18-sample3-in  [[6,[5,[4,[3,2]]]],1])
-(def day18-sample3-out [[6,[5,[7,0]]],3])
+(def d18-s03-in  [[6,[5,[4,[3,2]]]],1])
+(def d18-s03-out [[6,[5,[7,0]]],3])
 
-(def day18-sample4-in  [[3,[2,[1,[7,3]]]],[6,[5,[4,[3,2]]]]])
-(def day18-sample4-out [[3,[2,[8,0]]],[9,[5,[7,0]]]])
+(def d18-s04-in  [[3,[2,[1,[7,3]]]],[6,[5,[4,[3,2]]]]])
+(def d18-s04-out [[3,[2,[8,0]]],[9,[5,[7,0]]]])
 
-(def day18-sample5-in  [[[[[4,3],4],4],[7,[[8,4],9]]],[1,1]])
-(def day18-sample5-out [[[[0,7],4],[[7,8],[6,0]]],[8,1]])
+(def d18-s05-in  [[[[[4,3],4],4],[7,[[8,4],9]]],[1,1]])
+(def d18-s05-out [[[[0,7],4],[[7,8],[6,0]]],[8,1]])
 
-(def day18-sample6-in [[1,1]
-                       [2,2]
-                       [3,3]
-                       [4,4]])
-(def day18-sample6-out [[[[1,1],[2,2]],[3,3]],[4,4]])
+(def d18-s06-in [[1,1]
+                 [2,2]
+                 [3,3]
+                 [4,4]])
+(def d18-s06-out [[[[1,1],[2,2]],[3,3]],[4,4]])
 
-(def day18-sample7-in [[1,1]
-                       [2,2]
-                       [3,3]
-                       [4,4]
-                       [5,5]])
-(def day18-sample7-out [[[[3,0],[5,3]],[4,4]],[5,5]])
+(def d18-s07-in [[1,1]
+                 [2,2]
+                 [3,3]
+                 [4,4]
+                 [5,5]])
+(def d18-s07-out [[[[3,0],[5,3]],[4,4]],[5,5]])
 
-(def day18-sample8-in [[1,1]
-                       [2,2]
-                       [3,3]
-                       [4,4]
-                       [5,5]
-                       [6,6]])
-(def day18-sample8-out [[[[5,0],[7,4]],[5,5]],[6,6]])
+(def d18-s08-in [[1,1]
+                 [2,2]
+                 [3,3]
+                 [4,4]
+                 [5,5]
+                 [6,6]])
+(def d18-s08-out [[[[5,0],[7,4]],[5,5]],[6,6]])
 
-(def day18-sample9-in [[[[0,[4,5]],[0,0]],[[[4,5],[2,6]],[9,5]]]
-                       [7,[[[3,7],[4,3]],[[6,3],[8,8]]]]
-                       [[2,[[0,8],[3,4]]],[[[6,7],1],[7,[1,6]]]]
-                       [[[[2,4],7],[6,[0,5]]],[[[6,8],[2,8]],[[2,1],[4,5]]]]
-                       [7,[5,[[3,8],[1,4]]]]
-                       [[2,[2,2]],[8,[8,1]]]
-                       [2,9]
-                       [1,[[[9,3],9],[[9,0],[0,7]]]]
-                       [[[5,[7,4]],7],1]
-                       [[[[4,2],2],6],[8,7]]])
-(def day18-sample9-out [[[[8,7],[7,7]],[[8,6],[7,7]]],[[[0,7],[6,6]],[8,7]]])
+(def d18-s09-in [[[[0,[4,5]],[0,0]],[[[4,5],[2,6]],[9,5]]]
+                 [7,[[[3,7],[4,3]],[[6,3],[8,8]]]]
+                 [[2,[[0,8],[3,4]]],[[[6,7],1],[7,[1,6]]]]
+                 [[[[2,4],7],[6,[0,5]]],[[[6,8],[2,8]],[[2,1],[4,5]]]]
+                 [7,[5,[[3,8],[1,4]]]]
+                 [[2,[2,2]],[8,[8,1]]]
+                 [2,9]
+                 [1,[[[9,3],9],[[9,0],[0,7]]]]
+                 [[[5,[7,4]],7],1]
+                 [[[[4,2],2],6],[8,7]]])
+(def d18-s09-out [[[[8,7],[7,7]],[[8,6],[7,7]]],[[[0,7],[6,6]],[8,7]]])
 
-(def day18-sample10-in [[[[0,[5,8]],[[1,7],[9,6]]],[[4,[1,2]],[[1,4],2]]]
-                        [[[5,[2,8]],4],[5,[[9,9],0]]]
-                        [6,[[[6,2],[5,6]],[[7,6],[4,7]]]]
-                        [[[6,[0,7]],[0,9]],[4,[9,[9,0]]]]
-                        [[[7,[6,4]],[3,[1,3]]],[[[5,5],1],9]]
-                        [[6,[[7,3],[3,2]]],[[[3,8],[5,7]],4]]
-                        [[[[5,4],[7,7]],8],[[8,3],8]]
-                        [[9,3],[[9,9],[6,[4,9]]]]
-                        [[2,[[7,7],7]],[[5,8],[[9,3],[0,2]]]]
-                        [[[[5,2],5],[8,[3,7]]],[[5,[7,5]],[4,4]]]])
-(def day18-sample10-out [[[[6,6],[7,6]],[[7,7],[7,0]]],[[[7,7],[7,7]],[[7,8],[9,9]]]])
+(def d18-s10-in [[[[0,[5,8]],[[1,7],[9,6]]],[[4,[1,2]],[[1,4],2]]]
+                 [[[5,[2,8]],4],[5,[[9,9],0]]]
+                 [6,[[[6,2],[5,6]],[[7,6],[4,7]]]]
+                 [[[6,[0,7]],[0,9]],[4,[9,[9,0]]]]
+                 [[[7,[6,4]],[3,[1,3]]],[[[5,5],1],9]]
+                 [[6,[[7,3],[3,2]]],[[[3,8],[5,7]],4]]
+                 [[[[5,4],[7,7]],8],[[8,3],8]]
+                 [[9,3],[[9,9],[6,[4,9]]]]
+                 [[2,[[7,7],7]],[[5,8],[[9,3],[0,2]]]]
+                 [[[[5,2],5],[8,[3,7]]],[[5,[7,5]],[4,4]]]])
+(def d18-s10-out [[[[6,6],[7,6]],[[7,7],[7,0]]],[[[7,7],[7,7]],[[7,8],[9,9]]]])
 
 (deftest number-reduce
   (testing "Correctly applies number reduction logic for exploding/splitting"
-    (is (= day18-sample1-out (t/number-reduce day18-sample1-in)))
-    (is (= day18-sample2-out (t/number-reduce day18-sample2-in)))
-    (is (= day18-sample3-out (t/number-reduce day18-sample3-in)))
-    (is (= day18-sample4-out (t/number-reduce day18-sample4-in)))
-    (is (= day18-sample5-out (t/number-reduce day18-sample5-in)))))
+    (is (= d18-s00-out (t/number-reduce d18-s00-in)))
+    (is (= d18-s02-out (t/number-reduce d18-s02-in)))
+    (is (= d18-s03-out (t/number-reduce d18-s03-in)))
+    (is (= d18-s04-out (t/number-reduce d18-s04-in)))
+    (is (= d18-s05-out (t/number-reduce d18-s05-in)))))
 
 (deftest addition
-  (testing "Snailfish addition, including reduction steps works correctly on sample data"
-    (is (= day18-sample6-out  (reduce t/snailfish-add day18-sample6-in)))
-    (is (= day18-sample7-out  (reduce t/snailfish-add day18-sample7-in)))
-    (is (= day18-sample8-out  (reduce t/snailfish-add day18-sample8-in)))
-    (is (= day18-sample9-out  (reduce t/snailfish-add day18-sample9-in)))
-    (is (= day18-sample10-out (reduce t/snailfish-add day18-sample10-in)))))
+  (testing "Snailfish addition, including reduction steps works correctly on s0 data"
+    (is (= d18-s06-out (reduce t/snailfish-add d18-s06-in)))
+    (is (= d18-s07-out (reduce t/snailfish-add d18-s07-in)))
+    (is (= d18-s08-out (reduce t/snailfish-add d18-s08-in)))
+    (is (= d18-s09-out (reduce t/snailfish-add d18-s09-in)))
+    (is (= d18-s10-out (reduce t/snailfish-add d18-s10-in)))))
 
 (deftest magnitude
   (testing "Computes the recursive magnitude of a number"
@@ -87,17 +88,18 @@
     (is (=  791 (t/magnitude [[[[3,0],[5,3]],[4,4]],[5,5]])))
     (is (= 1137 (t/magnitude [[[[5,0],[7,4]],[5,5]],[6,6]])))
     (is (= 3488 (t/magnitude [[[[8,7],[7,7]],[[8,6],[7,7]]],[[[0,7],[6,6]],[8,7]]])))
-    (is (= 4140 (t/magnitude day18-sample10-out)))))
+    (is (= 4140 (t/magnitude d18-s10-out)))))
 
 (deftest largest-magnitude-sum
-  (testing "Finds the largest magnitude sum in the sample data"
-    (is (= 3993 (t/largest-magnitude-sum day18-sample10-in)))))
+  (testing "Finds the largest magnitude sum in the s0 data"
+    (is (= 3993 (t/largest-magnitude-sum d18-s10-in)))))
+
+(def day18-input (u/parse-puzzle-input t/parse 2021 18))
 
 (deftest day18-part1-soln
   (testing "Reproduces the answer for day18, part1"
-    (is (= 3647 (t/day18-part1-soln)))))
+    (is (= 3647 (t/day18-part1-soln day18-input)))))
 
-;; Commented out because it's too slow to run as a unit test
-;; (deftest day18-part2-soln
-;;   (testing "Reproduces the answer for day18, part2"
-;;     (is (= 4600 (t/day18-part2-soln)))))
+(deftest ^:slow day18-part2-soln
+  (testing "Reproduces the answer for day18, part2"
+    (is (= 4600 (t/day18-part2-soln day18-input)))))

--- a/test/aoc_clj/2021/day19_test.clj
+++ b/test/aoc_clj/2021/day19_test.clj
@@ -3,27 +3,41 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day19 :as t]))
 
-(def day19-sample1 (u/fmap t/add-relative-vectors (t/parse (u/puzzle-input "inputs/2021/day19-sample1.txt"))))
+;; (def d19-s00
+;;   (t/parse
+;;    ["--- scanner 0 ---"
+;;     "0,2"
+;;     "4,1"
+;;     "3,3"
+;;     ""
+;;     "--- scanner 1 ---"
+;;     "-1,-1"
+;;     "-5,0"
+;;     "-2,1"]))
+
+(def d19-s01 (t/parse (u/puzzle-input "inputs/2021/day19-sample1.txt")))
 
 (deftest orient-sensor-to-known
   (testing "Can compute the offset for sensor 1 to sensor 0 in the sample data"
     (is (= [68 -1246 -43]
-           (:offset (t/orient-sensor-to-known (get day19-sample1 0) (get day19-sample1 1)))))))
+           (:offset (t/orient-sensor-to-known (get d19-s01 0) (get d19-s01 1)))))))
 
 (deftest count-all-beacons
   (testing "Counts all the beacons in the sample data"
-    (is (= 79 (count (t/all-beacons day19-sample1))))))
+    (is (= 79 (count (t/all-beacons d19-s01))))))
 
 (deftest max-sensor-distance
   (testing "Finds the maximum (Manhattan) distance between any two sensors"
-    (is (= 3621 (t/max-sensor-distance day19-sample1)))))
+    (is (= 3621 (t/max-sensor-distance d19-s01)))))
+
+(def day19-input (u/parse-puzzle-input t/intermediate-parse 2021 19))
 
 ;; FIXME: 2021.day19 is too slow to unit test
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/7
 (deftest ^:slow day19-part1-soln
   (testing "Reproduces the answer for day19, part1"
-    (is (= 449 (t/day19-part1-soln)))))
+    (is (= 449 (t/day19-part1-soln day19-input)))))
 
 (deftest ^:slow day19-part2-soln
   (testing "Reproduces the answer for day19, part2"
-    (is (= 13128 (t/day19-part2-soln)))))
+    (is (= 13128 (t/day19-part2-soln day19-input)))))

--- a/test/aoc_clj/2021/day20_test.clj
+++ b/test/aoc_clj/2021/day20_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2021.day20-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day20 :as t]))
 
 (def day20-sample
@@ -17,12 +18,14 @@
     (is (= 35   (t/illuminated (t/enhance-n-times day20-sample 2))))
     (is (= 3351 (t/illuminated (t/enhance-n-times day20-sample 50))))))
 
+(def day20-input (u/parse-puzzle-input t/parse 2021 20))
+
 (deftest day20-part1-soln
   (testing "Reproduces the answer for day20, part1"
-    (is (= 5097 (t/day20-part1-soln)))))
+    (is (= 5097 (t/day20-part1-soln day20-input)))))
 
 ;; FIXME: 2021.day20 part 2 is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/10
 (deftest ^:slow day20-part2-soln
   (testing "Reproduces the answer for day20, part2"
-    (is (= 17987 (t/day20-part2-soln)))))
+    (is (= 17987 (t/day20-part2-soln day20-input)))))

--- a/test/aoc_clj/2021/day21_test.clj
+++ b/test/aoc_clj/2021/day21_test.clj
@@ -1,30 +1,38 @@
 (ns aoc-clj.2021.day21-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day21 :as t]))
 
-;; Sample data
-;; Player 1 starting position: 4
-;; Player 2 starting position: 8
-(def day21-sample [3 7])
+(def d21-s00-raw
+  ["Player 1 starting position: 4"
+   "Player 2 starting position: 8"])
+
+(def d21-s00 [3 7])
+
+(deftest parse-test
+  (testing "Correctly parses the input"
+    (is (= d21-s00 (t/parse d21-s00-raw)))))
 
 (deftest roll-until-win
   (testing "Determines when game ends for sample positions"
     (is (= {:roll 331 :player 1 :spaces [9 2] :score [1000 745]}
-           (select-keys (t/play-until-win day21-sample)
+           (select-keys (t/play-until-win d21-s00)
                         [:roll :player :spaces :score])))))
 
 (deftest loser-score-times-die-rolls
   (testing "Computes the product of the loser score and number of die rolls"
-    (is (= 739785 (t/loser-score-times-die-rolls (t/play-until-win day21-sample))))))
+    (is (= 739785 (t/loser-score-times-die-rolls (t/play-until-win d21-s00))))))
 
 (deftest dirac-max-win-count
   (testing "Computes the number of universes the winner wins in"
-    (is (= 444356092776315 (apply max (t/win-counts {[[0 0] day21-sample] 1} 0))))))
+    (is (= 444356092776315 (apply max (t/win-counts {[[0 0] d21-s00] 1} 0))))))
+
+(def day21-input (u/parse-puzzle-input t/parse 2021 21))
 
 (deftest day21-part1-soln
   (testing "Reproduces the answer for day21, part1"
-    (is (= 707784 (t/day21-part1-soln)))))
+    (is (= 707784 (t/day21-part1-soln day21-input)))))
 
 (deftest day21-part2-soln
   (testing "Reproduces the answer for day21, part2"
-    (is (= 157595953724471 (t/day21-part2-soln)))))
+    (is (= 157595953724471 (t/day21-part2-soln day21-input)))))

--- a/test/aoc_clj/2021/day22_test.clj
+++ b/test/aoc_clj/2021/day22_test.clj
@@ -3,14 +3,14 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day22 :as t]))
 
-(def day22-sample1
+(def d22-s00
   (t/parse
    ["on x=10..12,y=10..12,z=10..12"
     "on x=11..13,y=11..13,z=11..13"
     "off x=9..11,y=9..11,z=9..11"
     "on x=10..10,y=10..10,z=10..10"]))
 
-(def day22-sample2
+(def d22-s01
   (t/parse
    ["on x=-20..26,y=-36..17,z=-47..7"
     "on x=-20..33,y=-21..23,z=-26..28"
@@ -35,24 +35,26 @@
     "on x=-54112..-39298,y=-85059..-49293,z=-27449..7877"
     "on x=967..23432,y=45373..81175,z=27513..53682"]))
 
-(def day22-sample3 (t/parse (u/puzzle-input "inputs/2021/day22-sample3.txt")))
+(def d22-s02 (t/parse (u/puzzle-input "inputs/2021/day22-sample3.txt")))
 
 (deftest cubes-in-init-area
   (testing "Computes the cuboids that are 'on' inside the init area"
-    (is (= 39     (t/on-cubes-in-init-area day22-sample1)))
-    (is (= 590784 (t/on-cubes-in-init-area day22-sample2)))
-    (is (= 474140 (t/on-cubes-in-init-area day22-sample3)))))
+    (is (= 39     (t/on-cubes-in-init-area d22-s00)))
+    (is (= 590784 (t/on-cubes-in-init-area d22-s01)))
+    (is (= 474140 (t/on-cubes-in-init-area d22-s02)))))
 
 (deftest cubes-in-large-example
   (testing "Computes all of the on cubes in a large example"
-    (is (= 2758514936282235 (t/on-cubes day22-sample3)))))
+    (is (= 2758514936282235 (t/on-cubes d22-s02)))))
+
+(def day22-input (u/parse-puzzle-input t/parse 2021 22))
 
 (deftest day22-part1-soln
   (testing "Reproduces the answer for day22, part1"
-    (is (= 503864 (t/day22-part1-soln)))))
+    (is (= 503864 (t/day22-part1-soln day22-input)))))
 
 ;; FIXME 2021.day22 part2 is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/8
 (deftest ^:slow day22-part2-soln
   (testing "Reproduces the answer for day22, part2"
-    (is (= 1255547543528356 (t/day22-part2-soln)))))
+    (is (= 1255547543528356 (t/day22-part2-soln day22-input)))))

--- a/test/aoc_clj/2021/day23_test.clj
+++ b/test/aoc_clj/2021/day23_test.clj
@@ -1,13 +1,16 @@
 (ns aoc-clj.2021.day23-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day23 :as t]))
 
-(def day23-sample1
-  ;; "#############"
-  ;; "#...........#"
-  ;; "###B#C#B#D###"
-  ;; "  #A#D#C#A#  "
-  ;; "  #########  "
+(def d23-s00-raw
+  ["#############"
+   "#...........#"
+   "###B#C#B#D###"
+   "  #A#D#C#A#  "
+   "  #########  "])
+
+(def d23-s00
   {:a0 {:type :b}
    :a1 {:type :a}
    :b0 {:type :c}
@@ -17,7 +20,7 @@
    :d0 {:type :d}
    :d1 {:type :a}})
 
-(def day23-sample1-soln
+(def d23-s00-soln
   [[:c0 :h2]
    [:b0 :c0]
    [:b1 :h3]
@@ -29,7 +32,7 @@
    [:h3 :d0]
    [:h5 :a0]])
 
-(def day23-sample1-part2-soln
+(def d23-s00-part2-soln
   [[:d0 :h6]
    [:d1 :h0]
    [:c0 :h5]
@@ -54,19 +57,24 @@
    [:h5 :a0]
    [:h6 :d0]])
 
+(deftest parse-test
+  (testing "Correctly parses the input"
+    (is (= d23-s00 (t/parse d23-s00-raw)))))
+
 (deftest cost-of-moves
   (testing "Computes the costs of the moves identified in sample solution"
-    (is (= 12521 (t/cost-of-moves day23-sample1 day23-sample1-soln)))))
+    (is (= 12521 (t/cost-of-moves d23-s00 d23-s00-soln)))))
 
 (deftest cost-of-moves-part2
   (testing "Computes the costs of the moves identified in sample solution in part2 "
-    (is (= 44169 (t/cost-of-moves (t/unfold-input day23-sample1) day23-sample1-part2-soln)))))
+    (is (= 44169 (t/cost-of-moves (t/unfold-input d23-s00) d23-s00-part2-soln)))))
 
+(def day23-input (u/parse-puzzle-input t/parse 2021 23))
 
 (deftest day23-part1-soln
   (testing "Reproduces the answer for day23, part1"
-    (is (= 16489 (t/day23-part1-soln)))))
+    (is (= 16489 (t/day23-part1-soln day23-input)))))
 
 (deftest day23-part2-soln
   (testing "Reproduces the answer for day23, part2"
-    (is (= 43413 (t/day23-part2-soln)))))
+    (is (= 43413 (t/day23-part2-soln day23-input)))))

--- a/test/aoc_clj/2021/day24_test.clj
+++ b/test/aoc_clj/2021/day24_test.clj
@@ -1,13 +1,42 @@
 (ns aoc-clj.2021.day24-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day24 :as t]))
+
+;; (def day24-sample1
+;;   (t/parse
+;;    ["inp x"
+;;     "mul x -1"]))
+
+;; (def day24-sample2
+;;   (t/parse
+;;    ["inp z"
+;;     "inp x"
+;;     "mul z 3"
+;;     "eql z x"]))
+
+;; (def day24-sample3
+;;   (t/parse
+;;    ["inp w"
+;;     "add z w"
+;;     "mod z 2"
+;;     "div w 2"
+;;     "add y w"
+;;     "mod y 2"
+;;     "div w 2"
+;;     "add x w"
+;;     "mod x 2"
+;;     "div w 2"
+;;     "mod w 2"]))
+
+(def day24-input (u/parse-puzzle-input t/parse 2021 24))
 
 (deftest day24-part1-soln
   (testing "Reproduces the answer for day24, part1"
-    (is (= 98998519596997 (t/day24-part1-soln)))))
+    (is (= 98998519596997 (t/day24-part1-soln day24-input)))))
 
 ;; FIXME: 2021.day24 part 2 solution is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/11
 (deftest ^:slow day24-part2-soln
   (testing "Reproduces the answer for day24, part2"
-    (is (= 31521119151421 (t/day24-part2-soln)))))
+    (is (= 31521119151421 (t/day24-part2-soln day24-input)))))

--- a/test/aoc_clj/2021/day25_test.clj
+++ b/test/aoc_clj/2021/day25_test.clj
@@ -1,11 +1,10 @@
 (ns aoc-clj.2021.day25-test
   (:require [clojure.test :refer [deftest testing is]]
-            [aoc-clj.utils.grid.mapgrid :as mapgrid]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2021.day25 :as t]))
 
 (def day25-sample
-  (mapgrid/ascii->MapGrid2D
-   t/charmap
+  (t/parse
    ["v...>>.vv>"
     ".vv>>.vv.."
     ">>.>v>...v"
@@ -14,16 +13,17 @@
     ">.>>..v..."
     ".vv..>.>v."
     "v.v..>>v.v"
-    "....v..v.>"]
-   :down true))
+    "....v..v.>"]))
 
 (deftest steps-until-done-changing
   (testing "Computes the number of steps until no more changes occur"
     (is (= 58 (first (t/evolve-until-stop day25-sample))))))
 
+(def day25-input (u/parse-puzzle-input t/parse 2021 25))
+
 ;; FIXME: 2021.day25 solution is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/9
 (deftest ^:slow day25-part1-soln
   (testing "Reproduces the answer for day25, part1"
-    (is (= 429 (t/day25-part1-soln)))))
+    (is (= 429 (t/day25-part1-soln day25-input)))))
 

--- a/test/aoc_clj/2022/day01_test.clj
+++ b/test/aoc_clj/2022/day01_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2022.day01-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day01 :as t]))
 
-(def d01-s01
+(def d01-s00
   (t/parse
    ["1000"
     "2000"
@@ -21,18 +22,20 @@
 
 (deftest parse-test
   (testing "Parses the sample input correctly"
-    (is (= d01-s01
+    (is (= d01-s00
            [[1000 2000 3000] [4000] [5000 6000] [7000 8000 9000] [10000]]))))
 
 (deftest top-n-capacity-sum-test
   (testing "Find the max calorie capacity of top elf and top 3 elves"
-    (is (= 24000 (t/top-n-capacity-sum 1 d01-s01)))
-    (is (= 45000 (t/top-n-capacity-sum 3 d01-s01)))))
+    (is (= 24000 (t/top-n-capacity-sum 1 d01-s00)))
+    (is (= 45000 (t/top-n-capacity-sum 3 d01-s00)))))
+
+(def day01-input (u/parse-puzzle-input t/parse 2022 1))
 
 (deftest day01-part1-soln
   (testing "Reproduces the answer for day01, part1"
-    (is (= 70116 (t/day01-part1-soln)))))
+    (is (= 70116 (t/day01-part1-soln day01-input)))))
 
 (deftest day01-part2-soln
   (testing "Reproduces the answer for day01, part2"
-    (is (= 206582 (t/day01-part2-soln)))))
+    (is (= 206582 (t/day01-part2-soln day01-input)))))

--- a/test/aoc_clj/2022/day02_test.clj
+++ b/test/aoc_clj/2022/day02_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2022.day02-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day02 :as t]))
 
-(def d02-s01
+(def d02-s00
   (t/parse
    ["A Y"
     "B X"
@@ -10,31 +11,33 @@
 
 (deftest parse-test
   (testing "Correctly parses the sample input"
-    (is (= d02-s01 [["A" "Y"] ["B" "X"] ["C" "Z"]]))))
+    (is (= d02-s00 [["A" "Y"] ["B" "X"] ["C" "Z"]]))))
 
-(def d02-s01-1 (t/interpret-part1 d02-s01))
-(def d02-s01-2 (t/interpret-part2 d02-s01))
+(def d02-s00-1 (t/interpret-part1 d02-s00))
+(def d02-s00-2 (t/interpret-part2 d02-s00))
 
 (deftest interpret-test
   (testing "Interprets the letter codes according to the guidance"
     (is (= [[::t/rock     ::t/paper]
             [::t/paper    ::t/rock]
             [::t/scissors ::t/scissors]]
-           d02-s01-1))
+           d02-s00-1))
     (is (= [[::t/rock     ::t/draw]
             [::t/paper    ::t/lose]
             [::t/scissors ::t/win]]
-           d02-s01-2))))
+           d02-s00-2))))
 
 (deftest round-score
   (testing "Computes the score for each round"
-    (is (= [8 1 6] (mapv t/score-part1 d02-s01-1)))
-    (is (= [4 1 7] (mapv t/score-part2 d02-s01-2)))))
+    (is (= [8 1 6] (mapv t/score-part1 d02-s00-1)))
+    (is (= [4 1 7] (mapv t/score-part2 d02-s00-2)))))
+
+(def day02-input (u/parse-puzzle-input t/parse 2022 2))
 
 (deftest day02-part1-soln
   (testing "Reproduces the answer for day02, part1"
-    (is (= 11906 (t/day02-part1-soln)))))
+    (is (= 11906 (t/day02-part1-soln day02-input)))))
 
 (deftest day02-part2-soln
   (testing "Reproduces the answer for day02, part2"
-    (is (= 11186 (t/day02-part2-soln)))))
+    (is (= 11186 (t/day02-part2-soln day02-input)))))

--- a/test/aoc_clj/2022/day03_test.clj
+++ b/test/aoc_clj/2022/day03_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2022.day03-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day03 :as t]))
 
-(def d03-s01
+(def d03-s00
   ["vJrwpWtwJgWrhcsFMMfFFhFp"
    "jqHRNqRjqzjGDLGLrsFMfFZSrLrFZsSL"
    "PmmdzqPrVvPwwTWBwg"
@@ -14,9 +15,9 @@
   (testing "Finds the overlapping items in the first/second halves
             or among groups of three"
     (is (= [\p \L \P \v \t \s]
-           (t/overlaps ::t/halfway d03-s01)))
+           (t/overlaps ::t/halfway d03-s00)))
     (is (= [\r \Z]
-           (t/overlaps ::t/thirds d03-s01)))))
+           (t/overlaps ::t/thirds d03-s00)))))
 
 (deftest priority-test
   (testing "Computes the priority for a given character"
@@ -29,13 +30,15 @@
 
 (deftest overlaps-priority-test
   (testing "Finds the sum of the priorities of the overlapping items"
-    (is (= 157 (t/overlap-priority-sum ::t/halfway d03-s01)))
-    (is (= 70  (t/overlap-priority-sum ::t/thirds d03-s01)))))
+    (is (= 157 (t/overlap-priority-sum ::t/halfway d03-s00)))
+    (is (= 70  (t/overlap-priority-sum ::t/thirds d03-s00)))))
+
+(def day03-input (u/parse-puzzle-input t/parse 2022 3))
 
 (deftest day03-part1-soln
   (testing "Reproduces the answer for day03, part1"
-    (is (= 7597 (t/day03-part1-soln)))))
+    (is (= 7597 (t/day03-part1-soln day03-input)))))
 
 (deftest day03-part2-soln
   (testing "Reproduces the answer for day03, part2"
-    (is (= 2607 (t/day03-part2-soln)))))
+    (is (= 2607 (t/day03-part2-soln day03-input)))))

--- a/test/aoc_clj/2022/day04_test.clj
+++ b/test/aoc_clj/2022/day04_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2022.day04-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day04 :as t]))
 
-(def s04-01
+(def d04-s00
   (t/parse
    ["2-4,6-8"
     "2-3,4-5"
@@ -13,7 +14,7 @@
 
 (deftest parse-test
   (testing "Parses the sample input correctly"
-    (is (= s04-01
+    (is (= d04-s00
            [[[2 4] [6 8]]
             [[2 3] [4 5]]
             [[5 7] [7 9]]
@@ -21,10 +22,12 @@
             [[6 6] [4 6]]
             [[2 6] [4 8]]]))))
 
+(def day04-input (u/parse-puzzle-input t/parse 2022 4))
+
 (deftest day04-part1-soln
   (testing "Reproduces the answer for day04, part1"
-    (is (= 584 (t/day04-part1-soln)))))
+    (is (= 584 (t/day04-part1-soln day04-input)))))
 
 (deftest day04-part2-soln
   (testing "Reproduces the answer for day04, part2"
-    (is (= 933 (t/day04-part2-soln)))))
+    (is (= 933 (t/day04-part2-soln day04-input)))))

--- a/test/aoc_clj/2022/day05_test.clj
+++ b/test/aoc_clj/2022/day05_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2022.day05-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day05 :as t]))
 
-(def d05-s01
+(def d05-s00
   (t/parse
    ["    [D]    "
     "[N] [C]    "
@@ -16,7 +17,7 @@
 
 (deftest parse-test
   (testing "Correctly parses the sample input"
-    (is (= d05-s01
+    (is (= d05-s00
            {:stacks {1 ["Z" "N"]
                      2 ["M" "C" "D"]
                      3 ["P"]}
@@ -98,17 +99,19 @@
 (deftest final-arrangement-1-test
   (testing "Stacks end up in the correct final state in part1"
     (is (= {1 ["C"], 2 ["M"], 3 ["P" "D" "N" "Z"]}
-           (t/final-arrangement-1 d05-s01)))))
+           (t/final-arrangement-1 d05-s00)))))
 
 (deftest final-arrangement-2-test
   (testing "Stacks end up in the correct final state in part1"
     (is (= {1 ["M"], 2 ["C"], 3 ["P" "Z" "N" "D"]}
-           (t/final-arrangement-2 d05-s01)))))
+           (t/final-arrangement-2 d05-s00)))))
+
+(def day05-input (u/parse-puzzle-input t/parse 2022 5))
 
 (deftest day05-part1-soln
   (testing "Reproduces the answer for day05, part1"
-    (is (= "CNSZFDVLJ" (t/day05-part1-soln)))))
+    (is (= "CNSZFDVLJ" (t/day05-part1-soln day05-input)))))
 
 (deftest day05-part2-soln
   (testing "Reproduces the answer for day05, part2"
-    (is (= "QNDWLMGNS" (t/day05-part2-soln)))))
+    (is (= "QNDWLMGNS" (t/day05-part2-soln day05-input)))))

--- a/test/aoc_clj/2022/day06_test.clj
+++ b/test/aoc_clj/2022/day06_test.clj
@@ -1,39 +1,42 @@
 (ns aoc-clj.2022.day06-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day06 :as t]))
 
-(def d06-s01 "mjqjpqmgbljsphdztnvjfqwrcgsmlb")
-(def d06-s02 "bvwbjplbgvbhsrlpgdmjqwftvncz")
-(def d06-s03 "nppdvjthqldpwncqszvftbrmjlhg")
-(def d06-s04 "nznrnfrfntjfmvfwmzdfjlvtqnbhcprsg")
-(def d06-s05 "zcfzfwzzqfrljwzlrfnpqdbhtmscgvjw")
+(def d06-s00 "mjqjpqmgbljsphdztnvjfqwrcgsmlb")
+(def d06-s01 "bvwbjplbgvbhsrlpgdmjqwftvncz")
+(def d06-s02 "nppdvjthqldpwncqszvftbrmjlhg")
+(def d06-s03 "nznrnfrfntjfmvfwmzdfjlvtqnbhcprsg")
+(def d06-s04 "zcfzfwzzqfrljwzlrfnpqdbhtmscgvjw")
 
-(def d06-s06 "mjqjpqmgbljsphdztnvjfqwrcgsmlb")
-(def d06-s07 "bvwbjplbgvbhsrlpgdmjqwftvncz")
-(def d06-s08 "nppdvjthqldpwncqszvftbrmjlhg")
-(def d06-s09 "nznrnfrfntjfmvfwmzdfjlvtqnbhcprsg")
-(def d06-s10 "zcfzfwzzqfrljwzlrfnpqdbhtmscgvjw")
+(def d06-s05 "mjqjpqmgbljsphdztnvjfqwrcgsmlb")
+(def d06-s06 "bvwbjplbgvbhsrlpgdmjqwftvncz")
+(def d06-s07 "nppdvjthqldpwncqszvftbrmjlhg")
+(def d06-s08 "nznrnfrfntjfmvfwmzdfjlvtqnbhcprsg")
+(def d06-s09 "zcfzfwzzqfrljwzlrfnpqdbhtmscgvjw")
 
 (deftest chars-to-distinct-run-test
   (testing "Finds number of chars to examine to find first
             start-of-packet or start-of-message sequence"
     ;; start of packet: sequence of 4 unique chars
-    (is (= 7  (t/chars-to-distinct-run 4 d06-s01)))
-    (is (= 5  (t/chars-to-distinct-run 4 d06-s02)))
-    (is (= 6  (t/chars-to-distinct-run 4 d06-s03)))
-    (is (= 10 (t/chars-to-distinct-run 4 d06-s04)))
-    (is (= 11 (t/chars-to-distinct-run 4 d06-s05)))
+    (is (= 7  (t/chars-to-distinct-run 4 d06-s00)))
+    (is (= 5  (t/chars-to-distinct-run 4 d06-s01)))
+    (is (= 6  (t/chars-to-distinct-run 4 d06-s02)))
+    (is (= 10 (t/chars-to-distinct-run 4 d06-s03)))
+    (is (= 11 (t/chars-to-distinct-run 4 d06-s04)))
     ;; start of message: sequence of 14 unique chars
-    (is (= 19 (t/chars-to-distinct-run 14 d06-s06)))
+    (is (= 19 (t/chars-to-distinct-run 14 d06-s05)))
+    (is (= 23 (t/chars-to-distinct-run 14 d06-s06)))
     (is (= 23 (t/chars-to-distinct-run 14 d06-s07)))
-    (is (= 23 (t/chars-to-distinct-run 14 d06-s08)))
-    (is (= 29 (t/chars-to-distinct-run 14 d06-s09)))
-    (is (= 26 (t/chars-to-distinct-run 14 d06-s10)))))
+    (is (= 29 (t/chars-to-distinct-run 14 d06-s08)))
+    (is (= 26 (t/chars-to-distinct-run 14 d06-s09)))))
+
+(def day06-input (u/parse-puzzle-input t/parse 2022 6))
 
 (deftest day06-part1-soln
   (testing "Reproduces the answer for day06, part1"
-    (is (= 1855 (t/day06-part1-soln)))))
+    (is (= 1855 (t/day06-part1-soln day06-input)))))
 
 (deftest day06-part2-soln
   (testing "Reproduces the answer for day06, part2"
-    (is (= 3256 (t/day06-part2-soln)))))
+    (is (= 3256 (t/day06-part2-soln day06-input)))))

--- a/test/aoc_clj/2022/day07_test.clj
+++ b/test/aoc_clj/2022/day07_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2022.day07-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day07 :as t]))
 
-(def d07-s01-raw
+(def d07-s00-raw
   ["$ cd /"
    "$ ls"
    "dir a"
@@ -27,7 +28,7 @@
    "5626152 d.ext"
    "7214296 k"])
 
-(def d07-s01
+(def d07-s00
   {"/"
    {"a"
     {"e"
@@ -45,33 +46,35 @@
 
 (deftest parse-test
   (testing "Parses the terminal commands to construct the directory tree"
-    (is (= d07-s01 (t/parse d07-s01-raw)))))
+    (is (= d07-s00 (t/parse d07-s00-raw)))))
 
 (deftest node-size-test
   (testing "Returns the size of the node in the directory tree"
-    (is (= 584 (t/node-size d07-s01 ["/" "a" "e"])))
-    (is (= 94853 (t/node-size d07-s01 ["/" "a"])))
-    (is (= 24933642 (t/node-size d07-s01 ["/" "d"])))
-    (is (= 48381165 (t/node-size d07-s01 ["/"])))))
+    (is (= 584 (t/node-size d07-s00 ["/" "a" "e"])))
+    (is (= 94853 (t/node-size d07-s00 ["/" "a"])))
+    (is (= 24933642 (t/node-size d07-s00 ["/" "d"])))
+    (is (= 48381165 (t/node-size d07-s00 ["/"])))))
 
 (deftest dir-path-test
   (testing "Returns the paths to all the directory nodes"
     (is (= [["/"] ["/" "a"] ["/" "a" "e"] ["/" "d"]]
-           (t/dir-paths d07-s01)))))
+           (t/dir-paths d07-s00)))))
 
 (deftest dir-total-below-100k-test
   (testing "Finds the sum of the sizes of directories smaller than 100k"
-    (is (= 95437 (t/dir-total-below-100k d07-s01)))))
+    (is (= 95437 (t/dir-total-below-100k d07-s00)))))
 
 (deftest smallest-dir-size-to-remove-test
   (testing "Find the size of the smallest directory that can be removed
             to free up the necessary disk space"
-    (is (= 24933642 (t/smallest-dir-size-to-remove d07-s01)))))
+    (is (= 24933642 (t/smallest-dir-size-to-remove d07-s00)))))
+
+(def day07-input (u/parse-puzzle-input t/parse 2022 7))
 
 (deftest day07-part1-soln
   (testing "Reproduces the answer for day07, part1"
-    (is (= 1306611 (t/day07-part1-soln)))))
+    (is (= 1306611 (t/day07-part1-soln day07-input)))))
 
 (deftest day07-part2-soln
   (testing "Reproduces the answer for day07, part2"
-    (is (= 13210366 (t/day07-part2-soln)))))
+    (is (= 13210366 (t/day07-part2-soln day07-input)))))

--- a/test/aoc_clj/2022/day08_test.clj
+++ b/test/aoc_clj/2022/day08_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2022.day08-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day08 :as t]))
 
-(def d08-s01
+(def d08-s00
   (t/parse
    ["30373"
     "25512"
@@ -12,7 +13,7 @@
 
 (deftest parse-test
   (testing "Correctly parses the sample input"
-    (is (= d08-s01
+    (is (= d08-s00
            [[3 0 3 7 3]
             [2 5 5 1 2]
             [6 5 3 3 2]
@@ -21,46 +22,48 @@
 
 (deftest visible?-test
   (testing "Determines which trees are visible in a given direction"
-    (is (= [1 0 0 1 0] (t/visible? (nth d08-s01 0))))
-    (is (= [1 1 0 0 0] (t/visible? (nth d08-s01 1))))
-    (is (= [1 0 0 0 0] (t/visible? (nth d08-s01 2))))
-    (is (= [1 0 1 0 1] (t/visible? (nth d08-s01 3))))
-    (is (= [1 1 0 1 0] (t/visible? (nth d08-s01 4))))))
+    (is (= [1 0 0 1 0] (t/visible? (nth d08-s00 0))))
+    (is (= [1 1 0 0 0] (t/visible? (nth d08-s00 1))))
+    (is (= [1 0 0 0 0] (t/visible? (nth d08-s00 2))))
+    (is (= [1 0 1 0 1] (t/visible? (nth d08-s00 3))))
+    (is (= [1 1 0 1 0] (t/visible? (nth d08-s00 4))))))
 
 (deftest row-visibility-test
   (testing "Determines which trees are visible from either edge"
-    (is (= [1 0 0 1 1] (t/row-visibility (nth d08-s01 0))))
-    (is (= [1 1 1 0 1] (t/row-visibility (nth d08-s01 1))))
-    (is (= [1 1 0 1 1] (t/row-visibility (nth d08-s01 2))))
-    (is (= [1 0 1 0 1] (t/row-visibility (nth d08-s01 3))))
-    (is (= [1 1 0 1 1] (t/row-visibility (nth d08-s01 4))))))
+    (is (= [1 0 0 1 1] (t/row-visibility (nth d08-s00 0))))
+    (is (= [1 1 1 0 1] (t/row-visibility (nth d08-s00 1))))
+    (is (= [1 1 0 1 1] (t/row-visibility (nth d08-s00 2))))
+    (is (= [1 0 1 0 1] (t/row-visibility (nth d08-s00 3))))
+    (is (= [1 1 0 1 1] (t/row-visibility (nth d08-s00 4))))))
 
 (deftest view-distance-test
   (testing "Determines the view distance product in the horizontal direction"
-    (is (= (* 0 2) (t/view-distance (nth d08-s01 0) 0)))
-    (is (= (* 1 1) (t/view-distance (nth d08-s01 0) 1)))
-    (is (= (* 2 1) (t/view-distance (nth d08-s01 0) 2)))
-    (is (= (* 3 1) (t/view-distance (nth d08-s01 0) 3)))
-    (is (= (* 1 0) (t/view-distance (nth d08-s01 0) 4)))
+    (is (= (* 0 2) (t/view-distance (nth d08-s00 0) 0)))
+    (is (= (* 1 1) (t/view-distance (nth d08-s00 0) 1)))
+    (is (= (* 2 1) (t/view-distance (nth d08-s00 0) 2)))
+    (is (= (* 3 1) (t/view-distance (nth d08-s00 0) 3)))
+    (is (= (* 1 0) (t/view-distance (nth d08-s00 0) 4)))
 
-    (is (= (* 0 1) (t/view-distance (nth d08-s01 1) 0)))
-    (is (= (* 1 1) (t/view-distance (nth d08-s01 1) 1)))
-    (is (= (* 1 2) (t/view-distance (nth d08-s01 1) 2)))
-    (is (= (* 1 1) (t/view-distance (nth d08-s01 1) 3)))
-    (is (= (* 2 0) (t/view-distance (nth d08-s01 1) 4)))))
+    (is (= (* 0 1) (t/view-distance (nth d08-s00 1) 0)))
+    (is (= (* 1 1) (t/view-distance (nth d08-s00 1) 1)))
+    (is (= (* 1 2) (t/view-distance (nth d08-s00 1) 2)))
+    (is (= (* 1 1) (t/view-distance (nth d08-s00 1) 3)))
+    (is (= (* 2 0) (t/view-distance (nth d08-s00 1) 4)))))
 
 (deftest visible-trees-test
   (testing "Counts the number of visible trees in the sample data"
-    (is (= 21 (t/visible-trees d08-s01)))))
+    (is (= 21 (t/visible-trees d08-s00)))))
 
 (deftest max-scenic-score-test
   (testing "Finds the maximum scenic score in the sample data"
-    (is (= 8 (t/max-scenic-score d08-s01)))))
+    (is (= 8 (t/max-scenic-score d08-s00)))))
+
+(def day08-input (u/parse-puzzle-input t/parse 2022 8))
 
 (deftest day08-part1-soln
   (testing "Reproduces the answer for day08, part1"
-    (is (= 1538 (t/day08-part1-soln)))))
+    (is (= 1538 (t/day08-part1-soln day08-input)))))
 
 (deftest day08-part2-soln
   (testing "Reproduces the answer for day08, part2"
-    (is (= 496125 (t/day08-part2-soln)))))
+    (is (= 496125 (t/day08-part2-soln day08-input)))))

--- a/test/aoc_clj/2022/day09_test.clj
+++ b/test/aoc_clj/2022/day09_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2022.day09-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day09 :as t]))
 
 (def d09-s01
@@ -52,10 +53,12 @@
     (is (= 1  (t/distinct-tail-positions 10 d09-s01)))
     (is (= 36 (t/distinct-tail-positions 10 d09-s02)))))
 
+(def day09-input (u/parse-puzzle-input t/parse 2022 9))
+
 (deftest day09-part1-soln
   (testing "Reproduces the answer for day09, part1"
-    (is (= 5874 (t/day09-part1-soln)))))
+    (is (= 5874 (t/day09-part1-soln day09-input)))))
 
 (deftest day09-part2-soln
   (testing "Reproduces the answer for day09, part2"
-    (is (= 2467 (t/day09-part2-soln)))))
+    (is (= 2467 (t/day09-part2-soln day09-input)))))

--- a/test/aoc_clj/2022/day10_test.clj
+++ b/test/aoc_clj/2022/day10_test.clj
@@ -1,14 +1,15 @@
 (ns aoc-clj.2022.day10-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day10 :as t]))
 
-(def d10-01
+(def d10-s00
   (t/parse
    ["noop"
     "addx 3"
     "addx -5"]))
 
-(def d10-02
+(def d10-s01
   (t/parse
    ["addx 15"
     "addx -11"
@@ -157,7 +158,7 @@
     "noop"
     "noop"]))
 
-(def d10-02-screen
+(def d10-s01-screen
   "##..##..##..##..##..##..##..##..##..##..
 ###...###...###...###...###...###...###.
 ####....####....####....####....####....
@@ -167,25 +168,27 @@
 
 (deftest parse-test
   (testing "Correctly parses the sample input"
-    (is (= d10-01
+    (is (= d10-s00
            [::t/noop 3 -5]))))
 
 (deftest register-values-test
   (testing "Computes the register value over time given the instructions"
-    (is (= [1 1 1 4 4 -1] (t/register-values d10-01)))))
+    (is (= [1 1 1 4 4 -1] (t/register-values d10-s00)))))
 
 (deftest sampled-signal-strength-sums-test
   (testing "Computes the sum of the signal strengths sampled every 40 ticks"
-    (is (= 13140 (t/sampled-signal-strength-sums d10-02)))))
+    (is (= 13140 (t/sampled-signal-strength-sums d10-s01)))))
 
 (deftest screen-test
   (testing "The screen lighting logic produces the test pattern"
-    (is (= d10-02-screen (t/screen d10-02)))))
+    (is (= d10-s01-screen (t/screen d10-s01)))))
+
+(def day10-input (u/parse-puzzle-input t/parse 2022 10))
 
 (deftest day10-part1-soln
   (testing "Reproduces the answer for day10, part1"
-    (is (= 16020 (t/day10-part1-soln)))))
+    (is (= 16020 (t/day10-part1-soln day10-input)))))
 
 (deftest day10-part2-soln
   (testing "Reproduces the answer for day10, part2"
-    (is (= "ECZUZALR" (t/day10-part2-soln)))))
+    (is (= "ECZUZALR" (t/day10-part2-soln day10-input)))))

--- a/test/aoc_clj/2022/day11_test.clj
+++ b/test/aoc_clj/2022/day11_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2022.day11-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day11 :as t]))
 
-(def d11-s01
+(def d11-s00
   (t/parse
    ["Monkey 0:"
     "  Starting items: 79, 98"
@@ -34,7 +35,7 @@
 
 (deftest parse-test
   (testing "Correctly parses the input sample"
-    (is (= d11-s01
+    (is (= d11-s00
            [{:counts    0
              :items     [79 98]
              :operation ["*" 19]
@@ -66,49 +67,51 @@
             [2080 25 167 207 401 1046]
             []
             []]
-           (t/items (t/round-1 d11-s01))))
+           (t/items (t/round-1 d11-s00))))
     (is (= [[695 10 71 135 350]
             [43 49 58 55 362]
             []
             []]
-           (t/items (t/round-1 (t/round-1 d11-s01)))))
+           (t/items (t/round-1 (t/round-1 d11-s00)))))
     (is (= [[83, 44, 8, 184, 9, 20, 26, 102]
             [110, 36]
             []
             []]
-           (t/items (nth (iterate t/round-1 d11-s01) 15))))
+           (t/items (nth (iterate t/round-1 d11-s00) 15))))
     (is (= [[10, 12, 14, 26, 34]
             [245, 93, 53, 199, 115]
             []
             []]
-           (t/items (nth (iterate t/round-1 d11-s01) 20))))))
+           (t/items (nth (iterate t/round-1 d11-s00) 20))))))
 
 (deftest counts-test
   (testing "Counts the number of items inspected by each monkey"
     (is (= [101 95 7 105]
-           (t/counts (nth (iterate t/round-1 d11-s01) 20))))
+           (t/counts (nth (iterate t/round-1 d11-s00) 20))))
     ;; part 2
     (is (= [2 4 3 6]
-           (t/counts (nth (iterate t/round-2 (t/part2-augment d11-s01)) 1))))
+           (t/counts (nth (iterate t/round-2 (t/part2-augment d11-s00)) 1))))
     (is (= [99 97 8 103]
-           (t/counts (nth (iterate t/round-2 (t/part2-augment d11-s01)) 20))))
+           (t/counts (nth (iterate t/round-2 (t/part2-augment d11-s00)) 20))))
     (is (= [5204 4792 199 5192]
-           (t/counts (nth (iterate t/round-2 (t/part2-augment d11-s01)) 1000))))
+           (t/counts (nth (iterate t/round-2 (t/part2-augment d11-s00)) 1000))))
     (is (= [26075 23921 974 26000]
-           (t/counts (nth (iterate t/round-2 (t/part2-augment d11-s01)) 5000))))
+           (t/counts (nth (iterate t/round-2 (t/part2-augment d11-s00)) 5000))))
     (is (= [52166 47830 1938 52013]
-           (t/counts (nth (iterate t/round-2 (t/part2-augment d11-s01)) 10000))))))
+           (t/counts (nth (iterate t/round-2 (t/part2-augment d11-s00)) 10000))))))
 
 (deftest monkey-business-test
   (testing "Computes the monkey business score (product of top two 
             inspection counts)"
-    (is (= 10605 (t/monkey-business-1 d11-s01 20)))
-    (is (= 2713310158 (t/monkey-business-2 (t/part2-augment d11-s01) 10000)))))
+    (is (= 10605 (t/monkey-business-1 d11-s00 20)))
+    (is (= 2713310158 (t/monkey-business-2 (t/part2-augment d11-s00) 10000)))))
+
+(def day11-input (u/parse-puzzle-input t/parse 2022 11))
 
 (deftest day11-part1-soln
   (testing "Reproduces the answer for day11, part1"
-    (is (= 112221 (t/day11-part1-soln)))))
+    (is (= 112221 (t/day11-part1-soln day11-input)))))
 
 (deftest day11-part2-soln
   (testing "Reproduces the answer for day11, part2"
-    (is (= 25272176808 (t/day11-part2-soln)))))
+    (is (= 25272176808 (t/day11-part2-soln day11-input)))))

--- a/test/aoc_clj/2022/day12_test.clj
+++ b/test/aoc_clj/2022/day12_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2022.day12-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day12 :as t]))
 
-(def d12-s01
+(def d12-s00
   (t/parse
    ["Sabqponm"
     "abcryxxl"
@@ -12,16 +13,18 @@
 
 (deftest shortest-path-from-start-test
   (testing "Finds the shortest path from the start location"
-    (is (= 31 (t/shortest-path-from-start d12-s01)))))
+    (is (= 31 (t/shortest-path-from-start d12-s00)))))
 
 (deftest shortest-path-from-any-a-test
   (testing "Finds the shortest path from any position at altitude a"
-    (is (= 29 (t/shortest-path-from-any-a d12-s01)))))
+    (is (= 29 (t/shortest-path-from-any-a d12-s00)))))
+
+(def day12-input (u/parse-puzzle-input t/parse 2022 12))
 
 (deftest day12-part1-soln
   (testing "Reproduces the answer for day12, part1"
-    (is (= 408 (t/day12-part1-soln)))))
+    (is (= 408 (t/day12-part1-soln day12-input)))))
 
 (deftest day12-part2-soln
   (testing "Reproduces the answer for day12, part2"
-    (is (= 399 (t/day12-part2-soln)))))
+    (is (= 399 (t/day12-part2-soln day12-input)))))

--- a/test/aoc_clj/2022/day13_test.clj
+++ b/test/aoc_clj/2022/day13_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2022.day13-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day13 :as t]))
 
-(def d13-s01
+(def d13-s00
   (t/parse
    ["[1,1,3,1,1]"
     "[1,1,5,1,1]"
@@ -30,7 +31,7 @@
 
 (deftest parse-test
   (testing "Correctly parses the sample input"
-    (is (= d13-s01
+    (is (= d13-s00
            [[[1 1 3 1 1] [1 1 5 1 1]]
             [[[1] [2 3 4]] [[1] 4]]
             [[9] [[8 7 6]]]
@@ -41,7 +42,7 @@
             [[1 [2 [3 [4 [5 6 7]]]] 8 9]
              [1 [2 [3 [4 [5 6 0]]]] 8 9]]]))))
 
-(def d13-s01-sorted
+(def d13-s00-sorted
   [[]
    [[]]
    [[[]]]
@@ -66,32 +67,34 @@
     ;; If the right list runs out of items first, 
     ;; the inputs are not in the right order.
     (is (true? (t/in-order? [1 2] [2])))
-    (is (true?  (apply t/in-order? (nth d13-s01 0))))
-    (is (true?  (apply t/in-order? (nth d13-s01 1))))
-    (is (false? (apply t/in-order? (nth d13-s01 2))))
-    (is (true?  (apply t/in-order? (nth d13-s01 3))))
-    (is (false? (apply t/in-order? (nth d13-s01 4))))
-    (is (true?  (apply t/in-order? (nth d13-s01 5))))
-    (is (false? (apply t/in-order? (nth d13-s01 6))))
-    (is (false? (apply t/in-order? (nth d13-s01 7))))))
+    (is (true?  (apply t/in-order? (nth d13-s00 0))))
+    (is (true?  (apply t/in-order? (nth d13-s00 1))))
+    (is (false? (apply t/in-order? (nth d13-s00 2))))
+    (is (true?  (apply t/in-order? (nth d13-s00 3))))
+    (is (false? (apply t/in-order? (nth d13-s00 4))))
+    (is (true?  (apply t/in-order? (nth d13-s00 5))))
+    (is (false? (apply t/in-order? (nth d13-s00 6))))
+    (is (false? (apply t/in-order? (nth d13-s00 7))))))
 
 (deftest right-order-packet-id-sum-test
   (testing "The sum of the packet pair ids for in-order packets"
-    (is (= 13 (t/right-order-packet-id-sum d13-s01)))))
+    (is (= 13 (t/right-order-packet-id-sum d13-s00)))))
 
 (deftest sorted-test
   (testing "Returns the packets in-order, with the divider packets"
-    (is (= d13-s01-sorted (t/sorted d13-s01)))))
+    (is (= d13-s00-sorted (t/sorted d13-s00)))))
 
 (deftest decoder-key-test
   (testing "Computes the decoder key (product of indices of two divider 
             packets)"
-    (is (= 140 (t/decoder-key d13-s01)))))
+    (is (= 140 (t/decoder-key d13-s00)))))
+
+(def day13-input (u/parse-puzzle-input t/parse 2022 13))
 
 (deftest day13-part1-soln
   (testing "Reproduces the answer for day13, part1"
-    (is (= 5503 (t/day13-part1-soln)))))
+    (is (= 5503 (t/day13-part1-soln day13-input)))))
 
 (deftest day13-part2-soln
   (testing "Reproduces the answer for day13, part2"
-    (is (= 20952 (t/day13-part2-soln)))))
+    (is (= 20952 (t/day13-part2-soln day13-input)))))

--- a/test/aoc_clj/2022/day14_test.clj
+++ b/test/aoc_clj/2022/day14_test.clj
@@ -1,15 +1,16 @@
 (ns aoc-clj.2022.day14-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day14 :as t]))
 
-(def d14-s01
+(def d14-s00
   (t/parse
    ["498,4 -> 498,6 -> 496,6"
     "503,4 -> 502,4 -> 502,9 -> 494,9"]))
 
 (deftest parse-test
   (testing "Correctly parses the sample input"
-    (is (= d14-s01
+    (is (= d14-s00
            #{[498 4]
              [498 5]
              [498 6]
@@ -41,7 +42,7 @@
                         [-1 1]
                         [1 1]} [0 0])))))
 
-(def sample (t/init-state d14-s01))
+(def sample (t/init-state d14-s00))
 (deftest deposit-sand-grain-test
   (testing "Updates the grid with a newly deposited sand grain"
     (is (= [500 8]
@@ -70,12 +71,14 @@
 
 (deftest sand-until-continuous-flow-test
   (testing "Finds the amount of sand that sticks before continuous flow"
-    (is (= 24 (t/sand-until-continuous-flow d14-s01)))))
+    (is (= 24 (t/sand-until-continuous-flow d14-s00)))))
+
+(def day14-input (u/parse-puzzle-input t/parse 2022 14))
 
 (deftest day14-part1-soln
   (testing "Reproduces the answer for day14, part1"
-    (is (= 913 (t/day14-part1-soln)))))
+    (is (= 913 (t/day14-part1-soln day14-input)))))
 
 (deftest day14-part2-soln
   (testing "Reproduces the answer for day14, part2"
-    (is (= 30762 (t/day14-part2-soln)))))
+    (is (= 30762 (t/day14-part2-soln day14-input)))))

--- a/test/aoc_clj/2022/day15_test.clj
+++ b/test/aoc_clj/2022/day15_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2022.day15-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day15 :as t]))
 
-(def d15-s01
+(def d15-s00
   (t/parse
    ["Sensor at x=2, y=18: closest beacon is at x=-2, y=15"
     "Sensor at x=9, y=16: closest beacon is at x=10, y=16"
@@ -21,7 +22,7 @@
 
 (deftest parse-test
   (testing "Correctly parses the sample input"
-    (is (= d15-s01
+    (is (= d15-s00
            [{:sensor [2 18],  :beacon [-2 15], :radius 7}
             {:sensor [9 16],  :beacon [10 16], :radius 1}
             {:sensor [13 2],  :beacon [15 3],  :radius 3}
@@ -40,20 +41,22 @@
 (deftest no-beacon-points-in-line-test
   (testing "Finds the right number of points that can't contain a beacon
             at a given line"
-    (is (= 26 (t/no-beacon-points-in-line d15-s01 10)))))
+    (is (= 26 (t/no-beacon-points-in-line d15-s00 10)))))
 
 (deftest gap-position
   (testing "Finds the point where there's no sensor coverage"
-    (is (= [14 11] (t/gap-position d15-s01)))))
+    (is (= [14 11] (t/gap-position d15-s00)))))
 
 (deftest tuning-frequency
   (testing "Computes the tuning frequency based on [x,y]"
     (is (= 56000011 (t/tuning-frequency [14 11])))))
 
+(def day15-input (u/parse-puzzle-input t/parse 2022 15))
+
 (deftest day15-part1-soln
   (testing "Reproduces the answer for day15, part1"
-    (is (= 4907780 (t/day15-part1-soln)))))
+    (is (= 4907780 (t/day15-part1-soln day15-input)))))
 
 (deftest day15-part2-soln
   (testing "Reproduces the answer for day15, part2"
-    (is (= 13639962836448 (t/day15-part2-soln)))))
+    (is (= 13639962836448 (t/day15-part2-soln day15-input)))))

--- a/test/aoc_clj/2022/day16_test.clj
+++ b/test/aoc_clj/2022/day16_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2022.day16-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day16 :as t]))
 
 (def d16-s01
@@ -46,13 +47,15 @@
   (testing "Finds the optimum amount of pressure released"
     (is (= 1707 (t/best-pressure-2 d16-s01)))))
 
+(def day16-input (u/parse-puzzle-input t/parse 2022 16))
+
 ;; FIXME: The implementation is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/28
 
 (deftest ^:slow day16-part1-soln
   (testing "Reproduces the answer for day16, part1"
-    (is (= 1701 (t/day16-part1-soln)))))
+    (is (= 1701 (t/day16-part1-soln day16-input)))))
 
 (deftest ^:slow day16-part2-soln
   (testing "Reproduces the answer for day16, part2"
-    (is (= 2455 (t/day16-part2-soln)))))
+    (is (= 2455 (t/day16-part2-soln day16-input)))))

--- a/test/aoc_clj/2022/day17_test.clj
+++ b/test/aoc_clj/2022/day17_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2022.day17-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day17 :as t]))
 
-(def d17-s01 ">>><<><>><<<>><>>><<<>>><<<><<<>><>><<>>")
+(def d17-s00 ">>><<><>><<<>><>>><<<>>><<<><<<>><>><<>>")
 
 (def step0 #{})
 (def step1 (into step0 [[2 1] [3 1] [4 1] [5 1]]))
@@ -13,21 +14,23 @@
 
 (deftest deposit-shape-test
   (testing "Lowers a new rock into place, as moved around by the jets"
-    (is (= step1 (:rocks (t/simulate d17-s01 1))))
-    (is (= step2 (:rocks (t/simulate d17-s01 2))))
-    (is (= step3 (:rocks (t/simulate d17-s01 3))))
-    (is (= step4 (:rocks (t/simulate d17-s01 4))))
-    (is (= step5 (:rocks (t/simulate d17-s01 5))))))
+    (is (= step1 (:rocks (t/simulate d17-s00 1))))
+    (is (= step2 (:rocks (t/simulate d17-s00 2))))
+    (is (= step3 (:rocks (t/simulate d17-s00 3))))
+    (is (= step4 (:rocks (t/simulate d17-s00 4))))
+    (is (= step5 (:rocks (t/simulate d17-s00 5))))))
 
 (deftest tower-height-after-n-test
   (testing "Computes the height after a number of rocks have been deposited"
-    (is (= 3068 (t/tower-height-after-n d17-s01 2022)))
-    (is (= 1514285714288 (t/tower-height-after-n d17-s01 1000000000000)))))
+    (is (= 3068 (t/tower-height-after-n d17-s00 2022)))
+    (is (= 1514285714288 (t/tower-height-after-n d17-s00 1000000000000)))))
+
+(def day17-input (u/parse-puzzle-input t/parse 2022 17))
 
 (deftest day17-part1-soln
   (testing "Reproduces the answer for day17, part1"
-    (is (= 3171 (t/day17-part1-soln)))))
+    (is (= 3171 (t/day17-part1-soln day17-input)))))
 
 (deftest day17-part2-soln
   (testing "Reproduces the answer for day17, part2"
-    (is (= 1586627906921 (t/day17-part2-soln)))))
+    (is (= 1586627906921 (t/day17-part2-soln day17-input)))))

--- a/test/aoc_clj/2022/day18_test.clj
+++ b/test/aoc_clj/2022/day18_test.clj
@@ -1,12 +1,13 @@
 (ns aoc-clj.2022.day18-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day18 :as t]))
 
-(def d18-s01
+(def d18-s00
   #{[1 1 1]
     [2 1 1]})
 
-(def d18-s02
+(def d18-s01
   #{[2 2 2]
     [1 2 2]
     [3 2 2]
@@ -23,19 +24,21 @@
 
 (deftest surface-area-test
   (testing "Counts the number of exposed (non-adjacent) sides of the cubes"
-    (is (= 10 (t/surface-area d18-s01)))
-    (is (= 64 (t/surface-area d18-s02)))))
+    (is (= 10 (t/surface-area d18-s00)))
+    (is (= 64 (t/surface-area d18-s01)))))
 
 (deftest outer-surface-area-test
   (testing "Counts the number of exposed (non-adjacent) sides of the cubes
             that are along the outer surface"
-    (is (= 10 (t/outer-surface-area d18-s01)))
-    (is (= 58 (t/outer-surface-area d18-s02)))))
+    (is (= 10 (t/outer-surface-area d18-s00)))
+    (is (= 58 (t/outer-surface-area d18-s01)))))
+
+(def day18-input (u/parse-puzzle-input t/parse 2022 18))
 
 (deftest day18-part1-soln
   (testing "Reproduces the answer for day18, part1"
-    (is (= 3390 (t/day18-part1-soln)))))
+    (is (= 3390 (t/day18-part1-soln day18-input)))))
 
 (deftest day18-part2-soln
   (testing "Reproduces the answer for day18, part2"
-    (is (= 2058 (t/day18-part2-soln)))))
+    (is (= 2058 (t/day18-part2-soln day18-input)))))

--- a/test/aoc_clj/2022/day19_test.clj
+++ b/test/aoc_clj/2022/day19_test.clj
@@ -1,5 +1,6 @@
 (ns aoc-clj.2022.day19-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day19 :as t]))
 
 (def d19-s01
@@ -37,12 +38,14 @@
   (testing "Computes the sum of all the quality levels of all the blueprints"
     (is (= 33 (t/quality-level-sum d19-s01)))))
 
+(def day19-input (u/parse-puzzle-input t/parse 2022 19))
+
 ;; FIXME: Solution is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/33
 (deftest ^:slow day19-part1-soln
   (testing "Reproduces the answer for day19, part1"
-    (is (= 1395 (t/day19-part1-soln)))))
+    (is (= 1395 (t/day19-part1-soln day19-input)))))
 
 (deftest ^:slow day19-part2-soln
   (testing "Reproduces the answer for day19, part2"
-    (is (= 2700 (t/day19-part2-soln)))))
+    (is (= 2700 (t/day19-part2-soln day19-input)))))

--- a/test/aoc_clj/2022/day20_test.clj
+++ b/test/aoc_clj/2022/day20_test.clj
@@ -1,51 +1,54 @@
 (ns aoc-clj.2022.day20-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day20 :as t]))
 
-(def d20-s01   [1 2 -3 3 -2 0 4])
-(def d20-s01-1 [2 1 -3 3 -2 0 4])
-(def d20-s01-2 [1 -3 2 3 -2 0 4])
-(def d20-s01-3 [1 2 3 -2 -3 0 4])
-(def d20-s01-4 [1 2 -2 -3 0 3 4])
-(def d20-s01-5 [1 2 -3 0 3 4 -2])
-(def d20-s01-6 [1 2 -3 0 3 4 -2])
-(def d20-s01-7 [1 2 -3 4 0 3 -2])
+(def d20-s00   [1 2 -3 3 -2 0 4])
+(def d20-s00-1 [2 1 -3 3 -2 0 4])
+(def d20-s00-2 [1 -3 2 3 -2 0 4])
+(def d20-s00-3 [1 2 3 -2 -3 0 4])
+(def d20-s00-4 [1 2 -2 -3 0 3 4])
+(def d20-s00-5 [1 2 -3 0 3 4 -2])
+(def d20-s00-6 [1 2 -3 0 3 4 -2])
+(def d20-s00-7 [1 2 -3 4 0 3 -2])
 
 (deftest mix-test
   (testing "Mixes the values correctly, one at a time"
-    (is (= d20-s01-1
-           (mapv d20-s01 (t/mix d20-s01 (vec (range 7)) 0))))
-    (is (= d20-s01-2
-           (mapv d20-s01-1 (t/mix d20-s01-1 (vec (range 7)) 0))))
-    (is (= d20-s01-3
-           (mapv d20-s01-2 (t/mix d20-s01-2 (vec (range 7)) 1))))
-    (is (= d20-s01-4
-           (mapv d20-s01-3 (t/mix d20-s01-3 (vec (range 7)) 2))))
-    (is (= d20-s01-5
-           (mapv d20-s01-4 (t/mix d20-s01-4 (vec (range 7)) 2))))
-    (is (= d20-s01-6
-           (mapv d20-s01-5 (t/mix d20-s01-5 (vec (range 7)) 3))))
-    (is (= d20-s01-7
-           (mapv d20-s01-6 (t/mix d20-s01-6 (vec (range 7)) 5))))))
+    (is (= d20-s00-1
+           (mapv d20-s00 (t/mix d20-s00 (vec (range 7)) 0))))
+    (is (= d20-s00-2
+           (mapv d20-s00-1 (t/mix d20-s00-1 (vec (range 7)) 0))))
+    (is (= d20-s00-3
+           (mapv d20-s00-2 (t/mix d20-s00-2 (vec (range 7)) 1))))
+    (is (= d20-s00-4
+           (mapv d20-s00-3 (t/mix d20-s00-3 (vec (range 7)) 2))))
+    (is (= d20-s00-5
+           (mapv d20-s00-4 (t/mix d20-s00-4 (vec (range 7)) 2))))
+    (is (= d20-s00-6
+           (mapv d20-s00-5 (t/mix d20-s00-5 (vec (range 7)) 3))))
+    (is (= d20-s00-7
+           (mapv d20-s00-6 (t/mix d20-s00-6 (vec (range 7)) 5))))))
 
 (deftest mixed-test
   (testing "Completes all mixing correctly"
-    (is (= d20-s01-7 (t/mixed d20-s01)))))
+    (is (= d20-s00-7 (t/mixed d20-s00)))))
 
 (deftest grove-coordinates-test
   (testing "Computes the `grove coordinates`"
-    (is (= 3 (t/grove-coordinates d20-s01-7)))))
+    (is (= 3 (t/grove-coordinates d20-s00-7)))))
 
 (deftest decrypt-and-mix-ten-test
   (testing "Applies decryption key and mixes 10 times"
-    (is (= 1623178306 (t/decrypt-and-mix-ten d20-s01)))))
+    (is (= 1623178306 (t/decrypt-and-mix-ten d20-s00)))))
+
+(def day20-input (u/parse-puzzle-input t/parse 2022 20))
 
 ;; FIXME: Implementation is far too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/29
 (deftest ^:slow day20-part1-soln
   (testing "Reproduces the answer for day20, part1"
-    (is (= 9866 (t/day20-part1-soln)))))
+    (is (= 9866 (t/day20-part1-soln day20-input)))))
 
 (deftest ^:slow day20-part2-soln
   (testing "Reproduces the answer for day20, part2"
-    (is (= 12374299815791 (t/day20-part2-soln)))))
+    (is (= 12374299815791 (t/day20-part2-soln day20-input)))))

--- a/test/aoc_clj/2022/day21_test.clj
+++ b/test/aoc_clj/2022/day21_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2022.day21-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day21 :as t]))
 
-(def d21-s01
+(def d21-s00
   (t/parse
    ["root: pppw + sjmn"
     "dbpl: 5"
@@ -22,7 +23,7 @@
 
 (deftest parse-test
   (testing "Correctly parses the sample input"
-    (is (= d21-s01
+    (is (= d21-s00
            {"root" ["pppw" "+" "sjmn"]
             "dbpl" 5
             "cczh" ["sllz" "+" "lgvd"]
@@ -41,7 +42,7 @@
 
 (deftest yell-test
   (testing "Yells out the value for root on the sample data"
-    (is (= 152 (t/root-yell d21-s01)))))
+    (is (= 152 (t/root-yell d21-s00)))))
 
 (deftest solve-for-x-test
   (testing "Inverts an equation to solve for the unknown"
@@ -57,12 +58,14 @@
 
 (deftest humn-value-test
   (testing "Computes the value the human should yell"
-    (is (= 301 (t/humn-value d21-s01)))))
+    (is (= 301 (t/humn-value d21-s00)))))
+
+(def day21-input (u/parse-puzzle-input t/parse 2022 21))
 
 (deftest day21-part1-soln
   (testing "Reproduces the answer for day21, part1"
-    (is (= 63119856257960 (t/day21-part1-soln)))))
+    (is (= 63119856257960 (t/day21-part1-soln day21-input)))))
 
 (deftest day21-part2-soln
   (testing "Reproduces the answer for day21, part2"
-    (is (= 3006709232464 (t/day21-part2-soln)))))
+    (is (= 3006709232464 (t/day21-part2-soln day21-input)))))

--- a/test/aoc_clj/2022/day22_test.clj
+++ b/test/aoc_clj/2022/day22_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2022.day22-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day22 :as t]))
 
-(def d22-s01
+(def d22-s00
   (t/parse
    ["        ...#"
     "        .#.."
@@ -21,7 +22,7 @@
 
 (deftest parse-test
   (testing "Correctly parses the sample input"
-    (is (= (select-keys d22-s01 [:start :h-zones :v-zones :path])
+    (is (= (select-keys d22-s00 [:start :h-zones :v-zones :path])
            {;; The start point is the upper-leftmost non-empty cell
             :start [9 1]
             ;; Horizontal zones are broken down to indicate areas
@@ -64,27 +65,29 @@
 
 (deftest wrap-around-test
   (testing "Computes the wrap-around positions correctly"
-    (is (= [9 1]  (:pos (t/wrap-around d22-s01 :R [13 1]))))
-    (is (= [12 1] (:pos (t/wrap-around d22-s01 :L [8 1]))))
-    (is (= [9 12] (:pos (t/wrap-around d22-s01 :U [9 0]))))
-    (is (= [12 5] (:pos (t/wrap-around d22-s01 :L [0 5]))))))
+    (is (= [9 1]  (:pos (t/wrap-around d22-s00 :R [13 1]))))
+    (is (= [12 1] (:pos (t/wrap-around d22-s00 :L [8 1]))))
+    (is (= [9 12] (:pos (t/wrap-around d22-s00 :U [9 0]))))
+    (is (= [12 5] (:pos (t/wrap-around d22-s00 :L [0 5]))))))
 
 (deftest follow-path-test
   (testing "Follows the path and arrives at the correct final position/orientation"
     (is (= {:pos [8 6] :facing :R}
-           (t/follow-path (assoc d22-s01 :wrap-fn t/wrap-around))))))
+           (t/follow-path (assoc d22-s00 :wrap-fn t/wrap-around))))))
 
 (deftest final-password-test
   (testing "Computes the final password given the final position/orientation"
     (is (= 6032 (t/final-password
-                 (t/follow-path (assoc d22-s01 :wrap-fn t/wrap-around)))))
+                 (t/follow-path (assoc d22-s00 :wrap-fn t/wrap-around)))))
     (is (= 5031 (t/final-password
-                 (t/follow-path (assoc d22-s01 :wrap-fn sample-cube-wrap-around)))))))
+                 (t/follow-path (assoc d22-s00 :wrap-fn sample-cube-wrap-around)))))))
+
+(def day22-input (u/parse-puzzle-input t/parse 2022 22))
 
 (deftest day22-part1-soln
   (testing "Reproduces the answer for day22, part1"
-    (is (= 1428 (t/day22-part1-soln)))))
+    (is (= 1428 (t/day22-part1-soln day22-input)))))
 
 (deftest day22-part2-soln
   (testing "Reproduces the answer for day22, part2"
-    (is (= 142380 (t/day22-part2-soln)))))
+    (is (= 142380 (t/day22-part2-soln day22-input)))))

--- a/test/aoc_clj/2022/day23_test.clj
+++ b/test/aoc_clj/2022/day23_test.clj
@@ -3,7 +3,7 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day23 :as t]))
 
-(def d23-s01
+(def d23-s00
   (t/parse
    ["....."
     "..##."
@@ -12,7 +12,7 @@
     "..##."
     "....."]))
 
-(def d23-s01-1
+(def d23-s00-1
   (t/parse
    ["..##."
     "....."
@@ -21,7 +21,7 @@
     "..#.."
     "....."]))
 
-(def d23-s01-2
+(def d23-s00-2
   (t/parse
    ["....."
     "..##."
@@ -30,7 +30,7 @@
     "....."
     "..#.."]))
 
-(def d23-s01-3
+(def d23-s00-3
   (t/parse
    ["..#.."
     "....#"
@@ -39,7 +39,7 @@
     "....."
     "..#.."]))
 
-(def d23-s02
+(def d23-s01
   (t/parse
    ["....#.."
     "..###.#"
@@ -51,32 +51,34 @@
 
 (deftest parse-test
   (testing "Correctly parses the sample input"
-    (is (= d23-s01
+    (is (= d23-s00
            #{[2 3] [3 4] [2 4] [3 1] [2 1]}))))
 
 (deftest round-test
   (testing "Returns the new elf locations after one round"
-    (is (= d23-s01-1 (first (t/round [d23-s01 t/dir-order]))))
-    (is (= d23-s01-2 (first (t/round [d23-s01-1 (u/rotate 1 t/dir-order)]))))
-    (is (= d23-s01-3 (first (t/round [d23-s01-2 (u/rotate 2 t/dir-order)]))))))
+    (is (= d23-s00-1 (first (t/round [d23-s00 t/dir-order]))))
+    (is (= d23-s00-2 (first (t/round [d23-s00-1 (u/rotate 1 t/dir-order)]))))
+    (is (= d23-s00-3 (first (t/round [d23-s00-2 (u/rotate 2 t/dir-order)]))))))
 
 (deftest empty-tiles-after-ten-rounds-test
   (testing "Computes the number of empty tiles in the tightest rectangular
             area around the elves after 10 rounds"
-    (is (= 25  (t/empty-tiles-after-ten-rounds d23-s01)))
-    (is (= 110 (t/empty-tiles-after-ten-rounds d23-s02)))))
+    (is (= 25  (t/empty-tiles-after-ten-rounds d23-s00)))
+    (is (= 110 (t/empty-tiles-after-ten-rounds d23-s01)))))
 
 (deftest rounds-until-static
   (testing "Computes the first round where elves will no longer move"
-    (is (= 4 (t/rounds-until-static d23-s01)))
-    (is (= 20 (t/rounds-until-static d23-s02)))))
+    (is (= 4 (t/rounds-until-static d23-s00)))
+    (is (= 20 (t/rounds-until-static d23-s01)))))
+
+(def day23-input (u/parse-puzzle-input t/parse 2022 23))
 
 (deftest day23-part1-soln
   (testing "Reproduces the answer for day23, part1"
-    (is (= 4172 (t/day23-part1-soln)))))
+    (is (= 4172 (t/day23-part1-soln day23-input)))))
 
 ;; TODO - Investigate whether there's a faster approach to part 2
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/30
 (deftest ^:slow day23-part2-soln
   (testing "Reproduces the answer for day23, part2"
-    (is (= 942 (t/day23-part2-soln)))))
+    (is (= 942 (t/day23-part2-soln day23-input)))))

--- a/test/aoc_clj/2022/day24_test.clj
+++ b/test/aoc_clj/2022/day24_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2022.day24-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day24 :as t]))
 
-(def d24-s01
+(def d24-s00
   (t/parse
    ["#.#####"
     "#.....#"
@@ -12,7 +13,7 @@
     "#.....#"
     "#####.#"]))
 
-(def d24-s02
+(def d24-s01
   (t/parse
    ["#.######"
     "#>>.<^<#"
@@ -23,13 +24,13 @@
 
 (deftest parse-test
   (testing "Correctly parses the sample input"
-    (is (= d24-s01
+    (is (= d24-s00
            {:x-bound 5, :y-bound 5, :blizzards '([[4 4] :d] [[1 2] :r])}))))
 
 (deftest blizzard-sim-test
   (testing "Evolves the map one step at a time, moving all blizzards to their
             new locations"
-    (let [sim (t/blizzard-sim d24-s01)]
+    (let [sim (t/blizzard-sim d24-s00)]
       ;; Initial state:
       (is (= #{[1 2] [4 4]} (sim 0)))
       ;; Bottommost blizzard moves down one, leftmost blizzard moves right
@@ -49,28 +50,28 @@
     ;; At t=0, the only possible move at the beginning is to stay put at the
     ;; start or to move down to [1 1]
     (is (= [[1 [1 0]] [1 [1 1]]]
-           (t/next-possible-states (t/augment d24-s02) [0 [1 0]])))
+           (t/next-possible-states (t/augment d24-s01) [0 [1 0]])))
     ;; At t=1, at [1 1], the elves can stay at [1 1] or move down to [1 2]
     (is (= [[2 [1 1]] [2 [1 2]] [2 [1 0]]]
-           (t/next-possible-states (t/augment d24-s02) [1 [1 1]])))
+           (t/next-possible-states (t/augment d24-s01) [1 [1 1]])))
     ;; At t=2, if the elves stayed at [1 1], the only option is now [1 2]
     (is (= [[3 [1 2]] [3 [1 0]]]
-           (t/next-possible-states (t/augment d24-s02) [2 [1 1]])))
+           (t/next-possible-states (t/augment d24-s01) [2 [1 1]])))
     ;; At t=2, if the elves were at [1 2], they can only stay put
     (is (= [[3 [1 2]]]
-           (t/next-possible-states (t/augment d24-s02) [2 [1 2]])))
+           (t/next-possible-states (t/augment d24-s01) [2 [1 2]])))
     ;; At t=3, at [1 2], elves can only move back up to [1 1]
     (is (= [[4 [1 1]]]
-           (t/next-possible-states (t/augment d24-s02) [3 [1 2]])))
+           (t/next-possible-states (t/augment d24-s01) [3 [1 2]])))
     ;; At t=4, at [1 1], elves can only move right to [2 1]
     (is (= [[5 [2 1]] [5 [1 0]]]
-           (t/next-possible-states (t/augment d24-s02) [4 [1 1]])))
+           (t/next-possible-states (t/augment d24-s01) [4 [1 1]])))
     ;; At t=5, at [2 1], elves can only move right to [3 1]
     (is (= [[6 [3 1]]]
-           (t/next-possible-states (t/augment d24-s02) [5 [2 1]])))
+           (t/next-possible-states (t/augment d24-s01) [5 [2 1]])))
     ;; At t=6, at [3 1], elves can only move down to [3 2]
     (is (= [[7 [3 2]]]
-           (t/next-possible-states (t/augment d24-s02) [6 [3 1]])))))
+           (t/next-possible-states (t/augment d24-s01) [6 [3 1]])))))
 
 (deftest path-to-exit-test
   (testing "Returns a shortest path that the elves can take, exploring the
@@ -95,23 +96,25 @@
             [6 3] ;; From t= 16, move down to...
             [6 4] ;; This is one move away from the destination 
             ]
-           (map second (t/path-to-exit d24-s02 0))))))
+           (map second (t/path-to-exit d24-s01 0))))))
 
 (deftest shortest-time-to-exit-test
   (testing "Computes the shortest amount of time required to navigate
             the evolving blizzard maze"
-    (is (= 18 (t/shortest-time-to-exit d24-s02)))))
+    (is (= 18 (t/shortest-time-to-exit d24-s01)))))
 
 (deftest shortest-roundtrip-to-exit-test
   (testing "Computes the shortest amount of time required to navigate
             the evolving blizzard maze from the start to the exit,
             back to the start, and back to the exit"
-    (is (= 54 (t/shortest-roundtrip-to-exit d24-s02)))))
+    (is (= 54 (t/shortest-roundtrip-to-exit d24-s01)))))
+
+(def day24-input (u/parse-puzzle-input t/parse 2022 24))
 
 (deftest day24-part1-soln
   (testing "Reproduces the answer for day24, part1"
-    (is (= 286 (t/day24-part1-soln)))))
+    (is (= 286 (t/day24-part1-soln day24-input)))))
 
 (deftest day24-part2-soln
   (testing "Reproduces the answer for day24, part2"
-    (is (= 820 (t/day24-part2-soln)))))
+    (is (= 820 (t/day24-part2-soln day24-input)))))

--- a/test/aoc_clj/2022/day25_test.clj
+++ b/test/aoc_clj/2022/day25_test.clj
@@ -1,8 +1,9 @@
 (ns aoc-clj.2022.day25-test
   (:require [clojure.test :refer [deftest testing is]]
+            [aoc-clj.utils.core :as u]
             [aoc-clj.2022.day25 :as t]))
 
-(def d25-s01
+(def d25-s00
   ["1=-0-2"
    "12111"
    "2=0="
@@ -17,7 +18,7 @@
    "1="
    "122"])
 
-(def d25-s02-decimal
+(def d25-s01-decimal
   [1
    2
    3
@@ -34,7 +35,7 @@
    12345
    314159265])
 
-(def d25-s02-snafu
+(def d25-s01-snafu
   ["1"
    "2"
    "1="
@@ -51,7 +52,7 @@
    "1-0---0"
    "1121-1110-1=0"])
 
-(def d25-s03-decimal
+(def d25-s02-decimal
   [1747
    906
    198
@@ -66,7 +67,7 @@
    3
    37])
 
-(def d25-s03-snafu
+(def d25-s02-snafu
   ["1=-0-2"
    "12111"
    "2=0="
@@ -83,18 +84,21 @@
 
 (deftest snafu->decimal-test
   (testing "Can convert SNAFU to decimal numerals"
-    (is (= d25-s02-decimal (map t/snafu->decimal d25-s02-snafu)))
-    (is (= d25-s03-decimal (map t/snafu->decimal d25-s03-snafu)))))
+    (is (= d25-s01-decimal (map t/snafu->decimal d25-s01-snafu)))
+    (is (= d25-s02-decimal (map t/snafu->decimal d25-s02-snafu)))))
 
 (deftest decimal->snafu-test
   (testing "Can convert decimal to SNAFU numerals"
-    (is (= d25-s02-snafu (map t/decimal->snafu d25-s02-decimal)))
-    (is (= d25-s03-snafu (map t/decimal->snafu d25-s03-decimal)))))
+    (is (= d25-s01-snafu (map t/decimal->snafu d25-s01-decimal)))
+    (is (= d25-s02-snafu (map t/decimal->snafu d25-s02-decimal)))))
 
 (deftest requirements-sum-test
   (testing "Returns sum of values from SNAFU back as SNAFU"
-    (is (= "2=-1=0" (t/requirements-sum d25-s01)))))
+    (is (= "2=-1=0" (t/requirements-sum d25-s00)))))
+
+(def day25-input (u/parse-puzzle-input t/parse 2022 25))
 
 (deftest day25-part1-soln
   (testing "Reproduces the answer for day25, part1"
-    (is (= "2=--00--0220-0-21==1" (t/day25-part1-soln)))))
+    (is (= "2=--00--0220-0-21==1"
+           (t/day25-part1-soln day25-input)))))

--- a/test/aoc_clj/2023/day01_test.clj
+++ b/test/aoc_clj/2023/day01_test.clj
@@ -3,13 +3,13 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day01 :as t]))
 
-(def d01-s01
+(def d01-s00
   ["1abc2"
    "pqr3stu8vwx"
    "a1b2c3d4e5f"
    "treb7uchet"])
 
-(def d01-s02
+(def d01-s01
   ["two1nine"
    "eightwothree"
    "abcone2threexyz"
@@ -24,33 +24,33 @@
 
 (deftest digits-test
   (testing "Finds all of the digits in the string"
-    (is (= [1 2]       (t/digits (nth d01-s01 0))))
-    (is (= [3 8]       (t/digits (nth d01-s01 1))))
-    (is (= [1 2 3 4 5] (t/digits (nth d01-s01 2))))
-    (is (= [7]         (t/digits (nth d01-s01 3))))
+    (is (= [1 2]       (t/digits (nth d01-s00 0))))
+    (is (= [3 8]       (t/digits (nth d01-s00 1))))
+    (is (= [1 2 3 4 5] (t/digits (nth d01-s00 2))))
+    (is (= [7]         (t/digits (nth d01-s00 3))))
 
-    (is (= [2 1 9]     (t/digits (nth d01-s02 0) true)))
-    (is (= [8 2 3]     (t/digits (nth d01-s02 1) true)))
-    (is (= [1 2 3]     (t/digits (nth d01-s02 2) true)))
-    (is (= [2 1 3 4]   (t/digits (nth d01-s02 3) true)))
-    (is (= [4 9 8 7 2] (t/digits (nth d01-s02 4) true)))
-    (is (= [1 8 2 3 4] (t/digits (nth d01-s02 5) true)))
-    (is (= [7 6]       (t/digits (nth d01-s02 6) true)))))
+    (is (= [2 1 9]     (t/digits (nth d01-s01 0) true)))
+    (is (= [8 2 3]     (t/digits (nth d01-s01 1) true)))
+    (is (= [1 2 3]     (t/digits (nth d01-s01 2) true)))
+    (is (= [2 1 3 4]   (t/digits (nth d01-s01 3) true)))
+    (is (= [4 9 8 7 2] (t/digits (nth d01-s01 4) true)))
+    (is (= [1 8 2 3 4] (t/digits (nth d01-s01 5) true)))
+    (is (= [7 6]       (t/digits (nth d01-s01 6) true)))))
 
 
 (deftest calibration-value-test
   (testing "Computes a calibration value (first and last digit)"
     (is (= [12 38 15 77]
-           (mapv t/calibration-value d01-s01)))
+           (mapv t/calibration-value d01-s00)))
     (is (= [29, 83, 13, 24, 42, 14, 76]
-           (mapv #(t/calibration-value % true) d01-s02)))
+           (mapv #(t/calibration-value % true) d01-s01)))
     (is (= [83 79]
            (mapv #(t/calibration-value % true) hard-cases)))))
 
 (deftest calibration-value-sum-test
   (testing "Computes the calibration value sum"
-    (is (= 142 (t/calibration-value-sum d01-s01)))
-    (is (= 281 (t/calibration-value-sum d01-s02 true)))))
+    (is (= 142 (t/calibration-value-sum d01-s00)))
+    (is (= 281 (t/calibration-value-sum d01-s01 true)))))
 
 (def day01-input (u/parse-puzzle-input t/parse 2023 1))
 

--- a/test/aoc_clj/2023/day02_test.clj
+++ b/test/aoc_clj/2023/day02_test.clj
@@ -3,14 +3,14 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day02 :as t]))
 
-(def d02-s01-raw
+(def d02-s00-raw
   ["Game 1: 3 blue, 4 red; 1 red, 2 green, 6 blue; 2 green"
    "Game 2: 1 blue, 2 green; 3 green, 4 blue, 1 red; 1 green, 1 blue"
    "Game 3: 8 green, 6 blue, 20 red; 5 blue, 4 red, 13 green; 5 green, 1 red"
    "Game 4: 1 green, 3 red, 6 blue; 3 green, 6 red; 3 green, 15 blue, 14 red"
    "Game 5: 6 red, 1 blue, 3 green; 2 blue, 1 red, 2 green"])
 
-(def d02-s01
+(def d02-s00
   [{:id 1, :sets [{:blue 3, :red 4}
                   {:red 1, :green 2, :blue 6}
                   {:green 2}]}
@@ -28,15 +28,15 @@
 
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d02-s01 (t/parse d02-s01-raw)))))
+    (is (= d02-s00 (t/parse d02-s00-raw)))))
 
 (deftest possible-game-test
   (testing "Determines which games are possible"
-    (is (= [true true false false true] (map t/possible-game d02-s01)))))
+    (is (= [true true false false true] (map t/possible-game d02-s00)))))
 
 (deftest possible-game-id-sum-test
   (testing "Computes sum of the ids of all possible games"
-    (is (= 8 (t/possible-game-id-sum d02-s01)))))
+    (is (= 8 (t/possible-game-id-sum d02-s00)))))
 
 (deftest fewest-cubes-test
   (testing "Computes the fewest cubes of each color in a game"
@@ -45,15 +45,15 @@
             {:red 20 :green 13 :blue 6}
             {:red 14 :green 3 :blue 15}
             {:red 6 :green 3 :blue 2}]
-           (map t/fewest-cubes d02-s01)))))
+           (map t/fewest-cubes d02-s00)))))
 
 (deftest power-fewest-cubes-test
   (testing "Computes the `power` of the fewest cubes of each color"
-    (is (= [48 12 1560 630 36] (map t/power-fewest-cubes d02-s01)))))
+    (is (= [48 12 1560 630 36] (map t/power-fewest-cubes d02-s00)))))
 
 (deftest power-fewest-cubes-sum-test
   (testing "Computes the sum of the powers of the fewest cubes"
-    (is (= 2286 (t/power-fewest-cubes-sum d02-s01)))))
+    (is (= 2286 (t/power-fewest-cubes-sum d02-s00)))))
 
 (def day02-input (u/parse-puzzle-input t/parse 2023 2))
 

--- a/test/aoc_clj/2023/day03_test.clj
+++ b/test/aoc_clj/2023/day03_test.clj
@@ -3,7 +3,7 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day03 :as t]))
 
-(def d03-s01-raw ["467..114.."
+(def d03-s00-raw ["467..114.."
                   "...*......"
                   "..35..633."
                   "......#..."
@@ -14,7 +14,7 @@
                   "...$.*...."
                   ".664.598.."])
 
-(def d03-s01
+(def d03-s00
   {:numbers [{:points [[0 0] [1 0] [2 0]] :value 467}
              {:points [[5 0] [6 0] [7 0]] :value 114}
              {:points [[2 2] [3 2]] :value 35}
@@ -34,20 +34,19 @@
 
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d03-s01 (t/parse d03-s01-raw)))))
+    (is (= d03-s00 (t/parse d03-s00-raw)))))
 
 (deftest part-numbers-test
   (testing "Finds all of the part numbers"
-    (is (= [467 35 633 617 592 755 664 598] (t/part-numbers d03-s01)))))
+    (is (= [467 35 633 617 592 755 664 598] (t/part-numbers d03-s00)))))
 
 (deftest part-numbers-sum-test
   (testing "Returns the sum of all the part numbers"
-    (is (= 4361 (t/part-numbers-sum d03-s01)))))
+    (is (= 4361 (t/part-numbers-sum d03-s00)))))
 
 (deftest gear-ratio-sum
   (testing "Computes the sum of all the gear ratios"
-    (is (= 467835 (t/gear-ratio-sum d03-s01)))))
-
+    (is (= 467835 (t/gear-ratio-sum d03-s00)))))
 
 (def day03-input (u/parse-puzzle-input t/parse 2023 3))
 

--- a/test/aoc_clj/2023/day04_test.clj
+++ b/test/aoc_clj/2023/day04_test.clj
@@ -3,8 +3,7 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day04 :as t]))
 
-
-(def d04-s01-raw
+(def d04-s00-raw
   ["Card 1: 41 48 83 86 17 | 83 86  6 31 17  9 48 53"
    "Card 2: 13 32 20 16 61 | 61 30 68 82 17 32 24 19"
    "Card 3:  1 21 53 59 44 | 69 82 63 72 16 21 14  1"
@@ -12,7 +11,7 @@
    "Card 5: 87 83 26 28 32 | 88 30 70 12 93 22 82 36"
    "Card 6: 31 18 13 56 72 | 74 77 10 23 35 67 36 11"])
 
-(def d04-s01
+(def d04-s00
   [{:winning #{41 48 83 86 17} :card #{83 86  6 31 17  9 48 53}}
    {:winning #{13 32 20 16 61} :card #{61 30 68 82 17 32 24 19}}
    {:winning #{1 21 53 59 44}  :card #{69 82 63 72 16 21 14  1}}
@@ -22,19 +21,19 @@
 
 (deftest parse-test
   (testing "Can parse the input correctly"
-    (is (= d04-s01 (t/parse d04-s01-raw)))))
+    (is (= d04-s00 (t/parse d04-s00-raw)))))
 
 (deftest winning-matches-test
   (testing "Determines how many winning matches a card has"
-    (is (= [4 2 2 1 0 0] (map t/winning-matches d04-s01)))))
+    (is (= [4 2 2 1 0 0] (map t/winning-matches d04-s00)))))
 
 (deftest points-test
   (testing "Scores the card correctly with the number of points"
-    (is (= [8 2 2 1 0 0] (map t/points d04-s01)))))
+    (is (= [8 2 2 1 0 0] (map t/points d04-s00)))))
 
 (deftest points-sum-test
   (testing "Computes the sum of the points of each card"
-    (is (= 13 (t/points-sum d04-s01)))))
+    (is (= 13 (t/points-sum d04-s00)))))
 
 (deftest update-card-count-test
   (testing "Determines how many of each of the lower cards there are based
@@ -54,7 +53,7 @@
 
 (deftest total-cards-test
   (testing "Computes the total number of cards you have in part2"
-    (is (= 30 (t/total-cards d04-s01)))))
+    (is (= 30 (t/total-cards d04-s00)))))
 
 (def day04-input (u/parse-puzzle-input t/parse 2023 4))
 

--- a/test/aoc_clj/2023/day06_test.clj
+++ b/test/aoc_clj/2023/day06_test.clj
@@ -3,38 +3,38 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day06 :as t]))
 
-(def d06-s01-raw ["Time:      7  15   30"
+(def d06-s00-raw ["Time:      7  15   30"
                   "Distance:  9  40  200"])
 
-(def d06-s01
+(def d06-s00
   [{:time 7  :dist 9}
    {:time 15 :dist 40}
    {:time 30 :dist 200}])
 
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d06-s01 (t/parse d06-s01-raw)))))
+    (is (= d06-s00 (t/parse d06-s00-raw)))))
 
 (deftest distance-options-test
   (testing "Computes the distances possible for various amounts of time 
             holding down the button"
-    (is (= [6 10 12 12 10 6] (t/distance-options (nth d06-s01 0))))))
+    (is (= [6 10 12 12 10 6] (t/distance-options (nth d06-s00 0))))))
 
 (deftest winning-options-count-test
   (testing "Computes how many ways there are to win a race"
-    (is (= 4 (t/winning-options-count (nth d06-s01 0))))
-    (is (= 8 (t/winning-options-count (nth d06-s01 1))))
-    (is (= 9 (t/winning-options-count (nth d06-s01 2))))
+    (is (= 4 (t/winning-options-count (nth d06-s00 0))))
+    (is (= 8 (t/winning-options-count (nth d06-s00 1))))
+    (is (= 9 (t/winning-options-count (nth d06-s00 2))))
 
-    (is (= 71503 (t/winning-options-count (t/long-race d06-s01))))))
+    (is (= 71503 (t/winning-options-count (t/long-race d06-s00))))))
 
 (deftest win-count-multiplied-test
   (testing "Computes the product of the ways to win each race"
-    (is (= 288 (t/win-count-multiplied d06-s01)))))
+    (is (= 288 (t/win-count-multiplied d06-s00)))))
 
 (deftest long-races-test
   (testing "Reinterprets the input as one long race"
-    (is (= {:time 71530 :dist 940200} (t/long-race d06-s01)))))
+    (is (= {:time 71530 :dist 940200} (t/long-race d06-s00)))))
 
 (def day06-input (u/parse-puzzle-input t/parse 2023 6))
 

--- a/test/aoc_clj/2023/day07_test.clj
+++ b/test/aoc_clj/2023/day07_test.clj
@@ -3,19 +3,19 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day07 :as t]))
 
-(def d07-s01-raw ["32T3K 765"
+(def d07-s00-raw ["32T3K 765"
                   "T55J5 684"
                   "KK677 28"
                   "KTJJT 220"
                   "QQQJA 483"])
 
-(def d07-s01 [{:hand [3 2 10 3 13] :bid 765}
+(def d07-s00 [{:hand [3 2 10 3 13] :bid 765}
               {:hand [10 5 5 11 5] :bid 684}
               {:hand [13 13 6 7 7] :bid 28}
               {:hand [13 10 11 11 10] :bid 220}
               {:hand [12 12 12 11 14] :bid 483}])
 
-(def d07-s01-jokers [{:hand [3 2 10 3 13] :bid 765}
+(def d07-s00-jokers [{:hand [3 2 10 3 13] :bid 765}
                      {:hand [10 5 5 0 5] :bid 684}
                      {:hand [13 13 6 7 7] :bid 28}
                      {:hand [13 10 0 0 10] :bid 220}
@@ -23,7 +23,7 @@
 
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d07-s01 (t/parse d07-s01-raw)))))
+    (is (= d07-s00 (t/parse d07-s00-raw)))))
 
 (deftest hand-type-test
   (testing "Determines the type of hand"
@@ -42,29 +42,29 @@
             {:hand [13 13 6 7 7] :bid 28}
             {:hand [10 5 5 11 5] :bid 684}
             {:hand [12 12 12 11 14] :bid 483}]
-           (sort t/compare-hands d07-s01)))))
+           (sort t/compare-hands d07-s00)))))
 
 (deftest winnings-test
   (testing "Computes the overall winnings"
-    (is (= 6440 (t/winnings d07-s01)))))
+    (is (= 6440 (t/winnings d07-s00)))))
 
 (deftest jokerize-hand-test
   (testing "Reinterprets the hand with J as Joker"
-    (is (= d07-s01-jokers (map t/jokerize-hand d07-s01)))))
+    (is (= d07-s00-jokers (map t/jokerize-hand d07-s00)))))
 
 (deftest effective-hand-test
   (testing "Returns the effective hand with the joker acting as any card"
-    (is (= [3 2 10 3 13]    (t/effective-hand (:hand (nth d07-s01-jokers 0)))))
-    (is (= [10 5 5 5 5]     (t/effective-hand (:hand (nth d07-s01-jokers 1)))))
-    (is (= [13 13 6 7 7]    (t/effective-hand (:hand (nth d07-s01-jokers 2)))))
-    (is (= [13 10 10 10 10] (t/effective-hand (:hand (nth d07-s01-jokers 3)))))
-    (is (= [12 12 12 12 14] (t/effective-hand (:hand (nth d07-s01-jokers 4)))))
+    (is (= [3 2 10 3 13]    (t/effective-hand (:hand (nth d07-s00-jokers 0)))))
+    (is (= [10 5 5 5 5]     (t/effective-hand (:hand (nth d07-s00-jokers 1)))))
+    (is (= [13 13 6 7 7]    (t/effective-hand (:hand (nth d07-s00-jokers 2)))))
+    (is (= [13 10 10 10 10] (t/effective-hand (:hand (nth d07-s00-jokers 3)))))
+    (is (= [12 12 12 12 14] (t/effective-hand (:hand (nth d07-s00-jokers 4)))))
     ;; Five Jokers is still Five Jokers
     (is (= [0 0 0 0 0]      (t/effective-hand [0 0 0 0 0])))))
 
 (deftest joker-winnings-test
   (testing "Computes the winnings correctly with joker rules"
-    (is (= 5905 (t/joker-winnings d07-s01)))))
+    (is (= 5905 (t/joker-winnings d07-s00)))))
 
 (def day07-input (u/parse-puzzle-input t/parse 2023 7))
 

--- a/test/aoc_clj/2023/day08_test.clj
+++ b/test/aoc_clj/2023/day08_test.clj
@@ -3,7 +3,7 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day08 :as t]))
 
-(def d08-s01-raw ["RL"
+(def d08-s00-raw ["RL"
                   ""
                   "AAA = (BBB, CCC)"
                   "BBB = (DDD, EEE)"
@@ -13,13 +13,13 @@
                   "GGG = (GGG, GGG)"
                   "ZZZ = (ZZZ, ZZZ)"])
 
-(def d08-s02-raw ["LLR"
+(def d08-s01-raw ["LLR"
                   ""
                   "AAA = (BBB, BBB)"
                   "BBB = (AAA, ZZZ)"
                   "ZZZ = (ZZZ, ZZZ)"])
 
-(def d08-s03-raw ["LR"
+(def d08-s02-raw ["LR"
                   ""
                   "11A = (11B, XXX)"
                   "11B = (XXX, 11Z)"
@@ -30,7 +30,7 @@
                   "22Z = (22B, 22B)"
                   "XXX = (XXX, XXX)"])
 
-(def d08-s01
+(def d08-s00
   {:instructions [:right :left]
    :nodes {"AAA" {:left "BBB" :right "CCC"}
            "BBB" {:left "DDD" :right "EEE"}
@@ -40,13 +40,13 @@
            "GGG" {:left "GGG" :right "GGG"}
            "ZZZ" {:left "ZZZ" :right "ZZZ"}}})
 
-(def d08-s02
+(def d08-s01
   {:instructions [:left :left :right]
    :nodes {"AAA" {:left "BBB" :right "BBB"}
            "BBB" {:left "AAA" :right "ZZZ"}
            "ZZZ" {:left "ZZZ" :right "ZZZ"}}})
 
-(def d08-s03
+(def d08-s02
   {:instructions [:left :right]
    :nodes {"11A" {:left "11B" :right "XXX"}
            "11B" {:left "XXX" :right "11Z"}
@@ -59,23 +59,23 @@
 
 (deftest parse-test
   (testing "Correctly parses the input"
+    (is (= d08-s00 (t/parse d08-s00-raw)))
     (is (= d08-s01 (t/parse d08-s01-raw)))
-    (is (= d08-s02 (t/parse d08-s02-raw)))
-    (is (= d08-s03 (t/parse d08-s03-raw)))))
+    (is (= d08-s02 (t/parse d08-s02-raw)))))
 
 (deftest steps-to-zzz
   (testing "Correctly counts the number of steps to get to ZZZ"
-    (is (= 2 (t/steps-to-zzz d08-s01 "AAA")))
-    (is (= 6 (t/steps-to-zzz d08-s02 "AAA")))))
+    (is (= 2 (t/steps-to-zzz d08-s00 "AAA")))
+    (is (= 6 (t/steps-to-zzz d08-s01 "AAA")))))
 
 (deftest start-nodes-test
   (testing "Finds all the start nodes"
-    (is (= ["11A" "22A"] (t/start-nodes (:nodes d08-s03))))))
+    (is (= ["11A" "22A"] (t/start-nodes (:nodes d08-s02))))))
 
 (deftest ghost-steps-to-zzz
   (testing "Counts the number of steps for all starting points to get to a
             node ending in Z"
-    (is (= 6 (t/ghost-steps-to-zzz d08-s03)))))
+    (is (= 6 (t/ghost-steps-to-zzz d08-s02)))))
 
 (def day08-input (u/parse-puzzle-input t/parse 2023 8))
 

--- a/test/aoc_clj/2023/day09_test.clj
+++ b/test/aoc_clj/2023/day09_test.clj
@@ -3,34 +3,34 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day09 :as t]))
 
-(def d09-s01-raw ["0 3 6 9 12 15"
+(def d09-s00-raw ["0 3 6 9 12 15"
                   "1 3 6 10 15 21"
                   "10 13 16 21 30 45"])
 
-(def d09-s01 [[0 3 6 9 12 15]
+(def d09-s00 [[0 3 6 9 12 15]
               [1 3 6 10 15 21]
               [10 13 16 21 30 45]])
 
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d09-s01 (t/parse d09-s01-raw)))))
+    (is (= d09-s00 (t/parse d09-s00-raw)))))
 
 (deftest extrapolate-test
   (testing "Appends the correct next value in the sequence"
-    (is (= [0 3 6 9 12 15 18]     (t/right-extrapolate (nth d09-s01 0))))
-    (is (= [1 3 6 10 15 21 28]    (t/right-extrapolate (nth d09-s01 1))))
-    (is (= [10 13 16 21 30 45 68] (t/right-extrapolate (nth d09-s01 2))))))
+    (is (= [0 3 6 9 12 15 18]     (t/right-extrapolate (nth d09-s00 0))))
+    (is (= [1 3 6 10 15 21 28]    (t/right-extrapolate (nth d09-s00 1))))
+    (is (= [10 13 16 21 30 45 68] (t/right-extrapolate (nth d09-s00 2))))))
 
 (deftest left-extrapolate-test
   (testing "Prepends the correct next value in the sequence"
-    (is (= [-3 0 3 6 9 12 15]    (t/left-extrapolate (nth d09-s01 0))))
-    (is (= [0 1 3 6 10 15 21]    (t/left-extrapolate (nth d09-s01 1))))
-    (is (= [5 10 13 16 21 30 45] (t/left-extrapolate (nth d09-s01 2))))))
+    (is (= [-3 0 3 6 9 12 15]    (t/left-extrapolate (nth d09-s00 0))))
+    (is (= [0 1 3 6 10 15 21]    (t/left-extrapolate (nth d09-s00 1))))
+    (is (= [5 10 13 16 21 30 45] (t/left-extrapolate (nth d09-s00 2))))))
 
 (deftest extrapolation-sum-test
   (testing "Returns the sum of the extrapolated values"
-    (is (= 114 (t/extrapolation-sum d09-s01)))
-    (is (= 2   (t/extrapolation-sum d09-s01 true)))))
+    (is (= 114 (t/extrapolation-sum d09-s00)))
+    (is (= 2   (t/extrapolation-sum d09-s00 true)))))
 
 (def day09-input (u/parse-puzzle-input t/parse 2023 9))
 

--- a/test/aoc_clj/2023/day10_test.clj
+++ b/test/aoc_clj/2023/day10_test.clj
@@ -4,28 +4,28 @@
             [aoc-clj.utils.grid.vecgrid :as vg]
             [aoc-clj.2023.day10 :as t]))
 
-(def d10-s01-raw
+(def d10-s00-raw
   ["-L|F7"
    "7S-7|"
    "L|7||"
    "-L-J|"
    "L|-JF"])
 
-(def d10-s01
+(def d10-s00
   (vg/->VecGrid2D [[:pipe-h :ell-ne :pipe-v :ell-se :ell-sw]
                    [:ell-sw :start :pipe-h :ell-sw :pipe-v]
                    [:ell-ne :pipe-v :ell-sw :pipe-v :pipe-v]
                    [:pipe-h :ell-ne :pipe-h :ell-nw :pipe-v]
                    [:ell-ne :pipe-v :pipe-h :ell-nw :ell-se]]))
 
-(def d10-s02-raw ["7-F7-"
+(def d10-s01-raw ["7-F7-"
                   ".FJ|7"
                   "SJLL7"
                   "|F--J"
                   "LJ.LJ"])
-(def d10-s02 (t/parse d10-s02-raw))
+(def d10-s01 (t/parse d10-s01-raw))
 
-(def d10-s03
+(def d10-s02
   (t/parse
    ["..........."
     ".S-------7."
@@ -37,7 +37,7 @@
     ".L--J.L--J."
     "..........."]))
 
-(def d10-s04
+(def d10-s03
   (t/parse
    [".........."
     ".S------7."
@@ -49,7 +49,7 @@
     ".L--JL--J."
     ".........."]))
 
-(def d10-s05
+(def d10-s04
   (t/parse
    [".F----7F7F7F7F-7...."
     ".|F--7||||||||FJ...."
@@ -64,31 +64,31 @@
 
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d10-s01 (t/parse d10-s01-raw)))))
+    (is (= d10-s00 (t/parse d10-s00-raw)))))
 
 (deftest start-test
   (testing "Finds the starting position"
-    (is (= [1 1] (t/start d10-s01)))))
+    (is (= [1 1] (t/start d10-s00)))))
 
 (deftest loop-positions-test
   (testing "Follows the loop from the start returning positions along the way"
     (is (= [[1 1] [1 2] [1 3] [2 3] [3 3] [3 2] [3 1] [2 1]]
-           (t/loop-positions d10-s01)))
+           (t/loop-positions d10-s00)))
     (is (= [[0 2] [0 3] [0 4] [1 4] [1 3] [2 3] [3 3] [4 3]
             [4 2] [3 2] [3 1] [3 0] [2 0] [2 1] [1 1] [1 2]]
-           (t/loop-positions d10-s02)))))
+           (t/loop-positions d10-s01)))))
 
 (deftest farthest-steps-from-start-test
   (testing "Computes the number of steps to get farthest away from the start 
             along the loop"
-    (is (= 4 (t/farthest-steps-from-start d10-s01)))
-    (is (= 8 (t/farthest-steps-from-start d10-s02)))))
+    (is (= 4 (t/farthest-steps-from-start d10-s00)))
+    (is (= 8 (t/farthest-steps-from-start d10-s01)))))
 
 (deftest interior-tiles-test
   (testing "Computes the number of tiles that are enclosed within the loop"
+    (is (= 4 (t/interior-tiles d10-s02)))
     (is (= 4 (t/interior-tiles d10-s03)))
-    (is (= 4 (t/interior-tiles d10-s04)))
-    (is (= 8 (t/interior-tiles d10-s05)))))
+    (is (= 8 (t/interior-tiles d10-s04)))))
 
 (def day10-input (u/parse-puzzle-input t/parse 2023 10))
 

--- a/test/aoc_clj/2023/day11_test.clj
+++ b/test/aoc_clj/2023/day11_test.clj
@@ -3,7 +3,7 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day11 :as t]))
 
-(def d11-s01-raw
+(def d11-s00-raw
   ["...#......"
    ".......#.."
    "#........."
@@ -15,7 +15,7 @@
    ".......#.."
    "#...#....."])
 
-(def d11-s01-raw-expanded
+(def d11-s00-raw-expanded
   ["....#........"
    ".........#..."
    "#............"
@@ -29,29 +29,29 @@
    ".........#..."
    "#....#......."])
 
-(def d11-s01          (t/parse d11-s01-raw))
-(def d11-s01-expanded (t/parse d11-s01-raw-expanded))
+(def d11-s00          (t/parse d11-s00-raw))
+(def d11-s00-expanded (t/parse d11-s00-raw-expanded))
 
 (deftest voids-test
   (testing "Finds the ids of empty rows and cols"
-    (is (= {:rows #{3 7} :cols #{2 5 8}} (t/voids d11-s01)))))
+    (is (= {:rows #{3 7} :cols #{2 5 8}} (t/voids d11-s00)))))
 
 (deftest galaxies-text
   (testing "Returns the locations of the galaxies in the grid"
     (is (= [[3 0] [7 1] [0 2] [6 4] [1 5] [9 6] [7 8] [0 9] [4 9]]
-           (t/galaxies d11-s01)))
+           (t/galaxies d11-s00)))
     (is (= [[4 0] [9 1] [0 2] [8 5] [1 6] [12 7] [9 10] [0 11] [5 11]]
-           (t/galaxies d11-s01-expanded)))))
+           (t/galaxies d11-s00-expanded)))))
 
 (deftest expanded-coords-test
   (testing "Returns the locations of the galaxies in an expanded space"
-    (is (= (t/galaxies d11-s01-expanded) (t/expanded-coords d11-s01 2)))))
+    (is (= (t/galaxies d11-s00-expanded) (t/expanded-coords d11-s00 2)))))
 
 (deftest pairwise-distance-sum-test
   (testing "Returns the sum of the distances between the galaxies"
-    (is (= 374  (t/pairwise-distance-sum (t/expanded-coords d11-s01 2))))
-    (is (= 1030 (t/pairwise-distance-sum (t/expanded-coords d11-s01 10))))
-    (is (= 8410 (t/pairwise-distance-sum (t/expanded-coords d11-s01 100))))))
+    (is (= 374  (t/pairwise-distance-sum (t/expanded-coords d11-s00 2))))
+    (is (= 1030 (t/pairwise-distance-sum (t/expanded-coords d11-s00 10))))
+    (is (= 8410 (t/pairwise-distance-sum (t/expanded-coords d11-s00 100))))))
 
 (def day11-input (u/parse-puzzle-input t/parse 2023 11))
 

--- a/test/aoc_clj/2023/day12_test.clj
+++ b/test/aoc_clj/2023/day12_test.clj
@@ -3,7 +3,7 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day12 :as t]))
 
-(def d12-s01-raw
+(def d12-s00-raw
   ["???.### 1,1,3"
    ".??..??...?##. 1,1,3"
    "?#?#?#?#?#?#?#? 1,3,1,6"
@@ -11,7 +11,7 @@
    "????.######..#####. 1,6,5"
    "?###???????? 3,2,1"])
 
-(def d12-s01
+(def d12-s00
   [["???.###"             [1 1 3]]
    [".??..??...?##."      [1 1 3]]
    ["?#?#?#?#?#?#?#?"     [1 3 1 6]]
@@ -21,14 +21,14 @@
 
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d12-s01 (t/parse d12-s01-raw)))))
+    (is (= d12-s00 (t/parse d12-s00-raw)))))
 
 (deftest unfold-test
   (testing "Unfolds the values"
     (is (= [".#?.#?.#?.#?.#" [1,1,1,1,1]] (t/unfold [".#" [1]])))
     (is (= ["???.###????.###????.###????.###????.###"
             [1,1,3,1,1,3,1,1,3,1,1,3,1,1,3]]
-           (t/unfold (nth d12-s01 0))))))
+           (t/unfold (nth d12-s00 0))))))
 
 (deftest num-arrangements-test
   (testing "Counts the number of possible arrangements that satisfy
@@ -42,27 +42,27 @@
     (is (= 2 (t/num-arrangements ["??" [1]])))
     (is (= 0 (t/num-arrangements ["##?#?#?#?" [1 6]])))
 
-    (is (= 1 (t/num-arrangements (nth d12-s01 0))))
-    (is (= 4 (t/num-arrangements (nth d12-s01 1))))
-    (is (= 1 (t/num-arrangements (nth d12-s01 2))))
-    (is (= 1 (t/num-arrangements (nth d12-s01 3))))
-    (is (= 4 (t/num-arrangements (nth d12-s01 4))))
-    (is (= 10 (t/num-arrangements (nth d12-s01 5))))
+    (is (= 1 (t/num-arrangements (nth d12-s00 0))))
+    (is (= 4 (t/num-arrangements (nth d12-s00 1))))
+    (is (= 1 (t/num-arrangements (nth d12-s00 2))))
+    (is (= 1 (t/num-arrangements (nth d12-s00 3))))
+    (is (= 4 (t/num-arrangements (nth d12-s00 4))))
+    (is (= 10 (t/num-arrangements (nth d12-s00 5))))
 
-    (is (= 1      (t/num-arrangements (t/unfold (nth d12-s01 0)))))
-    (is (= 16384  (t/num-arrangements (t/unfold (nth d12-s01 1)))))
-    (is (= 1      (t/num-arrangements (t/unfold (nth d12-s01 2)))))
-    (is (= 16     (t/num-arrangements (t/unfold (nth d12-s01 3)))))
-    (is (= 2500   (t/num-arrangements (t/unfold (nth d12-s01 4)))))
-    (is (= 506250 (t/num-arrangements (t/unfold (nth d12-s01 5)))))))
+    (is (= 1      (t/num-arrangements (t/unfold (nth d12-s00 0)))))
+    (is (= 16384  (t/num-arrangements (t/unfold (nth d12-s00 1)))))
+    (is (= 1      (t/num-arrangements (t/unfold (nth d12-s00 2)))))
+    (is (= 16     (t/num-arrangements (t/unfold (nth d12-s00 3)))))
+    (is (= 2500   (t/num-arrangements (t/unfold (nth d12-s00 4)))))
+    (is (= 506250 (t/num-arrangements (t/unfold (nth d12-s00 5)))))))
 
 (deftest num-arrangements-sum-test
   (testing "Sum of all the valid arrangement counts"
-    (is (= 21 (t/num-arrangements-sum d12-s01)))))
+    (is (= 21 (t/num-arrangements-sum d12-s00)))))
 
 (deftest unfolded-arrangements-sum-test
   (testing "Sums all the valid arrangements with the unfolded input"
-    (is (= 525152 (t/unfolded-arrangements-sum d12-s01)))))
+    (is (= 525152 (t/unfolded-arrangements-sum d12-s00)))))
 
 (def day12-input (u/parse-puzzle-input t/parse 2023 12))
 

--- a/test/aoc_clj/2023/day13_test.clj
+++ b/test/aoc_clj/2023/day13_test.clj
@@ -3,7 +3,7 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day13 :as t]))
 
-(def d13-s01
+(def d13-s00
   ["#.##..##."
    "..#.##.#."
    "##......#"
@@ -12,7 +12,7 @@
    "..##..##."
    "#.#.##.#."])
 
-(def d13-s02
+(def d13-s01
   ["#...##..#"
    "#....#..#"
    "..##..###"
@@ -21,7 +21,7 @@
    "..##..###"
    "#....#..#"])
 
-(def d13-s03
+(def d13-s02
   ["####....####.#..."
    "#.#.#..#.#.#.#..."
    "...#....#....#.##"
@@ -38,17 +38,17 @@
 
 (deftest mirror-pos-test
   (testing "Returns the position of the reflection point"
-    (is (= {:type :vertical :pos 5}   (t/mirror-pos 0 d13-s01)))
-    (is (= {:type :horizontal :pos 4} (t/mirror-pos 0 d13-s02)))
-    (is (= {:type :vertical :pos 16}  (t/mirror-pos 0 d13-s03)))
+    (is (= {:type :vertical :pos 5}   (t/mirror-pos 0 d13-s00)))
+    (is (= {:type :horizontal :pos 4} (t/mirror-pos 0 d13-s01)))
+    (is (= {:type :vertical :pos 16}  (t/mirror-pos 0 d13-s02)))
 
-    (is (= {:type :horizontal :pos 3} (t/mirror-pos 1 d13-s01)))
-    (is (= {:type :horizontal :pos 1} (t/mirror-pos 1 d13-s02)))))
+    (is (= {:type :horizontal :pos 3} (t/mirror-pos 1 d13-s00)))
+    (is (= {:type :horizontal :pos 1} (t/mirror-pos 1 d13-s01)))))
 
 (deftest summarize-test
   (testing "Computes the summarized sum"
-    (is (= 405 (t/summarize 0 [d13-s01 d13-s02])))
-    (is (= 400 (t/summarize 1 [d13-s01 d13-s02])))))
+    (is (= 405 (t/summarize 0 [d13-s00 d13-s01])))
+    (is (= 400 (t/summarize 1 [d13-s00 d13-s01])))))
 
 (def day13-input (u/parse-puzzle-input t/parse 2023 13))
 

--- a/test/aoc_clj/2023/day15_test.clj
+++ b/test/aoc_clj/2023/day15_test.clj
@@ -3,8 +3,8 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day15 :as t]))
 
-(def d15-s01-raw ["rn=1,cm-,qp=3,cm=2,qp-,pc=4,ot=9,ab=5,pc-,pc=6,ot=7"])
-(def d15-s01 ["rn=1"
+(def d15-s00-raw ["rn=1,cm-,qp=3,cm=2,qp-,pc=4,ot=9,ab=5,pc-,pc=6,ot=7"])
+(def d15-s00 ["rn=1"
               "cm-"
               "qp=3"
               "cm=2"
@@ -18,7 +18,7 @@
 
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d15-s01 (t/parse d15-s01-raw)))))
+    (is (= d15-s00 (t/parse d15-s00-raw)))))
 
 (deftest hash-char-test
   (testing "Steps of the HASH algorithm, character-by-character"
@@ -30,57 +30,57 @@
 (deftest hash-alg-test
   (testing "Correct HASH algorithm output"
     (is (= 52 (t/hash-alg "HASH")))
-    (is (= 30 (t/hash-alg (nth d15-s01 0))))
-    (is (= 253 (t/hash-alg (nth d15-s01 1))))))
+    (is (= 30 (t/hash-alg (nth d15-s00 0))))
+    (is (= 253 (t/hash-alg (nth d15-s00 1))))))
 
 (deftest hash-sum-test
   (testing "Adds the HASH values of the input strings"
-    (is (= 1320 (t/hash-sum d15-s01)))))
+    (is (= 1320 (t/hash-sum d15-s00)))))
 
 (deftest sequence-step-test
   (testing "Incrementally processing the sequence steps"
     (is (= {0 [["rn" 1]]}
            (t/sequence-step {}
-                            (nth d15-s01 0))))
+                            (nth d15-s00 0))))
     (is (= {0 [["rn" 1]]}
            (t/sequence-step {0 [["rn" 1]]}
-                            (nth d15-s01 1))))
+                            (nth d15-s00 1))))
     (is (= {0 [["rn" 1]] 1 [["qp" 3]]}
            (t/sequence-step {0 [["rn" 1]]}
-                            (nth d15-s01 2))))
+                            (nth d15-s00 2))))
     (is (= {0 [["rn" 1] ["cm" 2]] 1 [["qp" 3]]}
            (t/sequence-step {0 [["rn" 1]] 1 [["qp" 3]]}
-                            (nth d15-s01 3))))
+                            (nth d15-s00 3))))
     (is (= {0 [["rn" 1] ["cm" 2]] 1 []}
            (t/sequence-step {0 [["rn" 1] ["cm" 2]] 1 [["qp" 3]]}
-                            (nth d15-s01 4))))
+                            (nth d15-s00 4))))
     (is (= {0 [["rn" 1] ["cm" 2]] 1 [] 3 [["pc" 4]]}
            (t/sequence-step {0 [["rn" 1] ["cm" 2]] 1 []}
-                            (nth d15-s01 5))))
+                            (nth d15-s00 5))))
     (is (= {0 [["rn" 1] ["cm" 2]] 1 [] 3 [["pc" 4] ["ot" 9]]}
            (t/sequence-step {0 [["rn" 1] ["cm" 2]] 1 [] 3 [["pc" 4]]}
-                            (nth d15-s01 6))))
+                            (nth d15-s00 6))))
     (is (= {0 [["rn" 1] ["cm" 2]] 1 [] 3 [["pc" 4] ["ot" 9] ["ab" 5]]}
            (t/sequence-step {0 [["rn" 1] ["cm" 2]] 1 [] 3 [["pc" 4] ["ot" 9]]}
-                            (nth d15-s01 7))))
+                            (nth d15-s00 7))))
     (is (= {0 [["rn" 1] ["cm" 2]] 1 [] 3 [["ot" 9] ["ab" 5]]}
            (t/sequence-step {0 [["rn" 1] ["cm" 2]] 1 [] 3 [["pc" 4] ["ot" 9] ["ab" 5]]}
-                            (nth d15-s01 8))))
+                            (nth d15-s00 8))))
     (is (= {0 [["rn" 1] ["cm" 2]] 1 [] 3 [["ot" 9] ["ab" 5] ["pc" 6]]}
            (t/sequence-step {0 [["rn" 1] ["cm" 2]] 1 [] 3 [["ot" 9] ["ab" 5]]}
-                            (nth d15-s01 9))))
+                            (nth d15-s00 9))))
     (is (= {0 [["rn" 1] ["cm" 2]] 1 [] 3 [["ot" 7] ["ab" 5] ["pc" 6]]}
            (t/sequence-step {0 [["rn" 1] ["cm" 2]] 1 [] 3 [["ot" 9] ["ab" 5] ["pc" 6]]}
-                            (nth d15-s01 10))))))
+                            (nth d15-s00 10))))))
 
 (deftest lens-arrangement-test
   (testing "Final lens arrangement"
     (is (= {0 [["rn" 1] ["cm" 2]] 1 [] 3 [["ot" 7] ["ab" 5] ["pc" 6]]}
-           (t/lens-arrangement d15-s01)))))
+           (t/lens-arrangement d15-s00)))))
 
 (deftest focusing-power-test
   (testing "Focusing power"
-    (is (= 145 (t/focusing-power d15-s01)))))
+    (is (= 145 (t/focusing-power d15-s00)))))
 
 (def day15-input (u/parse-puzzle-input t/parse 2023 15))
 

--- a/test/aoc_clj/2023/day16_test.clj
+++ b/test/aoc_clj/2023/day16_test.clj
@@ -4,7 +4,7 @@
             [aoc-clj.utils.grid.vecgrid :as vg]
             [aoc-clj.2023.day16 :as t]))
 
-(def d16-s01-raw
+(def d16-s00-raw
   [".|...\\...."
    "|.-.\\....."
    ".....|-..."
@@ -16,7 +16,7 @@
    ".|....-|.\\"
    "..//.|...."])
 
-(def d16-s01
+(def d16-s00
   (vg/->VecGrid2D
    [[:empty :spltv :empty :empty :empty :mrrr1 :empty :empty :empty :empty]
     [:spltv :empty :splth :empty :mrrr1 :empty :empty :empty :empty :empty]
@@ -31,25 +31,25 @@
 
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d16-s01 (t/parse d16-s01-raw)))))
+    (is (= d16-s00 (t/parse d16-s00-raw)))))
 
 (deftest next-beams-test
   (testing "Determines the next position and heading of a light beam"
-    (is (= #{[[1 0] :R]}             (t/next-beams d16-s01 [[0 0] :R])))
-    (is (= #{[[1 1] :D]}             (t/next-beams d16-s01 [[1 0] :R])))
-    (is (= #{[[0 7] :L] [[2 7] :R]}  (t/next-beams d16-s01 [[1 7] :D])))
-    (is (= #{[[4 7] :R]}             (t/next-beams d16-s01 [[3 7] :R])))
-    (is (= #{[[4 6] :U]}             (t/next-beams d16-s01 [[4 7] :R])))
-    (is (= #{[[5 6] :R]}             (t/next-beams d16-s01 [[4 6] :U])))))
+    (is (= #{[[1 0] :R]}             (t/next-beams d16-s00 [[0 0] :R])))
+    (is (= #{[[1 1] :D]}             (t/next-beams d16-s00 [[1 0] :R])))
+    (is (= #{[[0 7] :L] [[2 7] :R]}  (t/next-beams d16-s00 [[1 7] :D])))
+    (is (= #{[[4 7] :R]}             (t/next-beams d16-s00 [[3 7] :R])))
+    (is (= #{[[4 6] :U]}             (t/next-beams d16-s00 [[4 7] :R])))
+    (is (= #{[[5 6] :R]}             (t/next-beams d16-s00 [[4 6] :U])))))
 
 (deftest energized-count-test
   (testing "Counts the number of energized cells"
-    (is (= 46 (t/energized-count d16-s01 [[0 0] :R])))
-    (is (= 51 (t/energized-count d16-s01 [[3 0] :D])))))
+    (is (= 46 (t/energized-count d16-s00 [[0 0] :R])))
+    (is (= 51 (t/energized-count d16-s00 [[3 0] :D])))))
 
 (deftest max-energization-test
   (testing "Finds the maximum possible number of energized cells"
-    (is (= 51 (t/max-energization d16-s01)))))
+    (is (= 51 (t/max-energization d16-s00)))))
 
 (def day16-input (u/parse-puzzle-input t/parse 2023 16))
 

--- a/test/aoc_clj/2023/day18_test.clj
+++ b/test/aoc_clj/2023/day18_test.clj
@@ -3,7 +3,7 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day18 :as t]))
 
-(def d18-s01-raw
+(def d18-s00-raw
   ["R 6 (#70c710)"
    "D 5 (#0dc571)"
    "L 2 (#5713f0)"
@@ -19,7 +19,7 @@
    "L 2 (#015232)"
    "U 2 (#7a21e3)"])
 
-(def d18-s01
+(def d18-s00
   [{:dir "R" :dist 6 :color "70c710"}
    {:dir "D" :dist 5 :color "0dc571"}
    {:dir "L" :dist 2 :color "5713f0"}
@@ -35,7 +35,7 @@
    {:dir "L" :dist 2 :color "015232"}
    {:dir "U" :dist 2 :color "7a21e3"}])
 
-(def d18-s01-reinterpreted
+(def d18-s00-reinterpreted
   [{:dir "R" :dist 461937}
    {:dir "D" :dist 56407}
    {:dir "R" :dist 356671}
@@ -51,29 +51,29 @@
    {:dir "L" :dist 5411}
    {:dir "U" :dist 500254}])
 
-(def d18-s01-vertices
+(def d18-s00-vertices
   [[6 0] [6 5] [4 5] [4 7] [6 7] [6 9] [1 9]
    [1 7] [0 7] [0 5] [2 5] [2 2] [0 2] [0 0]])
 
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d18-s01 (t/parse d18-s01-raw)))))
+    (is (= d18-s00 (t/parse d18-s00-raw)))))
 
 (deftest vertices-test
   (testing "Returns the collection of vertices for each segment"
-    (is (= d18-s01-vertices (t/vertices d18-s01)))))
+    (is (= d18-s00-vertices (t/vertices d18-s00)))))
 
 (deftest dig-area-test
   (testing "Computes the number of tiles excavated"
-    (is (= 62 (t/dig-area d18-s01)))))
+    (is (= 62 (t/dig-area d18-s00)))))
 
 (deftest interpret-hex-test
   (testing "Reinterprets the hex color codes as dist/dir values"
-    (is (= d18-s01-reinterpreted (map t/interpret-hex d18-s01)))))
+    (is (= d18-s00-reinterpreted (map t/interpret-hex d18-s00)))))
 
 (deftest dig-area-reinterpreted-test
   (testing "Computes the dig area with the hex reinterpretation of the input"
-    (is (= 952408144115 (t/dig-area-reinterpreted d18-s01)))))
+    (is (= 952408144115 (t/dig-area-reinterpreted d18-s00)))))
 
 (def day18-input (u/parse-puzzle-input t/parse 2023 18))
 

--- a/test/aoc_clj/2023/day19_test.clj
+++ b/test/aoc_clj/2023/day19_test.clj
@@ -3,7 +3,7 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day19 :as t]))
 
-(def d19-s01-raw
+(def d19-s00-raw
   ["px{a<2006:qkq,m>2090:A,rfg}"
    "pv{a>1716:R,A}"
    "lnx{m>1548:A,A}"
@@ -22,7 +22,7 @@
    "{x=2461,m=1339,a=466,s=291}"
    "{x=2127,m=1623,a=2188,s=1013}"])
 
-(def d19-s01
+(def d19-s00
   {:workflows {:px  [[:qkq "a" "<" 2006] [:A "m" ">" 2090]   [:rfg]]
                :pv  [[:R   "a" ">" 1716] [:A]]
                :lnx [[:A   "m" ">" 1548] [:A]]
@@ -40,7 +40,7 @@
            [2461 1339 466 291]
            [2127 1623 2188 1013]]})
 
-(def d19-s01-explicit
+(def d19-s00-explicit
   "In this explicit representation, the conditions required to be routed
    to each outcome (or subsequent workflow) are fully spelled out"
   {:px  [[:qkq [["a" "<" 2006]]]
@@ -69,7 +69,7 @@
    :hdj [[:A   [["m" ">" 838]]]
          [:pv  [["m" "<=" 838]]]]})
 
-(def d19-s01-all-paths
+(def d19-s00-all-paths
   "For the sample data, the conditions along each of the possible paths
    resulting in an accepted outcome"
   [[["s" "<" 1351]  ["a" "<" 2006]  ["x" "<" 1416]]
@@ -84,49 +84,49 @@
 
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d19-s01 (t/parse d19-s01-raw)))))
+    (is (= d19-s00 (t/parse d19-s00-raw)))))
 
 (deftest workflow->fn-str-test
   (testing "Converts the rules in a workflow into a string representation of
             a clojure function"
     (is (= "(fn [[x m a s]] (cond (< a 2006) :qkq (> m 2090) :A :else :rfg))"
-           (t/workflow->fn-str (get-in d19-s01 [:workflows :px]))))
+           (t/workflow->fn-str (get-in d19-s00 [:workflows :px]))))
     (is (= "(fn [[x m a s]] (cond (> m 838) :A :else :pv))"
-           (t/workflow->fn-str (get-in d19-s01 [:workflows :hdj]))))))
+           (t/workflow->fn-str (get-in d19-s00 [:workflows :hdj]))))))
 
-(def d19-s01-fns (t/functionized-input d19-s01))
+(def d19-s01-fns (t/functionized-input d19-s00))
 (deftest outcome-test
   (testing "Runs the workflows and returns the correct verdict for each part"
-    (is (= :A (t/apply-workflows d19-s01-fns (nth (:parts d19-s01) 0))))
-    (is (= :R (t/apply-workflows d19-s01-fns (nth (:parts d19-s01) 1))))
-    (is (= :A (t/apply-workflows d19-s01-fns (nth (:parts d19-s01) 2))))
-    (is (= :R (t/apply-workflows d19-s01-fns (nth (:parts d19-s01) 3))))
-    (is (= :A (t/apply-workflows d19-s01-fns (nth (:parts d19-s01) 4))))))
+    (is (= :A (t/apply-workflows d19-s01-fns (nth (:parts d19-s00) 0))))
+    (is (= :R (t/apply-workflows d19-s01-fns (nth (:parts d19-s00) 1))))
+    (is (= :A (t/apply-workflows d19-s01-fns (nth (:parts d19-s00) 2))))
+    (is (= :R (t/apply-workflows d19-s01-fns (nth (:parts d19-s00) 3))))
+    (is (= :A (t/apply-workflows d19-s01-fns (nth (:parts d19-s00) 4))))))
 
 (deftest accepted-parts-test
   (testing "Returns the parts (expressed as xmas ratings values) that are accepted"
     (is (= [[787 2655 1222 2876]
             [2036 264 79 2244]
             [2127 1623 2188 1013]]
-           (t/accepted-parts d19-s01)))))
+           (t/accepted-parts d19-s00)))))
 
 (deftest accepted-parts-sum-test
   (testing "Returns the sum of all the ratings of all the accepted parts"
-    (is (= 19114 (t/accepted-parts-sum d19-s01)))))
+    (is (= 19114 (t/accepted-parts-sum d19-s00)))))
 
 (deftest explicit-conditions-test
   (testing "Expands the conditional logic to be explicit"
-    (is (= d19-s01-explicit (t/explicit-conditions d19-s01)))))
+    (is (= d19-s00-explicit (t/explicit-conditions d19-s00)))))
 
 (deftest all-accepted-paths
   (testing "Retrieves all the possible rules that allow for reaching an
             accepted outcome"
-    (is (= d19-s01-all-paths (t/all-accepted-paths d19-s01)))))
+    (is (= d19-s00-all-paths (t/all-accepted-paths d19-s00)))))
 
 (deftest all-accepted-count
   (testing "Computes how many possible combinations of ratings will
             reach an acceptable outcome"
-    (is (= 167409079868000 (t/all-accepted-count d19-s01)))))
+    (is (= 167409079868000 (t/all-accepted-count d19-s00)))))
 
 
 (def day19-input (u/parse-puzzle-input t/parse 2023 19))

--- a/test/aoc_clj/2023/day20_test.clj
+++ b/test/aoc_clj/2023/day20_test.clj
@@ -3,28 +3,28 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day20 :as t]))
 
-(def d20-s01-raw
+(def d20-s00-raw
   ["broadcaster -> a, b, c"
    "%a -> b"
    "%b -> c"
    "%c -> inv"
    "&inv -> a"])
 
-(def d20-s02-raw
+(def d20-s01-raw
   ["broadcaster -> a"
    "%a -> inv, con"
    "&inv -> b"
    "%b -> con"
    "&con -> output"])
 
-(def d20-s01
+(def d20-s00
   {"broadcaster" {:type :broadcast   :dest ["a" "b" "c"]}
    "a"           {:type :flip-flop   :dest ["b"]}
    "b"           {:type :flip-flop   :dest ["c"]}
    "c"           {:type :flip-flop   :dest ["inv"]}
    "inv"         {:type :conjunction :dest ["a"]}})
 
-(def d20-s02
+(def d20-s01
   {"broadcaster" {:type :broadcast   :dest ["a"]}
    "a"           {:type :flip-flop   :dest ["inv" "con"]}
    "inv"         {:type :conjunction :dest ["b"]}
@@ -33,67 +33,67 @@
 
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d20-s01 (t/parse d20-s01-raw)))
-    (is (= d20-s02 (t/parse d20-s02-raw)))))
+    (is (= d20-s00 (t/parse d20-s00-raw)))
+    (is (= d20-s01 (t/parse d20-s01-raw)))))
 
 (deftest conj-inputs-test
   (testing "Finds all the input modules for a conjunction module"
-    (is (= ["c"]     (t/conj-inputs d20-s01 "inv")))
-    (is (= ["a"]     (t/conj-inputs d20-s02 "inv")))
-    (is (= ["a" "b"] (t/conj-inputs d20-s02 "con")))))
+    (is (= ["c"]     (t/conj-inputs d20-s00 "inv")))
+    (is (= ["a"]     (t/conj-inputs d20-s01 "inv")))
+    (is (= ["a" "b"] (t/conj-inputs d20-s01 "con")))))
 
 (deftest initial-circuit-state-test
   (testing "Constructs the initial state of the connected modules"
     (is (= {"a" :off
             "b" :off
             "c" :off
-            "inv" {"c" :low}} (t/initial-circuit-state d20-s01)))
+            "inv" {"c" :low}} (t/initial-circuit-state d20-s00)))
     (is (= {"a" :off
             "b" :off
             "inv" {"a" :low}
-            "con" {"a" :low "b" :low}} (t/initial-circuit-state d20-s02)))))
+            "con" {"a" :low "b" :low}} (t/initial-circuit-state d20-s01)))))
 
 (deftest pulse-history-test
   (testing "Confirms the number of high and low pulses after processing
             initial pulse"
     (is (= {:low 8 :high 4 :buttons 1}
-           (:pulse-history (t/after-n-buttons d20-s01 1))))
+           (:pulse-history (t/after-n-buttons d20-s00 1))))
     (is (= {:low 4 :high 4 :buttons 1}
-           (:pulse-history (t/after-n-buttons d20-s02 1))))
+           (:pulse-history (t/after-n-buttons d20-s01 1))))
     (is (= {:low 8 :high 6 :buttons 2}
-           (:pulse-history (t/after-n-buttons d20-s02 2))))
+           (:pulse-history (t/after-n-buttons d20-s01 2))))
     (is (= {:low 13 :high 9 :buttons 3}
-           (:pulse-history (t/after-n-buttons d20-s02 3))))
+           (:pulse-history (t/after-n-buttons d20-s01 3))))
     (is (= {:low 17 :high 11 :buttons 4}
-           (:pulse-history (t/after-n-buttons d20-s02 4))))))
+           (:pulse-history (t/after-n-buttons d20-s01 4))))))
 
 (deftest circuit-state-cycle-test
   (testing "Confirms that the circuit state returns to the initial value
             after the correct number of cycles"
     ;; Just one button press for the first sample data
-    (is (= (:circuit-state (t/init-state d20-s01))
-           (:circuit-state (t/after-n-buttons d20-s01 1))))
+    (is (= (:circuit-state (t/init-state d20-s00))
+           (:circuit-state (t/after-n-buttons d20-s00 1))))
     ;; Four button presses for the second sample date
-    (is (= (:circuit-state (t/init-state d20-s02))
-           (:circuit-state (t/after-n-buttons d20-s02 4))))))
+    (is (= (:circuit-state (t/init-state d20-s01))
+           (:circuit-state (t/after-n-buttons d20-s01 4))))))
 
 (deftest pulses-until-cycle
   (testing "Computes the number of pulses of high and low type are 
             processed before the network cycles back to its initial state"
-    (is (= {:low 8  :high 4  :buttons 1} (t/pulses-until-cycle d20-s01)))
-    (is (= {:low 17 :high 11 :buttons 4} (t/pulses-until-cycle d20-s02)))))
+    (is (= {:low 8  :high 4  :buttons 1} (t/pulses-until-cycle d20-s00)))
+    (is (= {:low 17 :high 11 :buttons 4} (t/pulses-until-cycle d20-s01)))))
 
 (deftest pulses-after-1000
   (testing "Product of the number of pulses of each type after processing
             1000 button presses"
-    (is (= 32000000 (t/pulses-after-1000 d20-s01)))
-    (is (= 11687500 (t/pulses-after-1000 d20-s02)))))
+    (is (= 32000000 (t/pulses-after-1000 d20-s00)))
+    (is (= 11687500 (t/pulses-after-1000 d20-s01)))))
 
 (deftest pulses-after-1000-brute-force
   (testing "Product of the number of pulses of each type after processing
             1000 button presses by actually simulating all those presses"
-    (is (= 32000000 (t/pulses-after-1000-brute-force d20-s01)))
-    (is (= 11687500 (t/pulses-after-1000-brute-force d20-s02)))))
+    (is (= 32000000 (t/pulses-after-1000-brute-force d20-s00)))
+    (is (= 11687500 (t/pulses-after-1000-brute-force d20-s01)))))
 
 (def day20-input (u/parse-puzzle-input t/parse 2023 20))
 

--- a/test/aoc_clj/2023/day21_test.clj
+++ b/test/aoc_clj/2023/day21_test.clj
@@ -4,7 +4,7 @@
             [aoc-clj.utils.grid.vecgrid :as vg]
             [aoc-clj.2023.day21 :as t]))
 
-(def d21-s01-raw
+(def d21-s00-raw
   ["..........."
    ".....###.#."
    ".###.##..#."
@@ -17,7 +17,7 @@
    ".##..##.##."
    "..........."])
 
-(def d21-s01
+(def d21-s00
   (vg/->VecGrid2D
    [[:plot :plot :plot :plot :plot :plot :plot :plot :plot :plot :plot]
     [:plot :plot :plot :plot :plot :rock :rock :rock :plot :rock :plot]
@@ -33,29 +33,29 @@
 
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d21-s01 (t/parse d21-s01-raw)))))
+    (is (= d21-s00 (t/parse d21-s00-raw)))))
 
 (deftest start-pos-test
   (testing "Returns the position of the starting tile"
-    (is (= [5 5] (t/start-pos d21-s01)))))
+    (is (= [5 5] (t/start-pos d21-s00)))))
 
 (deftest all-possible-locations-test
   (testing "For the given set of starting positions, returns all possible
             move locations"
     (is (= #{[5 4] [4 5]}
-           (t/all-possible-locations d21-s01 [[5 5]])))
+           (t/all-possible-locations d21-s00 [[5 5]])))
     (is (= #{[5 3] [3 5] [5 5] [4 6]}
-           (t/all-possible-locations d21-s01 #{[5 4] [4 5]})))
+           (t/all-possible-locations d21-s00 #{[5 4] [4 5]})))
     (is (= #{[6 3] [3 4] [5 4] [4 5] [3 6] [4 7]}
-           (t/all-possible-locations d21-s01 #{[5 3] [3 5] [5 5] [4 6]})))))
+           (t/all-possible-locations d21-s00 #{[5 3] [3 5] [5 5] [4 6]})))))
 
 (deftest reachable-steps-test
   (testing "Returns the number of plot tiles reachable within exactly n steps"
-    (is (= 1  (t/reachable-steps d21-s01 0)))
-    (is (= 2  (t/reachable-steps d21-s01 1)))
-    (is (= 4  (t/reachable-steps d21-s01 2)))
-    (is (= 6  (t/reachable-steps d21-s01 3)))
-    (is (= 16 (t/reachable-steps d21-s01 6)))))
+    (is (= 1  (t/reachable-steps d21-s00 0)))
+    (is (= 2  (t/reachable-steps d21-s00 1)))
+    (is (= 4  (t/reachable-steps d21-s00 2)))
+    (is (= 6  (t/reachable-steps d21-s00 3)))
+    (is (= 16 (t/reachable-steps d21-s00 6)))))
 
 (def day21-input (u/parse-puzzle-input t/parse 2023 21))
 

--- a/test/aoc_clj/2023/day22_test.clj
+++ b/test/aoc_clj/2023/day22_test.clj
@@ -3,7 +3,7 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day22 :as t]))
 
-(def d22-s01-raw
+(def d22-s00-raw
   ["1,0,1~1,2,1"
    "0,0,2~2,0,2"
    "0,2,3~2,2,3"
@@ -12,13 +12,13 @@
    "0,1,6~2,1,6"
    "1,1,8~1,1,9"])
 
-(def d22-s02-raw
+(def d22-s01-raw
   ["0,0,1~0,1,1"
    "1,1,1~1,1,1"
    "0,0,2~0,0,2"
    "0,1,2~1,1,2"])
 
-(def d22-s01
+(def d22-s00
   [[[1 0 1] [1 2 1]]
    [[0 0 2] [2 0 2]]
    [[0 2 3] [2 2 3]]
@@ -27,7 +27,7 @@
    [[0 1 6] [2 1 6]]
    [[1 1 8] [1 1 9]]])
 
-(def d22-s01-z-rep
+(def d22-s00-z-rep
   [{1 #{[1 0] [1 1] [1 2]}}
    {2 #{[0 0] [1 0] [2 0]}}
    {3 #{[0 2] [1 2] [2 2]}}
@@ -39,21 +39,21 @@
 
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d22-s01 (t/parse d22-s01-raw)))))
+    (is (= d22-s00 (t/parse d22-s00-raw)))))
 
 (deftest lowest-z-test
   (testing "Computes the lowest z position of a brick"
-    (is (= [1 2 3 4 5 6 8] (map t/lowest-z d22-s01-z-rep)))))
+    (is (= [1 2 3 4 5 6 8] (map t/lowest-z d22-s00-z-rep)))))
 
 (deftest brick-z-rep-test
   (testing "Converts the brick expression into occupied cells at each z-level"
-    (is (= d22-s01-z-rep (map t/brick-z-rep d22-s01)))))
+    (is (= d22-s00-z-rep (map t/brick-z-rep d22-s00)))))
 
 (deftest place-brick-test
   (testing "Places each brick in correct location in sample data"
     (is (= {:z-index {1 #{[1 0] [1 1] [1 2]}}
             :bricks [{1 #{[1 0] [1 1] [1 2]}}]}
-           (t/place-brick {:z-index {} :bricks []} (nth d22-s01-z-rep 0))))
+           (t/place-brick {:z-index {} :bricks []} (nth d22-s00-z-rep 0))))
 
     (is (= {:z-index {1 #{[1 0] [1 1] [1 2]}
                       2 #{[0 0] [1 0] [2 0]}}
@@ -61,7 +61,7 @@
                      {2 #{[0 0] [1 0] [2 0]}}]}
            (t/place-brick {:z-index {1 #{[1 0] [1 1] [1 2]}}
                            :bricks [{1 #{[1 0] [1 1] [1 2]}}]}
-                          (nth d22-s01-z-rep 1))))
+                          (nth d22-s00-z-rep 1))))
 
     (is (= {:z-index {1 #{[1 0] [1 1] [1 2]}
                       2 #{[0 0] [1 0] [2 0] [0 2] [1 2] [2 2]}}
@@ -72,9 +72,9 @@
                                      2 #{[0 0] [1 0] [2 0]}}
                            :bricks [{1 #{[1 0] [1 1] [1 2]}}
                                     {2 #{[0 0] [1 0] [2 0]}}]}
-                          (nth d22-s01-z-rep 2))))))
+                          (nth d22-s00-z-rep 2))))))
 
-(def d22-s01-placed-bricks (t/place-bricks d22-s01-z-rep))
+(def d22-s01-placed-bricks (t/place-bricks d22-s00-z-rep))
 (deftest place-bricks-test
   (testing "Correctly determines resting place/coords of each brick"
     (is (= [{1 #{[1 0] [1 1] [1 2]}}
@@ -96,7 +96,7 @@
             4 [5]   ;; E supports F
             5 [6]   ;; F supports G
             6 []}   ;; G supports nothing
-           (t/supports-graph d22-s01)))))
+           (t/supports-graph d22-s00)))))
 
 (deftest supported-by-graph-test
   (testing "Constructs the graph of which bricks are supporting a given brick"
@@ -106,21 +106,21 @@
             4 [1 2]
             5 [3 4]
             6 [5]}
-           (t/supported-by-graph (t/supports-graph d22-s01))))))
+           (t/supported-by-graph (t/supports-graph d22-s00))))))
 
 (deftest disintegratable-bricks-test
   (testing "Identifies the brick ids of the bricks that can be disintegrated"
-    (is (= [1 2 3 4 6] (t/disintegratable-bricks d22-s01)))))
+    (is (= [1 2 3 4 6] (t/disintegratable-bricks d22-s00)))))
 
 (deftest disintegratable-count-test
   (testing "Counts how many placed bricks can be disintegrated"
-    (is (= 5 (t/disintegratable-count d22-s01)))
-    (is (= 3 (t/disintegratable-count (t/parse d22-s02-raw))))))
+    (is (= 5 (t/disintegratable-count d22-s00)))
+    (is (= 3 (t/disintegratable-count (t/parse d22-s01-raw))))))
 
 (deftest bricks-to-fall-test
   (testing "Computes the number of bricks that will fall when
             the non-disintegratable bricks are removed"
-    (is (= 7 (t/bricks-to-fall d22-s01)))))
+    (is (= 7 (t/bricks-to-fall d22-s00)))))
 
 (def day22-input (u/parse-puzzle-input t/parse 2023 22))
 

--- a/test/aoc_clj/2023/day23_test.clj
+++ b/test/aoc_clj/2023/day23_test.clj
@@ -4,7 +4,7 @@
             [aoc-clj.utils.grid.vecgrid :as vg]
             [aoc-clj.2023.day23 :as t]))
 
-(def d23-s01-raw
+(def d23-s00-raw
   ["#.#####################"
    "#.......#########...###"
    "#######.#########.#.###"
@@ -29,7 +29,7 @@
    "#.....###...###...#...#"
    "#####################.#"])
 
-(def d23-s01
+(def d23-s00
   (vg/->VecGrid2D
    [[\# \. \# \# \# \# \# \# \# \# \# \# \# \# \# \# \# \# \# \# \# \# \#]
     [\# \. \. \. \. \. \. \. \# \# \# \# \# \# \# \# \# \. \. \. \# \# \#]
@@ -78,12 +78,12 @@
 
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d23-s01 (t/parse d23-s01-raw)))))
+    (is (= d23-s00 (t/parse d23-s00-raw)))))
 
 (deftest trace-maze-test
   (testing "Explores the maze and returns a map representation
             of a DAG representing the vertices"
-    (is (= d23-s01-graph (t/trace-maze d23-s01 {:pos [1 0] :heading :n})))))
+    (is (= d23-s01-graph (t/trace-maze d23-s00 {:pos [1 0] :heading :n})))))
 
 (deftest full-graph-test
   (testing "Adds the reverse edges to the graph"
@@ -91,8 +91,8 @@
 
 (deftest longest-possible-path-test
   (testing "Finds the longest possible path through the maze"
-    (is (= 94 (t/longest-downslope-path d23-s01)))
-    (is (= 154 (t/longest-full-path d23-s01)))))
+    (is (= 94 (t/longest-downslope-path d23-s00)))
+    (is (= 154 (t/longest-full-path d23-s00)))))
 
 (def day23-input (u/parse-puzzle-input t/parse 2023 23))
 

--- a/test/aoc_clj/2023/day24_test.clj
+++ b/test/aoc_clj/2023/day24_test.clj
@@ -3,14 +3,14 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day24 :as t]))
 
-(def d24-s01-raw
+(def d23-s00-raw
   ["19, 13, 30 @ -2,  1, -2"
    "18, 19, 22 @ -1, -1, -2"
    "20, 25, 34 @ -2, -2, -4"
    "12, 31, 28 @ -1, -2, -1"
    "20, 19, 15 @  1, -5, -3"])
 
-(def d24-s01
+(def d24-s00
   [[[19 13 30] [-2  1 -2]]
    [[18 19 22] [-1 -1 -2]]
    [[20 25 34] [-2 -2 -4]]
@@ -19,33 +19,33 @@
 
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d24-s01 (t/parse d24-s01-raw)))))
+    (is (= d24-s00 (t/parse d23-s00-raw)))))
 
 (deftest hailstone-intersect-xy-test
   (testing "Tests the comparisons of where hailstones will intersect"
-    (is (= [43/3 46/3] (t/hailstone-intersect-xy [(nth d24-s01 0) (nth d24-s01 1)])))
-    (is (= [35/3 50/3] (t/hailstone-intersect-xy [(nth d24-s01 0) (nth d24-s01 2)])))
-    (is (= [31/5 97/5] (t/hailstone-intersect-xy [(nth d24-s01 0) (nth d24-s01 3)])))
-    (is (= :past       (t/hailstone-intersect-xy [(nth d24-s01 0) (nth d24-s01 4)])))
-    (is (= :parallel   (t/hailstone-intersect-xy [(nth d24-s01 1) (nth d24-s01 2)])))
-    (is (= [-6 -5]     (t/hailstone-intersect-xy [(nth d24-s01 1) (nth d24-s01 3)])))
-    (is (= :past       (t/hailstone-intersect-xy [(nth d24-s01 1) (nth d24-s01 4)])))
-    (is (= [-2 3]      (t/hailstone-intersect-xy [(nth d24-s01 2) (nth d24-s01 3)])))
-    (is (= :past       (t/hailstone-intersect-xy [(nth d24-s01 2) (nth d24-s01 4)])))
-    (is (= :past       (t/hailstone-intersect-xy [(nth d24-s01 3) (nth d24-s01 4)])))))
+    (is (= [43/3 46/3] (t/hailstone-intersect-xy [(nth d24-s00 0) (nth d24-s00 1)])))
+    (is (= [35/3 50/3] (t/hailstone-intersect-xy [(nth d24-s00 0) (nth d24-s00 2)])))
+    (is (= [31/5 97/5] (t/hailstone-intersect-xy [(nth d24-s00 0) (nth d24-s00 3)])))
+    (is (= :past       (t/hailstone-intersect-xy [(nth d24-s00 0) (nth d24-s00 4)])))
+    (is (= :parallel   (t/hailstone-intersect-xy [(nth d24-s00 1) (nth d24-s00 2)])))
+    (is (= [-6 -5]     (t/hailstone-intersect-xy [(nth d24-s00 1) (nth d24-s00 3)])))
+    (is (= :past       (t/hailstone-intersect-xy [(nth d24-s00 1) (nth d24-s00 4)])))
+    (is (= [-2 3]      (t/hailstone-intersect-xy [(nth d24-s00 2) (nth d24-s00 3)])))
+    (is (= :past       (t/hailstone-intersect-xy [(nth d24-s00 2) (nth d24-s00 4)])))
+    (is (= :past       (t/hailstone-intersect-xy [(nth d24-s00 3) (nth d24-s00 4)])))))
 
 (deftest intersections-within-area-test
   (testing "Counts the number of hailstone intersections within a prescribed area"
-    (is (= 2 (t/intersections-within-area [7 27] d24-s01)))))
+    (is (= 2 (t/intersections-within-area [7 27] d24-s00)))))
 
 (deftest rock-parameters-test
   (testing "Solves the linear equations to find the rock's parameters"
     (is (= [24 13 10 -3 1 2]
-           (apply t/rock-parameters (take 3 d24-s01))))))
+           (apply t/rock-parameters (take 3 d24-s00))))))
 
 (deftest rock-position-sum
   (testing "Computes the sum of the position values of the rock"
-    (is (= 47 (t/rock-position-sum d24-s01)))))
+    (is (= 47 (t/rock-position-sum d24-s00)))))
 
 (def day24-input (u/parse-puzzle-input t/parse 2023 24))
 

--- a/test/aoc_clj/2023/day25_test.clj
+++ b/test/aoc_clj/2023/day25_test.clj
@@ -3,7 +3,7 @@
             [aoc-clj.utils.core :as u]
             [aoc-clj.2023.day25 :as t]))
 
-(def d25-s01-raw
+(def d25-s00-raw
   ["jqt: rhn xhk nvd"
    "rsh: frs pzl lsr"
    "xhk: hfx"
@@ -18,11 +18,11 @@
    "rzs: qnr cmg lsr rsh"
    "frs: qnr lhk lsr"])
 
-(def d25-s02-raw
+(def d25-s01-raw
   ["jqt: rhn xhk nvd"
    "rsh: frs pzl lsr"])
 
-(def d25-s01
+(def d25-s00
   {"jqt" ["rhn" "xhk" "nvd"]
    "rsh" ["frs" "pzl" "lsr"]
    "xhk" ["hfx"]
@@ -37,11 +37,11 @@
    "rzs" ["qnr" "cmg" "lsr" "rsh"]
    "frs" ["qnr" "lhk" "lsr"]})
 
-(def d25-s02
+(def d25-s01
   {"jqt" ["rhn" "xhk" "nvd"]
    "rsh" ["frs" "pzl" "lsr"]})
 
-(def d25-s02-flattened
+(def d25-s01-flattened
   [#{"jqt" "rhn"}
    #{"jqt" "xhk"}
    #{"jqt" "nvd"}
@@ -51,12 +51,12 @@
 
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d25-s01 (t/parse d25-s01-raw)))
-    (is (= d25-s02 (t/parse d25-s02-raw)))))
+    (is (= d25-s00 (t/parse d25-s00-raw)))
+    (is (= d25-s01 (t/parse d25-s01-raw)))))
 
 (deftest flatten-graph-test
   (testing "Flattens the graph to just edge sets"
-    (is (= d25-s02-flattened (t/flatten-graph d25-s02)))))
+    (is (= d25-s01-flattened (t/flatten-graph d25-s01)))))
 
 (deftest graph-without-nodes-test
   (testing "Removes edge sets from the graph"
@@ -64,23 +64,23 @@
             #{"jqt" "nvd"}
             #{"rsh" "pzl"}
             #{"rsh" "lsr"}]
-           (t/graph-without-nodes d25-s02-flattened [#{"jqt" "rhn"}
+           (t/graph-without-nodes d25-s01-flattened [#{"jqt" "rhn"}
                                                      #{"rsh" "frs"}])))))
 
 (deftest neighbors-test
   (testing "Computes the neighboring (directly connected) nodes"
-    (is (= #{"rhn" "xhk" "nvd"} (t/neighbors d25-s02-flattened "jqt")))))
+    (is (= #{"rhn" "xhk" "nvd"} (t/neighbors d25-s01-flattened "jqt")))))
 
 ;; Determined by plotting the graph with graphviz and seeing what links crossed
 ;; between the two clusters
-(def d25-s01-cuts
+(def d25-s00-cuts
   [#{"hfx" "pzl"}
    #{"bvb" "cmg"}
    #{"nvd" "jqt"}])
 
 (deftest clique-sizes-test
   (testing "Computes the sizes of the two subgraphs after removing 3 edges"
-    (is (= #{9 6} (set (t/clique-sizes d25-s01 d25-s01-cuts))))))
+    (is (= #{9 6} (set (t/clique-sizes d25-s00 d25-s00-cuts))))))
 
 (def day25-input (u/parse-puzzle-input t/parse 2023 25))
 


### PR DESCRIPTION
This change makes earlier puzzle years consistent with what I did for 2023, where the puzzle input is not directly loaded into the main solution namespace and is instead loaded only in the test namespace for verifying solutions.

This change also shifted everything to use the `parse-puzzle-input` helper function so that we don't have a bunch of 
hard-coded path strings everywhere.

I also tried to rationalize the naming convention for sample data.