### PR TITLE
Simplify solution names

### DIFF
--- a/src/aoc_clj/2015/day01.clj
+++ b/src/aoc_clj/2015/day01.clj
@@ -18,14 +18,14 @@
        count))
 
 ;; Puzzle solutions
-(defn day01-part1-soln
+(defn part1
   "Interepting `(` as going up one floor and `)` as going down
    one floor what floor do you end up on given a string of 
    parentheses as input"
   [input]
   (final-floor input))
 
-(defn day01-part2-soln
+(defn part2
   "Still interpreting `(` as up one floor and `)` as down one
    floor, what's the first character in the input string that 
    causes the elevator to reach the basement (floor -1) "

--- a/src/aoc_clj/2015/day02.clj
+++ b/src/aoc_clj/2015/day02.clj
@@ -21,10 +21,10 @@
     (+ (* 2 (reduce + smallest))
        (* l w h))))
 
-(defn day02-part1-soln
+(defn part1
   [input]
   (reduce + (map wrapping-paper-area input)))
 
-(defn day02-part2-soln
+(defn part2
   [input]
   (reduce + (map ribbon-length input)))

--- a/src/aoc_clj/2015/day03.clj
+++ b/src/aoc_clj/2015/day03.clj
@@ -30,10 +30,10 @@
          set
          count)))
 
-(defn day03-part1-soln
+(defn part1
   [input]
   (houses-visited input))
 
-(defn day03-part2-soln
+(defn part2
   [input]
   (split-houses-visited input))

--- a/src/aoc_clj/2015/day04.clj
+++ b/src/aoc_clj/2015/day04.clj
@@ -35,10 +35,10 @@
 (def first-to-start-with-six-zeros
   (partial first-to-meet-condition starts-with-six-zeros?))
 
-(defn day04-part1-soln
+(defn part1
   [input]
   (first-to-start-with-five-zeros input))
 
-(defn day04-part2-soln
+(defn part2
   [input]
   (first-to-start-with-six-zeros input))

--- a/src/aoc_clj/2015/day05.clj
+++ b/src/aoc_clj/2015/day05.clj
@@ -34,10 +34,10 @@
    non-overlapping-pair?
    repeat-with-letter-between?))
 
-(defn day05-part1-soln
+(defn part1
   [input]
   (count (filter nice? input)))
 
-(defn day05-part2-soln
+(defn part2
   [input]
   (count (filter new-nice? input)))

--- a/src/aoc_clj/2015/day06.clj
+++ b/src/aoc_clj/2015/day06.clj
@@ -73,11 +73,11 @@
   (reduce + (filter some? (vals grid))))
 
 (def update-grid-part1 (partial update-grid commands))
-(defn day06-part1-soln
+(defn part1
   [input]
   (count-on (reduce update-grid-part1 {} input)))
 
 (def update-grid-part2 (partial update-grid commands2))
-(defn day06-part2-soln
+(defn part2
   [input]
   (brightness (reduce update-grid-part2 {} input)))

--- a/src/aoc_clj/2015/day07.clj
+++ b/src/aoc_clj/2015/day07.clj
@@ -56,11 +56,11 @@
   [circuit val]
   (assoc circuit "b" {:op :assign :args val}))
 
-(defn day07-part1-soln
+(defn part1
   [input]
   (wire-val input "a"))
 
-(defn day07-part2-soln
+(defn part2
   [input]
   (let [circuit input
         wirea (wire-val circuit "a")

--- a/src/aoc_clj/2015/day08.clj
+++ b/src/aoc_clj/2015/day08.clj
@@ -58,10 +58,10 @@
   (- (reduce + (map escaped-chars input))
      (reduce + (map code-chars input))))
 
-(defn day08-part1-soln
+(defn part1
   [input]
   (unescaped-difference input))
 
-(defn day08-part2-soln
+(defn part2
   [input]
   (escaped-difference input))

--- a/src/aoc_clj/2015/day09.clj
+++ b/src/aoc_clj/2015/day09.clj
@@ -37,10 +37,10 @@
   [dists]
   (apply max (route-distances dists)))
 
-(defn day09-part1-soln
+(defn part1
   [input]
   (shortest-route-distance input))
 
-(defn day09-part2-soln
+(defn part2
   [input]
   (longest-route-distance input))

--- a/src/aoc_clj/2015/day10.clj
+++ b/src/aoc_clj/2015/day10.clj
@@ -10,10 +10,10 @@
         counts (map #(vector (str  (count %)) (str (first %))) chunks)]
     (str/join  (flatten  counts))))
 
-(defn day10-part1-soln
+(defn part1
   [input]
   (count (nth (iterate look-and-say input) 40)))
 
-(defn day10-part2-soln
+(defn part2
   [input]
   (count (nth (iterate look-and-say input) 50)))

--- a/src/aoc_clj/2015/day11.clj
+++ b/src/aoc_clj/2015/day11.clj
@@ -74,12 +74,12 @@
          first
          nums->str)))
 
-(defn day11-part1-soln
+(defn part1
   [input]
   (next-valid-password input))
 
-(defn day11-part2-soln
+(defn part2
   [input]
-  (-> (day11-part1-soln input)
+  (-> (part1 input)
       next-password
       next-valid-password))

--- a/src/aoc_clj/2015/day12.clj
+++ b/src/aoc_clj/2015/day12.clj
@@ -20,11 +20,11 @@
       (mapv drop-red s)
       s)))
 
-(defn day12-part1-soln
+(defn part1
   [input]
   (reduce + (all-numbers input)))
 
-(defn day12-part2-soln
+(defn part2
   [input]
   (->> (c/parse-string input)
        drop-red

--- a/src/aoc_clj/2015/day13.clj
+++ b/src/aoc_clj/2015/day13.clj
@@ -44,10 +44,10 @@
   (let [new-table (u/fmap #(assoc % "Me" 0) table)]
     (assoc new-table "Me" (zipmap (keys new-table) (repeat 0)))))
 
-(defn day13-part1-soln
+(defn part1
   [input]
   (max-happiness input))
 
-(defn day13-part2-soln
+(defn part2
   [input]
   (max-happiness (add-me input)))

--- a/src/aoc_clj/2015/day14.clj
+++ b/src/aoc_clj/2015/day14.clj
@@ -35,10 +35,10 @@
         scores (apply (partial map vector) (map score positions))]
     (mapv (partial reduce +) scores)))
 
-(defn day14-part1-soln
+(defn part1
   [input]
   (apply max (map (partial distance-at-time 2503) (vals input))))
 
-(defn day14-part2-soln
+(defn part2
   [input]
   (apply max (points-at-time 2503 input)))

--- a/src/aoc_clj/2015/day15.clj
+++ b/src/aoc_clj/2015/day15.clj
@@ -52,12 +52,12 @@
         opts (all-options max-teaspoons vars)]
     (apply max-key (partial score-fn input) opts)))
 
-(defn day15-part1-soln
+(defn part1
   [input]
   (let [best-combo (find-max-score score input)]
     (score input best-combo)))
 
-(defn day15-part2-soln
+(defn part2
   [input]
   (let [best-combo (find-max-score score-with-500cal input)]
     (score input best-combo)))

--- a/src/aoc_clj/2015/day16.clj
+++ b/src/aoc_clj/2015/day16.clj
@@ -51,10 +51,10 @@
   [criteria aunts]
   (ffirst (filter criteria aunts)))
 
-(defn day16-part1-soln
+(defn part1
   [input]
   (matching-aunt exact-match? input))
 
-(defn day16-part2-soln
+(defn part2
   [input]
   (matching-aunt range-match? input))

--- a/src/aoc_clj/2015/day17.clj
+++ b/src/aoc_clj/2015/day17.clj
@@ -23,10 +23,10 @@
         min-containers (apply min (map count combos))]
     (filter #(= min-containers (count %)) combos)))
 
-(defn day17-part1-soln
+(defn part1
   [input]
   (count (combinations 150 input)))
 
-(defn day17-part2-soln
+(defn part2
   [input]
   (count (minimal-combinations 150 input)))

--- a/src/aoc_clj/2015/day18.clj
+++ b/src/aoc_clj/2015/day18.clj
@@ -66,10 +66,10 @@
          (filter #(= :on (val %)))
          count)))
 
-(defn day18-part1-soln
+(defn part1
   [input]
   (lights-on-at-step-n 100 input))
 
-(defn day18-part2-soln
+(defn part2
   [input]
   (lights-on-at-step-n true 100 (corners-on input)))

--- a/src/aoc_clj/2015/day19.clj
+++ b/src/aoc_clj/2015/day19.clj
@@ -52,10 +52,10 @@
        (take-while #(not= "e" (:molecule %))
                    (iterate de-fabricate (ordered-replacements input)))))
 
-(defn day19-part1-soln
+(defn part1
   [input]
   (count (distinct-molecules input)))
 
-(defn day19-part2-soln
+(defn part2
   [input]
   (count (fabrication-steps input)))

--- a/src/aoc_clj/2015/day20.clj
+++ b/src/aoc_clj/2015/day20.clj
@@ -20,10 +20,10 @@
                      (filter #(zero? (rem house %))))]
     (* 11 (reduce + factors))))
 
-(defn day20-part1-soln
+(defn part1
   [input]
   (first-house-with-n-presents house-presents 776159 input))
 
-(defn day20-part2-soln
+(defn part2
   [input]
   (first-house-with-n-presents house-presents-part2 786239 input))

--- a/src/aoc_clj/2015/day21.clj
+++ b/src/aoc_clj/2015/day21.clj
@@ -78,10 +78,10 @@
         losers (remove (partial player-wins? boss) options)]
     (apply max-key :cost losers)))
 
-(defn day21-part1-soln
+(defn part1
   [input]
   (:cost (cheapest-winning-combo input)))
 
-(defn day21-part2-soln
+(defn part2
   [input]
   (:cost (priciest-losing-combo input)))

--- a/src/aoc_clj/2015/day22.clj
+++ b/src/aoc_clj/2015/day22.clj
@@ -114,12 +114,12 @@
 ;; TODO - These ought to be implemented so that they work on abitrary
 ;; inputs rather than hard-coding the winning plays
 (def winning-plays [:poison :recharge :shield :poison :recharge :magic-missile :poison :drain :magic-missile])
-(defn day22-part1-soln
+(defn part1
   []
   (reduce + (map spell-cost winning-plays)))
 
 (def winning-plays-part2 [:poison :recharge :shield :poison :recharge :shield :poison :magic-missile :magic-missile])
-(defn day22-part2-soln
+(defn part2
   []
   (reduce + (map spell-cost winning-plays-part2)))
 

--- a/src/aoc_clj/2015/day23.clj
+++ b/src/aoc_clj/2015/day23.clj
@@ -48,10 +48,10 @@
   (let [max-inst (count instructions)]
     (first (drop-while #(not-done? max-inst (:next-inst %)) (iterate (partial apply-inst instructions) init)))))
 
-(defn day23-part1-soln
+(defn part1
   [input]
   (:b (run-program input {:a 0 :b 0 :next-inst 0})))
 
-(defn day23-part2-soln
+(defn part2
   [input]
   (:b (run-program input {:a 1 :b 0 :next-inst 0})))

--- a/src/aoc_clj/2015/day24.clj
+++ b/src/aoc_clj/2015/day24.clj
@@ -28,10 +28,10 @@
   (->> (smallest-groups 4 input)
        best-quantum-entanglement))
 
-(defn day24-part1-soln
+(defn part1
   [input]
   (best-qe-thirds input))
 
-(defn day24-part2-soln
+(defn part2
   [input]
   (best-qe-fourths input))

--- a/src/aoc_clj/2015/day25.clj
+++ b/src/aoc_clj/2015/day25.clj
@@ -31,6 +31,6 @@
       first-code
       (m/mod-mul modulus (m/mod-pow modulus multiplier (dec code-num)) first-code))))
 
-(defn day25-part1-soln
+(defn part1
   [[row col]]
   (code row col))

--- a/src/aoc_clj/2016/day01.clj
+++ b/src/aoc_clj/2016/day01.clj
@@ -68,10 +68,10 @@
   [steps]
   (-> steps all-visited :visited first-duplicate (math/manhattan [0 0])))
 
-(defn day01-part1-soln
+(defn part1
   [input]
   (distance input))
 
-(defn day01-part2-soln
+(defn part2
   [input]
   (distance-to-first-duplicate input))

--- a/src/aoc_clj/2016/day02.clj
+++ b/src/aoc_clj/2016/day02.clj
@@ -45,10 +45,10 @@
 (def square-bathroom-code   (partial bathroom-code square-keypad))
 (def diagonal-bathroom-code (partial bathroom-code diagonal-keypad))
 
-(defn day02-part1-soln
+(defn part1
   [input]
   (square-bathroom-code input))
 
-(defn day02-part2-soln
+(defn part2
   [input]
   (diagonal-bathroom-code input))

--- a/src/aoc_clj/2016/day03.clj
+++ b/src/aoc_clj/2016/day03.clj
@@ -26,10 +26,10 @@
                (map #(nth % 2) input))
        (partition 3)))
 
-(defn day03-part1-soln
+(defn part1
   [input]
   (count-of-valid-triangles input))
 
-(defn day03-part2-soln
+(defn part2
   [input]
   (-> input group-by-columns count-of-valid-triangles))

--- a/src/aoc_clj/2016/day04.clj
+++ b/src/aoc_clj/2016/day04.clj
@@ -52,10 +52,10 @@
        first
        :sector-id))
 
-(defn day04-part1-soln
+(defn part1
   [input]
   (real-room-sector-id-sum input))
 
-(defn day04-part2-soln
+(defn part2
   [input]
   (north-pole-objects-room input))

--- a/src/aoc_clj/2016/day05.clj
+++ b/src/aoc_clj/2016/day05.clj
@@ -48,10 +48,10 @@
        (reduce set-char [\* \* \* \* \* \* \* \*])
        (apply str)))
 
-(defn day05-part1-soln
+(defn part1
   [input]
   (password input day05-input-valid-offsets))
 
-(defn day05-part2-soln
+(defn part2
   [input]
   (password-part2 input day05-input-valid-offsets))

--- a/src/aoc_clj/2016/day06.clj
+++ b/src/aoc_clj/2016/day06.clj
@@ -16,10 +16,10 @@
 (def most-frequent-chars (partial frequent-chars max-key))
 (def least-frequent-chars (partial frequent-chars min-key))
 
-(defn day06-part1-soln
+(defn part1
   [input]
   (most-frequent-chars input))
 
-(defn day06-part2-soln
+(defn part2
   [input]
   (least-frequent-chars input))

--- a/src/aoc_clj/2016/day07.clj
+++ b/src/aoc_clj/2016/day07.clj
@@ -40,11 +40,11 @@
        (some identity)
        boolean))
 
-(defn day07-part1-soln
+(defn part1
   [input]
   (count (filter supports-tls? input)))
 
-(defn day07-part2-soln
+(defn part2
   [input]
   (count (filter supports-ssl? input)))
 

--- a/src/aoc_clj/2016/day08.clj
+++ b/src/aoc_clj/2016/day08.clj
@@ -82,11 +82,11 @@
        (filter #{:on})
        count))
 
-(defn day08-part1-soln
+(defn part1
   [input]
   (lit-pixels 50 6 input))
 
-(defn day08-part2-soln
+(defn part2
   [input]
   ;; Execute the code in the comment to print the message
   (comment

--- a/src/aoc_clj/2016/day09.clj
+++ b/src/aoc_clj/2016/day09.clj
@@ -39,10 +39,10 @@
           (recur (+ (* (decompress-count repeat-string) repeats)
                     char-count open-marker-loc) new))))))
 
-(defn day09-part1-soln
+(defn part1
   [input]
   (count (decompress input)))
 
-(defn day09-part2-soln
+(defn part2
   [input]
   (decompress-count input))

--- a/src/aoc_clj/2016/day10.clj
+++ b/src/aoc_clj/2016/day10.clj
@@ -85,10 +85,10 @@
          (map first)
          (reduce *))))
 
-(defn day10-part1-soln
+(defn part1
   [input]
   (bot-that-compares input #{17 61}))
 
-(defn day10-part2-soln
+(defn part2
   [input]
   (output-values input))

--- a/src/aoc_clj/2016/day11.clj
+++ b/src/aoc_clj/2016/day11.clj
@@ -90,10 +90,10 @@
   [state]
   (update state 1 conj [:m "El"] [:g "El"] [:m "Li2"] [:g "Li2"]))
 
-(defn day11-part1-soln
+(defn part1
   [input]
   (move-count input))
 
-(defn day11-part2-soln
+(defn part2
   [input]
   (move-count (extra-items input)))

--- a/src/aoc_clj/2016/day12.clj
+++ b/src/aoc_clj/2016/day12.clj
@@ -52,11 +52,11 @@
         state
         (recur (apply-cmd state cmd))))))
 
-(defn day12-part1-soln
+(defn part1
   [input]
   (:a (execute init-state input)))
 
-(defn day12-part2-soln
+(defn part2
   [input]
   (:a (execute (assoc init-state :c 1) input)))
 

--- a/src/aoc_clj/2018/day01.clj
+++ b/src/aoc_clj/2018/day01.clj
@@ -20,10 +20,10 @@
         freq
         (recur (rest freqs) (conj observed freq))))))
 
-(defn day01-part1-soln
+(defn part1
   [input]
   (net-freq-change input))
 
-(defn day01-part2-soln
+(defn part2
   [input]
   (find-first-repeated-freq input))

--- a/src/aoc_clj/2018/day02.clj
+++ b/src/aoc_clj/2018/day02.clj
@@ -50,10 +50,10 @@
         index2 (quot closest box-id-count)]
     (chars-in-common (nth box-ids index1) (nth box-ids index2))))
 
-(defn day02-part1-soln
+(defn part1
   [input]
   (compute-checksum input))
 
-(defn day02-part2-soln
+(defn part2
   [input]
   (find-closest-boxids input))

--- a/src/aoc_clj/2018/day03.clj
+++ b/src/aoc_clj/2018/day03.clj
@@ -59,11 +59,11 @@
         overlap-ids (overlapping-swath-ids swaths)]
     (first (set/difference all-ids overlap-ids))))
 
-(defn day03-part1-soln
+(defn part1
   [input]
   (overlapping-squares input))
 
-(defn day03-part2-soln
+(defn part2
   [input]
   (nonoverlapping-swath input))
 

--- a/src/aoc_clj/2018/day04.clj
+++ b/src/aoc_clj/2018/day04.clj
@@ -43,10 +43,10 @@
         [guard [minute _]] (apply max-key (comp second val) max-minutes)]
     [guard minute]))
 
-(defn day04-part1-soln
+(defn part1
   [input]
   (reduce * (sleepiest-guard-and-optimal-minute input)))
 
-(defn day04-part2-soln
+(defn part2
   [input]
   (reduce * (guard-most-frequently-asleep-at-minute input)))

--- a/src/aoc_clj/2019/day01.clj
+++ b/src/aoc_clj/2019/day01.clj
@@ -28,10 +28,10 @@
        rest ;; drop the original mass itself
        (reduce +)))
 
-(defn day01-part1-soln
+(defn part1
   [input]
   (reduce + (map fuel input)))
 
-(defn day01-part2-soln
+(defn part2
   [input]
   (reduce + (map total-fuel input)))

--- a/src/aoc_clj/2019/day02.clj
+++ b/src/aoc_clj/2019/day02.clj
@@ -32,11 +32,11 @@
             #(not= output (intcode-output intcode %))
             candidates))))
 
-(defn day02-part1-soln
+(defn part1
   [input]
   (intcode-output input [12 2]))
 
-(defn day02-part2-soln
+(defn part2
   [input]
   (let [[noun verb] (pair-produces-output input 19690720)]
     (+ (* 100 noun) verb)))

--- a/src/aoc_clj/2019/day03.clj
+++ b/src/aoc_clj/2019/day03.clj
@@ -108,10 +108,10 @@
 ;;                        (get path1-dists (first %))) path2-dists)]
 ;;     (second (sort dists))))
 
-(defn day03-part1-soln
+(defn part1
   [input]
   (closest-intersection-dist input))
 
-(defn day03-part2-soln
+(defn part2
   [input]
   (shortest-steps-to-intersection input))

--- a/src/aoc_clj/2019/day04.clj
+++ b/src/aoc_clj/2019/day04.clj
@@ -29,7 +29,7 @@
        (map digits)
        (filter condition)))
 
-(defn day04-part1-soln
+(defn part1
   [input]
   (count (satisfactory-numbers (apply range input) all-conds-part1?)))
 
@@ -40,6 +40,6 @@
 (def all-conds-part2?
   (every-pred not-decreasing-digits? pair-not-in-larger-group?))
 
-(defn day04-part2-soln
+(defn part2
   [input]
   (count (satisfactory-numbers (apply range input) all-conds-part2?)))

--- a/src/aoc_clj/2019/day05.clj
+++ b/src/aoc_clj/2019/day05.clj
@@ -5,10 +5,10 @@
 
 (def parse u/firstv)
 
-(defn day05-part1-soln
+(defn part1
   [input]
   (intcode/last-out (intcode/intcode-exec input [1])))
 
-(defn day05-part2-soln
+(defn part2
   [input]
   (intcode/last-out (intcode/intcode-exec input [5])))

--- a/src/aoc_clj/2019/day06.clj
+++ b/src/aoc_clj/2019/day06.clj
@@ -49,10 +49,10 @@
           (distance-to-ancestor orbits objB ancestor))
        2)))
 
-(defn day06-part1-soln
+(defn part1
   [input]
   (orbit-count input))
 
-(defn day06-part2-soln
+(defn part2
   [input]
   (orbit-transfers input "YOU" "SAN"))

--- a/src/aoc_clj/2019/day07.clj
+++ b/src/aoc_clj/2019/day07.clj
@@ -62,10 +62,10 @@
   [intcode]
   (max-output intcode amplifier-loop [5 6 7 8 9]))
 
-(defn day07-part1-soln
+(defn part1
   [input]
   (max-amplifier-chain-output input))
 
-(defn day07-part2-soln
+(defn part2
   [input]
   (max-amplifier-loop-output input))

--- a/src/aoc_clj/2019/day08.clj
+++ b/src/aoc_clj/2019/day08.clj
@@ -25,14 +25,14 @@
     (doseq [line (partition width legible-pixels)]
       (println (str/join line)))))
 
-(defn day08-part1-soln
+(defn part1
   [input]
   (let [layers (partition (* 25 6) input)
         layer-freqs (map frequencies layers)
         min-zero-layer (apply min-key #(get % 0) layer-freqs)]
     (* (get min-zero-layer 1) (get min-zero-layer 2))))
 
-(defn day08-part2-soln
+(defn part2
   [input]
   (comment
     (pprint-image (decode-image input 25 6) 25)

--- a/src/aoc_clj/2019/day09.clj
+++ b/src/aoc_clj/2019/day09.clj
@@ -5,10 +5,10 @@
 
 (def parse u/firstv)
 
-(defn day09-part1-soln
+(defn part1
   [input]
   (intcode/last-out (intcode/intcode-exec input [1])))
 
-(defn day09-part2-soln
+(defn part2
   [input]
   (intcode/last-out (intcode/intcode-exec input [2])))

--- a/src/aoc_clj/2019/day10.clj
+++ b/src/aoc_clj/2019/day10.clj
@@ -90,13 +90,13 @@
          (apply mapcat vector)
          (filter some?))))
 
-(defn day10-part1-soln
+(defn part1
   [input]
   (best-location input))
 
-(defn day10-part2-soln
+(defn part2
   [input]
-  (let [pos (first (day10-part1-soln input))
+  (let [pos (first (part1 input))
         [x y] (nth (asteroids-laser-order pos input) 199)]
     (+ (* 100 x) y)))
 

--- a/src/aoc_clj/2019/day11.clj
+++ b/src/aoc_clj/2019/day11.clj
@@ -51,11 +51,11 @@
         state
         (recur (stepper state))))))
 
-(defn day11-part1-soln
+(defn part1
   [input]
   (count (keys (:hull (paint-bot input 0)))))
 
-(defn- derive-day11-part2-soln
+(defn- derive-part2
   [input]
   (->> (paint-bot input 1)
        :hull
@@ -64,10 +64,10 @@
        (grid/Grid2D->ascii {\  0 \* 1})
        print))
 
-(defn day11-part2-soln
+(defn part2
   [input]
   (comment
-    (derive-day11-part2-soln input)
+    (derive-part2 input)
     "Prints out:
       **** *    **** ***  *  *   ** ***   **    
          * *    *    *  * * *     * *  * *  *   

--- a/src/aoc_clj/2019/day12.clj
+++ b/src/aoc_clj/2019/day12.clj
@@ -87,10 +87,10 @@
   [moons]
   (* 2 (apply math/lcm (pmap axis-period [:x :y :z] (repeat moons)))))
 
-(defn day12-part1-soln
+(defn part1
   [input]
   (total-energy (nth (simulate input) 1000)))
 
-(defn day12-part2-soln
+(defn part2
   [input]
   (recurrence-period input))

--- a/src/aoc_clj/2019/day13.clj
+++ b/src/aoc_clj/2019/day13.clj
@@ -67,13 +67,13 @@
     @program
     (println "Finished!")))
 
-(defn day13-part1-soln
+(defn part1
   [input]
   (let [board (intcode/out-seq (intcode/intcode-exec input []))
         tile-values (flatten (partition 1 3 (drop 2 board)))]
     (get (frequencies tile-values) 2)))
 
-(defn day13-part2-soln
+(defn part2
   "After playing the `breakout` game above, 11140 is the max high score"
   [input]
   (comment (breakout input))

--- a/src/aoc_clj/2019/day14.clj
+++ b/src/aoc_clj/2019/day14.clj
@@ -83,10 +83,10 @@
         end-guess (int (* 1.3 start-guess))]
     (first (binary-search (partial ore-amount recipes) available-ore start-guess end-guess))))
 
-(defn day14-part1-soln
+(defn part1
   [input]
   (ore-amount input))
 
-(defn day14-part2-soln
+(defn part2
   [input]
   (max-fuel input))

--- a/src/aoc_clj/2019/day15.clj
+++ b/src/aoc_clj/2019/day15.clj
@@ -38,7 +38,7 @@
   [input]
   (map-maze-with-droid input))
 
-(defn day15-part1-soln
+(defn part1
   [input]
   (let [thismaze (thismaze input)
         start [0 0]
@@ -47,7 +47,7 @@
         path (g/dijkstra simplified-maze start (u/equals? finish))]
     (g/path-distance simplified-maze path)))
 
-(defn day15-part2-soln
+(defn part2
   [input]
   (let [thismaze (thismaze input)]
     (maze/flood-fill thismaze (maze/find-target thismaze :oxygen))))

--- a/src/aoc_clj/2019/day16.clj
+++ b/src/aoc_clj/2019/day16.clj
@@ -84,11 +84,11 @@
          (take-last 8)
          reverse)))
 
-(defn day16-part1-soln
+(defn part1
   [input]
   (nums->str (take 8 (run-phases input 100))))
 
-(defn day16-part2-soln
+(defn part2
   [input]
   (nums->str (real-signal input 100)))
 

--- a/src/aoc_clj/2019/day17.clj
+++ b/src/aoc_clj/2019/day17.clj
@@ -50,13 +50,13 @@
    "L,12,L,8,R,10\n"
    "n\n"))
 
-(defn day17-part1-soln
+(defn part1
   [input]
   (->> (day17-map input)
        intersections
        alignment-sum))
 
-(defn day17-part2-soln
+(defn part2
   [input]
   (let [code (assoc input 0 2)]
     (->> path

--- a/src/aoc_clj/2019/day18.clj
+++ b/src/aoc_clj/2019/day18.clj
@@ -201,10 +201,10 @@
            :nodes (into (filter (partial not= [x y]) nodes) newents)
            :entrances (zipmap newents (map str (range))))))
 
-(defn day18-part1-soln
+(defn part1
   [input]
   (shortest-path (load-graph (load-maze input))))
 
-(defn day18-part2-soln
+(defn part2
   [input]
   (shortest-path (load-graph (fix-maze (load-maze input)))))

--- a/src/aoc_clj/2019/day19.clj
+++ b/src/aoc_clj/2019/day19.clj
@@ -11,12 +11,12 @@
                  x (range size)]
              (intcode/out-seq (intcode/intcode-exec intcode [x y])))))
 
-(defn day19-part1-soln
+(defn part1
   [input]
   (count (filter pos? (tractor-beam input 50))))
 
 ;; TODO: Add algorithmic solution for day19 part 2
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/20
-(defn day19-part2-soln
+(defn part2
   [_]
   12201460)

--- a/src/aoc_clj/2019/day20.clj
+++ b/src/aoc_clj/2019/day20.clj
@@ -201,10 +201,10 @@
         rmaze (recursive-maze state)]
     (g/path-distance rmaze (g/dijkstra rmaze start end :limit 100000))))
 
-(defn day20-part1-soln
+(defn part1
   [input]
   (solve-maze input))
 
-(defn day20-part2-soln
+(defn part2
   [input]
   (solve-recursive-maze input))

--- a/src/aoc_clj/2019/day21.clj
+++ b/src/aoc_clj/2019/day21.clj
@@ -27,13 +27,13 @@
    "AND T J"
    "RUN"])
 
-(defn day21-part1-soln
+(defn part1
   [input]
   (->> (intcode/cmds->ascii spring-codes-part1)
        (intcode/intcode-exec input)
        intcode/last-out))
 
-(defn day21-part2-soln
+(defn part2
   [input]
   (->> (intcode/cmds->ascii spring-codes-part2)
        (intcode/intcode-exec input)

--- a/src/aoc_clj/2019/day22.clj
+++ b/src/aoc_clj/2019/day22.clj
@@ -79,11 +79,11 @@
    five hundred eighty-two million, seventy-six thousand, six hundred sixty-one"
   101741582076661)
 
-(defn day22-part1-soln
+(defn part1
   [input]
   (u/index-of (u/equals? 2019) (shuffle-deck 10007 input)))
 
-(defn day22-part2-soln
+(defn part2
   [input]
   (card-after-multiple-shuffles card-count input shuffle-count 2020))
 

--- a/src/aoc_clj/2019/day23.clj
+++ b/src/aoc_clj/2019/day23.clj
@@ -85,10 +85,10 @@
 ;;         (state :status)
 ;;         (recur (stepper state))))))
 
-(defn day23-part1-soln
+(defn part1
   [_]
   23886)
 
-(defn day23-part2-soln
+(defn part2
   [_]
   18333)

--- a/src/aoc_clj/2019/day24.clj
+++ b/src/aoc_clj/2019/day24.clj
@@ -146,10 +146,10 @@
   [space3d]
   (u/count-if space3d #(= :bug (val %))))
 
-(defn day24-part1-soln
+(defn part1
   [input]
   (find-recurrence input))
 
-(defn day24-part2-soln
+(defn part2
   [input]
   (bug-count (simulate input 200)))

--- a/src/aoc_clj/2019/day25.clj
+++ b/src/aoc_clj/2019/day25.clj
@@ -53,7 +53,7 @@
          intcode/read-ascii-output
          println)))
 
-(defn day25-part1-soln
+(defn part1
   [input commands]
   (comment
     (text-adventure-walkthrough input commands)

--- a/src/aoc_clj/2020/day01.clj
+++ b/src/aoc_clj/2020/day01.clj
@@ -22,10 +22,10 @@
     (->> candidates
          (filter candidate-set))))
 
-(defn day01-part1-soln
+(defn part1
   [input]
   (apply * (find-pair-that-sums-to-total 2020 input)))
 
-(defn day02-part2-soln
+(defn part2
   [input]
   (apply * (find-triple-that-sums-to-total 2020 input)))

--- a/src/aoc_clj/2020/day02.clj
+++ b/src/aoc_clj/2020/day02.clj
@@ -34,10 +34,10 @@
         (and (= b char)
              (not (= a char))))))
 
-(defn day02-part1-soln
+(defn part1
   [input]
   (count (filter part1-valid? input)))
 
-(defn day02-part2-soln
+(defn part2
   [input]
   (count (filter part2-valid? input)))

--- a/src/aoc_clj/2020/day03.clj
+++ b/src/aoc_clj/2020/day03.clj
@@ -32,13 +32,13 @@
   [basemap slopes]
   (map (partial trees-along-slope basemap) slopes))
 
-(defn day03-part1-soln
+(defn part1
   [input]
   (let [basemap (forest-basemap input)
         slope   [3 1]]
     (trees-along-slope basemap slope)))
 
-(defn day03-part2-soln
+(defn part2
   [input]
   (let [basemap (forest-basemap input)
         slopes  [[1 1] [3 1] [5 1] [7 1] [1 2]]]

--- a/src/aoc_clj/2020/day04.clj
+++ b/src/aoc_clj/2020/day04.clj
@@ -87,10 +87,10 @@
               ecl-valid?
               pid-valid?))
 
-(defn day04-part1-soln
+(defn part1
   [input]
   (count (filter keys-valid? input)))
 
-(defn day04-part2-soln
+(defn part2
   [input]
   (count (filter passport-valid? input)))

--- a/src/aoc_clj/2020/day05.clj
+++ b/src/aoc_clj/2020/day05.clj
@@ -14,11 +14,11 @@
                                  "R" "1"})]
     (read-string (str "2r" bit-string))))
 
-(defn day05-part1-soln
+(defn part1
   [input]
   (apply max (map seat-id input)))
 
-(defn day05-part2-soln
+(defn part2
   [input]
   (let [seat-ids (sort (map seat-id input))]
     (->> (map vector seat-ids (rest seat-ids))

--- a/src/aoc_clj/2020/day06.clj
+++ b/src/aoc_clj/2020/day06.clj
@@ -25,10 +25,10 @@
        (map (comp count count-fn))
        (reduce +)))
 
-(defn day06-part1-soln
+(defn part1
   [input]
   (sum-counts input unique-answers-in-group))
 
-(defn day06-part2-soln
+(defn part2
   [input]
   (sum-counts input common-answers-in-group))

--- a/src/aoc_clj/2020/day07.clj
+++ b/src/aoc_clj/2020/day07.clj
@@ -53,10 +53,10 @@
   [rules bag]
   (dec (satisfy-rule (into {} rules) 1 bag)))
 
-(defn day07-part1-soln
+(defn part1
   [input]
   (count (all-outer-bags input :shiny-gold)))
 
-(defn day07-part2-soln
+(defn part2
   [input]
   (count-inner-bags input :shiny-gold))

--- a/src/aoc_clj/2020/day08.clj
+++ b/src/aoc_clj/2020/day08.clj
@@ -66,10 +66,10 @@
        first
        :acc))
 
-(defn day08-part1-soln
+(defn part1
   [input]
   (acc-value-at-second-loop input))
 
-(defn day08-part2-soln
+(defn part2
   [input]
   (acc-value-for-finite-loop input))

--- a/src/aoc_clj/2020/day09.clj
+++ b/src/aoc_clj/2020/day09.clj
@@ -28,10 +28,10 @@
           (recur left (inc right))
           (recur (inc left) right))))))
 
-(defn day09-part1-soln
+(defn part1
   [input]
   (first-non-sum input 25))
 
-(defn day09-part2-soln
+(defn part2
   [input]
-  (reduce + (contiguous-range-to-sum input (day09-part1-soln input))))
+  (reduce + (contiguous-range-to-sum input (part1 input))))

--- a/src/aoc_clj/2020/day10.clj
+++ b/src/aoc_clj/2020/day10.clj
@@ -31,11 +31,11 @@
          (map combo-mapping)
          (reduce *))))
 
-(defn day10-part1-soln
+(defn part1
   [input]
   (let [freqs (freq-steps input)]
     (reduce * freqs)))
 
-(defn day10-part2-soln
+(defn part2
   [input]
   (combination-count input))

--- a/src/aoc_clj/2020/day11.clj
+++ b/src/aoc_clj/2020/day11.clj
@@ -88,10 +88,10 @@
   (let [seats (seats grid)]
     (zipmap seats (map (partial first-visible-seats seatmap) seats))))
 
-(defn day11-part1-soln
+(defn part1
   [input]
   (occupied-seats-when-static input 4 adjacency))
 
-(defn day11-part2-soln
+(defn part2
   [input]
   (occupied-seats-when-static input 5 visibility))

--- a/src/aoc_clj/2020/day12.clj
+++ b/src/aoc_clj/2020/day12.clj
@@ -82,10 +82,10 @@
        (map #(Math/abs %))
        (reduce +)))
 
-(defn day12-part1-soln
+(defn part1
   [input]
   (final-distance input exec-cmd))
 
-(defn day12-part2-soln
+(defn part2
   [input]
   (final-distance input exec-cmd2))

--- a/src/aoc_clj/2020/day13.clj
+++ b/src/aoc_clj/2020/day13.clj
@@ -66,10 +66,10 @@
         offsets (map (partial bus-terms main-bus) positions)]
     (* main-bus (second (reduce earliest-match offsets)))))
 
-(defn day13-part1-soln
+(defn part1
   [input]
   (bus-id-by-wait-time input))
 
-(defn day13-part2-soln
+(defn part2
   [input]
   (earliest-consecutive-buses input))

--- a/src/aoc_clj/2020/day14.clj
+++ b/src/aoc_clj/2020/day14.clj
@@ -88,10 +88,10 @@
   [input decoder]
   (reduce + (vals (decoder input))))
 
-(defn day14-part1-soln
+(defn part1
   [input]
   (register-sum input execute))
 
-(defn day14-part2-soln
+(defn part2
   [input]
   (register-sum input execute2))

--- a/src/aoc_clj/2020/day15.clj
+++ b/src/aoc_clj/2020/day15.clj
@@ -35,10 +35,10 @@
                  (update nums nextnum #(conjv % cnt))
                  (inc cnt)))))))
 
-(defn day15-part1-soln
+(defn part1
   [input]
   (last (memory-seq input 2020)))
 
-(defn day15-part2-soln
+(defn part2
   [input]
   (last (memory-seq input 30000000)))

--- a/src/aoc_clj/2020/day16.clj
+++ b/src/aoc_clj/2020/day16.clj
@@ -77,11 +77,11 @@
   (let [mapping (identify-slots input)]
     (into {} (map-indexed (fn [idx val] [(get mapping idx) val]) yours))))
 
-(defn day16-part1-soln
+(defn part1
   [input]
   (reduce + (invalid-nearby input)))
 
-(defn day16-part2-soln
+(defn part2
   [input]
   (->> (resolved-ticket input)
        (filter #(str/starts-with? (str (symbol (key %))) "departure"))

--- a/src/aoc_clj/2020/day17.clj
+++ b/src/aoc_clj/2020/day17.clj
@@ -106,14 +106,14 @@
   (let [add-dim (fn [[x y z]] [x y z 0])]
     (assoc input :grid (u/kmap add-dim grid))))
 
-(defn day17-part1-soln
+(defn part1
   [input]
   (->> (evolve-3d input 6)
        vals
        (filter #{:active})
        count))
 
-(defn day17-part2-soln
+(defn part2
   [input]
   (->> (evolve-4d (promote-to-4d input) 6)
        vals

--- a/src/aoc_clj/2020/day18.clj
+++ b/src/aoc_clj/2020/day18.clj
@@ -33,10 +33,10 @@
          ((operize oper) acc y)))
      init (partition 2 (rest expr)))))
 
-(defn day18-part1-soln
+(defn part1
   [input]
   (reduce + (map (comp infix interpret) input)))
 
-(defn day18-part2-soln
+(defn part2
   [input]
   (reduce + (map (comp infix interpret2) input)))

--- a/src/aoc_clj/2020/day19.clj
+++ b/src/aoc_clj/2020/day19.clj
@@ -72,10 +72,10 @@
           (filter some?)
           count))))
 
-(defn day19-part1-soln
+(defn part1
   [input]
   (count-matches input))
 
-(defn day19-part2-soln
+(defn part2
   [input]
   (count-matches input true))

--- a/src/aoc_clj/2020/day20.clj
+++ b/src/aoc_clj/2020/day20.clj
@@ -279,7 +279,7 @@
         sea-monsters (apply max (map sea-monster-count (all-orientations image)))]
     (- ones (* sea-monsters (count sea-monster-pattern)))))
 
-(defn day20-part1-soln
+(defn part1
   [input]
   (->> input
        tile-edge-map
@@ -287,6 +287,6 @@
        corners
        (reduce *)))
 
-(defn day20-part2-soln
+(defn part2
   [input]
   (sea-roughness input))

--- a/src/aoc_clj/2020/day21.clj
+++ b/src/aoc_clj/2020/day21.clj
@@ -57,10 +57,10 @@
        (map second)
        (str/join ",")))
 
-(defn day21-part1-soln
+(defn part1
   [input]
   (count (safe-ingredients input)))
 
-(defn day21-part2-soln
+(defn part2
   [input]
   (allergen-sorted-unsafe-ingredients input))

--- a/src/aoc_clj/2020/day22.clj
+++ b/src/aoc_clj/2020/day22.clj
@@ -99,11 +99,11 @@
   (let [cnt (count deck)]
     (reduce + (map * deck (range cnt 0 -1)))))
 
-(defn day22-part1-soln
+(defn part1
   [input]
   (score (combat input)))
 
-(defn day22-part2-soln
+(defn part2
   [input]
   (score (recursive-combat input)))
 

--- a/src/aoc_clj/2020/day23.clj
+++ b/src/aoc_clj/2020/day23.clj
@@ -62,10 +62,10 @@
   (let [lotsa-cups (augment-cups input)]
     (take 10 (order-after-moves lotsa-cups moves))))
 
-(defn day23-part1-soln
+(defn part1
   [input]
   (str/join (drop 1 (order-after-moves input 100))))
 
-(defn day23-part2-soln
+(defn part2
   [input]
   (reduce * (take 2 (drop 1 (star-cups input 10000000)))))

--- a/src/aoc_clj/2020/day24.clj
+++ b/src/aoc_clj/2020/day24.clj
@@ -74,10 +74,10 @@
   (let [start (black-tiles input)]
     (nth (iterate evolve-tiles start) day)))
 
-(defn day24-part1-soln
+(defn part1
   [input]
   (count (black-tiles input)))
 
-(defn day24-part2-soln
+(defn part2
   [input]
   (count (black-tiles-on-day input 100)))

--- a/src/aoc_clj/2020/day25.clj
+++ b/src/aoc_clj/2020/day25.clj
@@ -19,6 +19,6 @@
   (let [door-loop-size (loop-size door-public-key)]
     (transform door-loop-size card-public-key)))
 
-(defn day25-part1-soln
+(defn part1
   [input]
   (encryption-key input))

--- a/src/aoc_clj/2021/day01.clj
+++ b/src/aoc_clj/2021/day01.clj
@@ -19,10 +19,10 @@
        (partition 3 1)
        (map #(reduce + %))))
 
-(defn day01-part1-soln
+(defn part1
   [input]
   (increases input))
 
-(defn day01-part2-soln
+(defn part2
   [input]
   (increases (sliding-window-sum input)))

--- a/src/aoc_clj/2021/day02.clj
+++ b/src/aoc_clj/2021/day02.clj
@@ -29,10 +29,10 @@
   [cmds rules]
   (reduce rules [0 0 0] cmds))
 
-(defn day02-part1-soln
+(defn part1
   [input]
   (reduce * (sub-end-state input part1-rules)))
 
-(defn day02-part2-soln
+(defn part2
   [input]
   (reduce * (drop-last (sub-end-state input part2-rules))))

--- a/src/aoc_clj/2021/day03.clj
+++ b/src/aoc_clj/2021/day03.clj
@@ -55,10 +55,10 @@
   [(Integer/parseInt (oxygen-generator signals) 2)
    (Integer/parseInt (co2-scrubber signals) 2)])
 
-(defn day03-part1-soln
+(defn part1
   [input]
   (reduce * (power-consumption input)))
 
-(defn day03-part2-soln
+(defn part2
   [input]
   (reduce * (life-support input)))

--- a/src/aoc_clj/2021/day04.clj
+++ b/src/aoc_clj/2021/day04.clj
@@ -98,10 +98,10 @@
       (let [losing-boards (filter (complement (comp winning-board? :drawn)) (:boards round))]
         (recur (next-winning-round (assoc round :boards losing-boards)))))))
 
-(defn day04-part1-soln
+(defn part1
   [input]
   (first-winning-board-score input))
 
-(defn day04-part2-soln
+(defn part2
   [input]
   (last-winning-board-score input))

--- a/src/aoc_clj/2021/day05.clj
+++ b/src/aoc_clj/2021/day05.clj
@@ -43,11 +43,11 @@
          (filter #(>= (val %) 2))
          count)))
 
-(defn day05-part1-soln
+(defn part1
   [input]
   (overlapping-points input false))
 
-(defn day05-part2-soln
+(defn part2
   [input]
   (overlapping-points input true))
 

--- a/src/aoc_clj/2021/day06.clj
+++ b/src/aoc_clj/2021/day06.clj
@@ -21,11 +21,11 @@
   (let [counts (reduce #(assoc %1 (key %2) (val %2)) zero-counts (frequencies input))]
     (reduce + (nth (iterate step counts) days))))
 
-(defn day06-part1-soln
+(defn part1
   [input]
   (fish-after-n-days input 80))
 
 
-(defn day06-part2-soln
+(defn part2
   [input]
   (fish-after-n-days input 256))

--- a/src/aoc_clj/2021/day07.clj
+++ b/src/aoc_clj/2021/day07.clj
@@ -46,10 +46,10 @@
     (min (fuel-part2 positions mn)
          (fuel-part2 positions (inc mn)))))
 
-(defn day07-part1-soln
+(defn part1
   [input]
   (min-fuel input))
 
-(defn day07-part2-soln
+(defn part2
   [input]
   (min-fuel-part2 input))

--- a/src/aoc_clj/2021/day08.clj
+++ b/src/aoc_clj/2021/day08.clj
@@ -93,11 +93,11 @@
   [input]
   (reduce + (map decode-notes input)))
 
-(defn day08-part1-soln
+(defn part1
   [input]
   (total-easy-digits-count input))
 
 
-(defn day08-part2-soln
+(defn part2
   [input]
   (sum-of-decoded-digits input))

--- a/src/aoc_clj/2021/day09.clj
+++ b/src/aoc_clj/2021/day09.clj
@@ -60,10 +60,10 @@
        (take 3)
        (reduce *)))
 
-(defn day09-part1-soln
+(defn part1
   [input]
   (risk-level-sum input))
 
-(defn day09-part2-soln
+(defn part2
   [input]
   (three-largest-basins-product input))

--- a/src/aoc_clj/2021/day10.clj
+++ b/src/aoc_clj/2021/day10.clj
@@ -79,10 +79,10 @@
         num    (count scores)]
     (nth scores (int (/ num 2)))))
 
-(defn day10-part1-soln
+(defn part1
   [input]
   (syntax-error-score input))
 
-(defn day10-part2-soln
+(defn part2
   [input]
   (middle-completion-score input))

--- a/src/aoc_clj/2021/day11.clj
+++ b/src/aoc_clj/2021/day11.clj
@@ -55,10 +55,10 @@
        (filter second)
        ffirst))
 
-(defn day11-part1-soln
+(defn part1
   [input]
   (flashes-after-100-steps input))
 
-(defn day11-part2-soln
+(defn part2
   [input]
   (steps-until-sync input))

--- a/src/aoc_clj/2021/day12.clj
+++ b/src/aoc_clj/2021/day12.clj
@@ -75,10 +75,10 @@
   ([graph rule]
    (split-by (complement #{"start"}) (map-cave-path graph ["start"] rule))))
 
-(defn day12-part1-soln
+(defn part1
   [input]
   (count (map-cave input)))
 
-(defn day12-part2-soln
+(defn part2
   [input]
   (count (map-cave input allowed-part2?)))

--- a/src/aoc_clj/2021/day13.clj
+++ b/src/aoc_clj/2021/day13.clj
@@ -56,11 +56,11 @@
               (map #(apply str %)
                    (partition (inc xmax) chars)))))
 
-(defn day13-part1-soln
+(defn part1
   [input]
   (dots-after-first-fold input))
 
-(defn day13-part2-soln
+(defn part2
   [input]
   (comment
     (->> (complete-folds input)

--- a/src/aoc_clj/2021/day14.clj
+++ b/src/aoc_clj/2021/day14.clj
@@ -79,10 +79,10 @@
         least (second (first freqs))]
     (- most least)))
 
-(defn day14-part1-soln
+(defn part1
   [input]
   (direct-most-minus-least-common-at-n input 10))
 
-(defn day14-part2-soln
+(defn part2
   [input]
   (most-minus-least-common-at-n input 40))

--- a/src/aoc_clj/2021/day15.clj
+++ b/src/aoc_clj/2021/day15.clj
@@ -47,10 +47,10 @@
      :grid
      (zipmap coords (map (partial tiled-value input) coords))}))
 
-(defn day15-part1-soln
+(defn part1
   [input]
   (path-risk input))
 
-(defn day15-part2-soln
+(defn part2
   [input]
   (path-risk (tile input 5)))

--- a/src/aoc_clj/2021/day16.clj
+++ b/src/aoc_clj/2021/day16.clj
@@ -109,10 +109,10 @@
       6 (if (< (first subvals) (second subvals)) 1 0)
       7 (if (= (first subvals) (second subvals)) 1 0))))
 
-(defn day16-part1-soln
+(defn part1
   [input]
   (version-sum 0 (decode input)))
 
-(defn day16-part2-soln
+(defn part2
   [input]
   (apply-operator (decode input)))

--- a/src/aoc_clj/2021/day17.clj
+++ b/src/aoc_clj/2021/day17.clj
@@ -70,10 +70,10 @@
         candidates (filter (partial hits-target? target) trajectories)]
     (count candidates)))
 
-(defn day17-part1-soln
+(defn part1
   [input]
   (highest-point input))
 
-(defn day17-part2-soln
+(defn part2
   [input]
   (viable-init-vels input 100))

--- a/src/aoc_clj/2021/day18.clj
+++ b/src/aoc_clj/2021/day18.clj
@@ -132,10 +132,10 @@
          flatten
          (apply max))))
 
-(defn day18-part1-soln
+(defn part1
   [input]
   (magnitude (reduce snailfish-add input)))
 
-(defn day18-part2-soln
+(defn part2
   [input]
   (largest-magnitude-sum input))

--- a/src/aoc_clj/2021/day19.clj
+++ b/src/aoc_clj/2021/day19.clj
@@ -200,10 +200,10 @@
          flatten
          (apply max))))
 
-(defn day19-part1-soln
+(defn part1
   [input]
   (count (all-beacons input)))
 
-(defn day19-part2-soln
+(defn part2
   [input]
   (max-sensor-distance input))

--- a/src/aoc_clj/2021/day20.clj
+++ b/src/aoc_clj/2021/day20.clj
@@ -58,10 +58,10 @@
        (filter pos?)
        count))
 
-(defn day20-part1-soln
+(defn part1
   [input]
   (illuminated (enhance-n-times input 2)))
 
-(defn day20-part2-soln
+(defn part2
   [input]
   (illuminated (enhance-n-times input 50)))

--- a/src/aoc_clj/2021/day21.clj
+++ b/src/aoc_clj/2021/day21.clj
@@ -90,10 +90,10 @@
       win-tally
       (mapv + win-tally (win-counts remaining (mod (inc player) 2))))))
 
-(defn day21-part1-soln
+(defn part1
   [input]
   (loser-score-times-die-rolls (play-until-win input)))
 
-(defn day21-part2-soln
+(defn part2
   [input]
   (apply max (win-counts {[[0 0] input] 1} 0)))

--- a/src/aoc_clj/2021/day22.clj
+++ b/src/aoc_clj/2021/day22.clj
@@ -68,10 +68,10 @@
   (->> (filter init-area? cuboids)
        on-cubes))
 
-(defn day22-part1-soln
+(defn part1
   [input]
   (on-cubes-in-init-area input))
 
-(defn day22-part2-soln
+(defn part2
   [input]
   (on-cubes input))

--- a/src/aoc_clj/2021/day23.clj
+++ b/src/aoc_clj/2021/day23.clj
@@ -180,10 +180,10 @@
    [:h5 :b0]
    [:h6 :c0]])
 
-(defn day23-part1-soln
+(defn part1
   [input]
   (cost-of-moves input day23-input-soln))
 
-(defn day23-part2-soln
+(defn part2
   [input]
   (cost-of-moves (unfold-input input) day23-input-soln-part2))

--- a/src/aoc_clj/2021/day24.clj
+++ b/src/aoc_clj/2021/day24.clj
@@ -168,10 +168,10 @@
 
 ;; worked this out by hand while iterating through the character logic
 (def largest-input [9 8 9 9 8 5 1 9 5 9 6 9 9 7])
-(defn day24-part1-soln
+(defn part1
   [_]
   (Long/parseLong (apply str largest-input)))
 
-(defn day24-part2-soln
+(defn part2
   [_]
   (Long/parseLong (apply str (first (smallest-model-number)))))

--- a/src/aoc_clj/2021/day25.clj
+++ b/src/aoc_clj/2021/day25.clj
@@ -48,6 +48,6 @@
       [steps curr-state]
       (recur curr-state (step curr-state) (inc steps)))))
 
-(defn day25-part1-soln
+(defn part1
   [input]
   (first (evolve-until-stop input)))

--- a/src/aoc_clj/2022/day01.clj
+++ b/src/aoc_clj/2022/day01.clj
@@ -28,13 +28,13 @@
 
 ;;;; Puzzle solutions
 
-(defn day01-part1-soln
+(defn part1
   "Find the Elf carrying the most Calories. 
    How many total Calories is that Elf carrying?"
   [input]
   (top-n-capacity-sum 1 input))
 
-(defn day01-part2-soln
+(defn part2
   "Find the top three Elves carrying the most Calories. 
    How many Calories are those Elves carrying in total?"
   [input]

--- a/src/aoc_clj/2022/day02.clj
+++ b/src/aoc_clj/2022/day02.clj
@@ -92,13 +92,13 @@
 
 ;;;; Puzzle solutions
 
-(defn day02-part1-soln
+(defn part1
   "What would your total score be if everything goes exactly according to 
    your strategy guide?"
   [input]
   (reduce + (map score-part1 (interpret-part1 input))))
 
-(defn day02-part2-soln
+(defn part2
   "Following the Elf's instructions for the second column, what would your 
    total score be if everything goes exactly according to your strategy guide?"
   [input]

--- a/src/aoc_clj/2022/day03.clj
+++ b/src/aoc_clj/2022/day03.clj
@@ -52,13 +52,13 @@
 
 ;;;; Puzzle solutions
 
-(defn day03-part1-soln
+(defn part1
   "Find the item type that appears in both compartments of each rucksack. 
    What is the sum of the priorities of those item types?"
   [input]
   (overlap-priority-sum ::halfway input))
 
-(defn day03-part2-soln
+(defn part2
   "Find the item type that corresponds to the badges of each three-Elf group. 
    What is the sum of the priorities of those item types?"
   [input]

--- a/src/aoc_clj/2022/day04.clj
+++ b/src/aoc_clj/2022/day04.clj
@@ -22,12 +22,12 @@
 
 ;;;; Puzzle solutions
 
-(defn day04-part1-soln
+(defn part1
   "In how many assignment pairs does one range fully contain the other?"
   [input]
   (count (filter #(apply ivs/fully-contained? %) input)))
 
-(defn day04-part2-soln
+(defn part2
   "In how many assignment pairs do the ranges overlap?"
   [input]
   (count (filter #(apply ivs/overlap? %) input)))

--- a/src/aoc_clj/2022/day05.clj
+++ b/src/aoc_clj/2022/day05.clj
@@ -101,13 +101,13 @@
 
 ;;;; Puzzle solutions
 
-(defn day05-part1-soln
+(defn part1
   "After the rearrangement procedure completes, 
    what crate ends up on top of each stack?"
   [input]
   (-> input final-arrangement-1 stack-tops))
 
-(defn day05-part2-soln
+(defn part2
   "The CrateMover 9001 is notable for many new and exciting features: 
    air conditioning, leather seats, an extra cup holder, and 
    the ability to pick up and move multiple crates at once.

--- a/src/aoc_clj/2022/day06.clj
+++ b/src/aoc_clj/2022/day06.clj
@@ -19,13 +19,13 @@
 
 ;;;; Puzzle solutions
 
-(defn day06-part1-soln
+(defn part1
   "How many characters need to be processed before the 
    first start-of-packet marker is detected?"
   [input]
   (chars-to-distinct-run 4 input))
 
-(defn day06-part2-soln
+(defn part2
   "How many characters need to be processed before the 
    first start-of-message marker is detected?"
   [input]

--- a/src/aoc_clj/2022/day07.clj
+++ b/src/aoc_clj/2022/day07.clj
@@ -129,13 +129,13 @@
 
 ;;;; Puzzle solutions
 
-(defn day07-part1-soln
+(defn part1
   "Find all of the directories with a total size of at most 100000. 
    What is the sum of the total sizes of those directories?"
   [input]
   (dir-total-below-100k input))
 
-(defn day07-part2-soln
+(defn part2
   "Find the smallest directory that, if deleted, would free up enough space 
    on the filesystem to run the update. What is the total size of that 
    directory?"

--- a/src/aoc_clj/2022/day08.clj
+++ b/src/aoc_clj/2022/day08.clj
@@ -104,12 +104,12 @@
 
 ;;;; Puzzle solutions
 
-(defn day08-part1-soln
+(defn part1
   "Consider your map; how many trees are visible from outside the grid?"
   [input]
   (visible-trees input))
 
-(defn day08-part2-soln
+(defn part2
   "Consider each tree on your map. What is the highest scenic score 
    possible for any tree?"
   [input]

--- a/src/aoc_clj/2022/day09.clj
+++ b/src/aoc_clj/2022/day09.clj
@@ -75,13 +75,13 @@
 
 ;;;; Puzzle solutions
 
-(defn day09-part1-soln
+(defn part1
   "Simulate your complete hypothetical series of motions. How many positions 
    does the tail of the rope visit at least once?"
   [input]
   (distinct-tail-positions 2 input))
 
-(defn day09-part2-soln
+(defn part2
   "Simulate your complete series of motions on a larger rope with ten knots. 
    How many positions does the tail of the rope visit at least once?"
   [input]

--- a/src/aoc_clj/2022/day10.clj
+++ b/src/aoc_clj/2022/day10.clj
@@ -70,13 +70,13 @@
 
 ;;;; Puzzle solutions
 
-(defn day10-part1-soln
+(defn part1
   "Find the signal strength during the 20th, 60th, 100th, 140th, 180th, 
    and 220th cycles. What is the sum of these six signal strengths?"
   [input]
   (sampled-signal-strength-sums input))
 
-(defn day10-part2-soln
+(defn part2
   "Render the image given by your program. 
    What eight capital letters appear on your CRT?"
   [input]

--- a/src/aoc_clj/2022/day11.clj
+++ b/src/aoc_clj/2022/day11.clj
@@ -156,13 +156,13 @@
 
 ;;;; Puzzle solutions
 
-(defn day11-part1-soln
+(defn part1
   "What is the level of monkey business after 20 rounds of stuff-slinging 
    simian shenanigans?"
   [input]
   (monkey-business-1 input 20))
 
-(defn day11-part2-soln
+(defn part2
   "Worry levels are no longer divided by three after each item is inspected; 
    you'll need to find another way to keep your worry levels manageable. 
    Starting again from the initial state in your puzzle input, what is the 

--- a/src/aoc_clj/2022/day12.clj
+++ b/src/aoc_clj/2022/day12.clj
@@ -66,13 +66,13 @@
 
 ;;;; Puzzle solutions
 
-(defn day12-part1-soln
+(defn part1
   "What is the fewest steps required to move from your current position to the 
    location that should get the best signal?"
   [input]
   (shortest-path-from-start input))
 
-(defn day12-part2-soln
+(defn part2
   "What is the fewest steps required to move starting from any square with 
    elevation `a` to the location that should get the best signal?"
   [input]

--- a/src/aoc_clj/2022/day13.clj
+++ b/src/aoc_clj/2022/day13.clj
@@ -83,13 +83,13 @@
 
 ;;;; Puzzle solutions
 
-(defn day13-part1-soln
+(defn part1
   "Determine which pairs of packets are already in the right order. 
    What is the sum of the indices of those pairs?"
   [input]
   (right-order-packet-id-sum input))
 
-(defn day13-part2-soln
+(defn part2
   "Organize all of the packets into the correct order. 
    What is the decoder key for the distress signal?"
   [input]

--- a/src/aoc_clj/2022/day14.clj
+++ b/src/aoc_clj/2022/day14.clj
@@ -118,13 +118,13 @@
 
 ;;;; Puzzle solutions
 
-(defn day14-part1-soln
+(defn part1
   "Using your scan, simulate the falling sand. How many units of sand come 
    to rest before sand starts flowing into the abyss below?"
   [input]
   (sand-until-continuous-flow input))
 
-(defn day14-part2-soln
+(defn part2
   "Using your scan, simulate the falling sand until the source of the sand 
    becomes blocked. How many units of sand come to rest?"
   [input]

--- a/src/aoc_clj/2022/day15.clj
+++ b/src/aoc_clj/2022/day15.clj
@@ -113,13 +113,13 @@
 
 ;;;; Puzzle solutions
 
-(defn day15-part1-soln
+(defn part1
   "Consult the report from the sensors you just deployed. In the row where 
    y=2000000, how many positions cannot contain a beacon?"
   [input]
   (no-beacon-points-in-line input 2000000))
 
-(defn day15-part2-soln
+(defn part2
   "Find the only possible position for the distress beacon. 
    What is its tuning frequency?"
   [input]

--- a/src/aoc_clj/2022/day16.clj
+++ b/src/aoc_clj/2022/day16.clj
@@ -151,13 +151,13 @@
 
 ;;;; Puzzle solutions
 
-(defn day16-part1-soln
+(defn part1
   "Work out the steps to release the most pressure in 30 minutes. 
    What is the most pressure you can release?"
   [input]
   (best-pressure input))
 
-(defn day16-part2-soln
+(defn part2
   "With you and an elephant working together for 26 minutes, what is the 
    most pressure you could release?"
   [input]

--- a/src/aoc_clj/2022/day17.clj
+++ b/src/aoc_clj/2022/day17.clj
@@ -203,13 +203,13 @@
 
 ;;;; Puzzle solutions
 
-(defn day17-part1-soln
+(defn part1
   "How many units tall will the tower of rocks be after 2022 rocks have 
    stopped falling?"
   [input]
   (tower-height-after-n input 2022))
 
-(defn day17-part2-soln
+(defn part2
   "How tall will the tower be after 1000000000000 rocks have stopped?"
   [input]
   (tower-height-after-n input 1000000000000))

--- a/src/aoc_clj/2022/day18.clj
+++ b/src/aoc_clj/2022/day18.clj
@@ -79,12 +79,12 @@
 
 ;;;; Puzzle solutions
 
-(defn day18-part1-soln
+(defn part1
   "What is the surface area of your scanned lava droplet?"
   [input]
   (surface-area input))
 
-(defn day18-part2-soln
+(defn part2
   "What is the exterior surface area of your scanned lava droplet?"
   [input]
   (outer-surface-area input))

--- a/src/aoc_clj/2022/day19.clj
+++ b/src/aoc_clj/2022/day19.clj
@@ -163,14 +163,14 @@
 
 ;;;; Puzzle solutions
 
-(defn day19-part1-soln
+(defn part1
   "Determine the quality level of each blueprint using the largest number of 
    geodes it could produce in 24 minutes. What do you get if you add up 
    the quality level of all of the blueprints in your list?"
   [input]
   (quality-level-sum input))
 
-(defn day19-part2-soln
+(defn part2
   "You no longer have enough blueprints to worry about quality levels. 
    Instead, for each of the first three blueprints, determine the largest 
    number of geodes you could open; then, multiply these three values together.

--- a/src/aoc_clj/2022/day20.clj
+++ b/src/aoc_clj/2022/day20.clj
@@ -88,13 +88,13 @@
 
 ;;;; Puzzle solutions
 
-(defn day20-part1-soln
+(defn part1
   "Mix your encrypted file exactly once. 
    What is the sum of the three numbers that form the grove coordinates?"
   [input]
   (grove-coordinates (mixed input)))
 
-(defn day20-part2-soln
+(defn part2
   "Apply the decryption key and mix your encrypted file ten times. 
    What is the sum of the three numbers that form the grove coordinates?"
   [input]

--- a/src/aoc_clj/2022/day21.clj
+++ b/src/aoc_clj/2022/day21.clj
@@ -113,12 +113,12 @@
 
 ;;;; Puzzle solutions
 
-(defn day21-part1-soln
+(defn part1
   "What number will the monkey named root yell?"
   [input]
   (root-yell input))
 
-(defn day21-part2-soln
+(defn part2
   "What number do you yell to pass root's equality test?"
   [input]
   (humn-value input))

--- a/src/aoc_clj/2022/day22.clj
+++ b/src/aoc_clj/2022/day22.clj
@@ -186,12 +186,12 @@
          (<= 101 y 150) {:pos [150 (+ 1 (- 150 y))]  :facing :L}
          (<= 151 y 200) {:pos [(+ 51 (- y 151)) 150] :facing :U})))
 
-(defn day22-part1-soln
+(defn part1
   "Follow the path given in the monkeys' notes. What is the final password?"
   [input]
   (final-password (follow-path (assoc input :wrap-fn wrap-around))))
 
-(defn day22-part2-soln
+(defn part2
   "Fold the map into a cube, then follow the path given in the monkeys' notes. 
    What is the final password?"
   [input]

--- a/src/aoc_clj/2022/day23.clj
+++ b/src/aoc_clj/2022/day23.clj
@@ -132,14 +132,14 @@
 
 ;;;; Puzzle solutions
 
-(defn day23-part1-soln
+(defn part1
   "Simulate the Elves' process and find the smallest rectangle that contains 
    the Elves after 10 rounds. How many empty ground tiles does that 
    rectangle contain?"
   [input]
   (empty-tiles-after-ten-rounds input))
 
-(defn day23-part2-soln
+(defn part2
   "Figure out where the Elves need to go. What is the number of the first 
    round where no Elf moves?"
   [input]

--- a/src/aoc_clj/2022/day24.clj
+++ b/src/aoc_clj/2022/day24.clj
@@ -147,13 +147,13 @@
 
 ;;;; Puzzle solutions
 
-(defn day24-part1-soln
+(defn part1
   "What is the fewest number of minutes required to avoid the blizzards and
    reach the goal?"
   [input]
   (shortest-time-to-exit input))
 
-(defn day24-part2-soln
+(defn part2
   "What is the fewest number of minutes required to reach the goal, 
    go back to the start, then reach the goal again?"
   [input]

--- a/src/aoc_clj/2022/day25.clj
+++ b/src/aoc_clj/2022/day25.clj
@@ -92,7 +92,7 @@
 
 ;;;; Puzzle solutions
 
-(defn day25-part1-soln
+(defn part1
   "What SNAFU number do you supply to Bob's console?"
   [input]
   (requirements-sum input))

--- a/src/aoc_clj/2023/day01.clj
+++ b/src/aoc_clj/2023/day01.clj
@@ -63,13 +63,13 @@
   ([input spelled]
    (reduce + (map #(calibration-value % spelled) input))))
 
-(defn day01-part1-soln
+(defn part1
   "Consider your entire calibration document. 
    What is the sum of all of the calibration values?"
   [input]
   (calibration-value-sum input))
 
-(defn day01-part2-soln
+(defn part2
   "It looks like some of the digits are actually spelled out with letters: 
    one, two, three, four, five, six, seven, eight, and nine also count 
    as valid 'digits'.

--- a/src/aoc_clj/2023/day02.clj
+++ b/src/aoc_clj/2023/day02.clj
@@ -93,14 +93,14 @@
   [games]
   (reduce + (map power-fewest-cubes games)))
 
-(defn day02-part1-soln
+(defn part1
   "Determine which games would have been possible if the bag had been loaded 
    with only 12 red cubes, 13 green cubes, and 14 blue cubes. 
    What is the sum of the IDs of those games?"
   [input]
   (possible-game-id-sum input))
 
-(defn day02-part2-soln
+(defn part2
   "For each game, find the minimum set of cubes that must have been present. 
    What is the sum of the power of these sets?"
   [input]

--- a/src/aoc_clj/2023/day03.clj
+++ b/src/aoc_clj/2023/day03.clj
@@ -91,12 +91,12 @@
        (map #(reduce * %))
        (reduce +)))
 
-(defn day03-part1-soln
+(defn part1
   "What is the sum of all of the part numbers in the engine schematic?"
   [input]
   (part-numbers-sum input))
 
-(defn day03-part2-soln
+(defn part2
   "What is the sum of all of the gear ratios in your engine schematic?"
   [input]
   (gear-ratio-sum input))

--- a/src/aoc_clj/2023/day04.clj
+++ b/src/aoc_clj/2023/day04.clj
@@ -55,13 +55,13 @@
         init     {:card-cnt card-cnt :total 0}]
     (:total (reduce update-card-count init scores))))
 
-(defn day04-part1-soln
+(defn part1
   "Take a seat in the large pile of colorful cards.
    How many points are they worth in total?"
   [input]
   (points-sum input))
 
-(defn day04-part2-soln
+(defn part2
   "Process all of the original and copied scratchcards until no more 
    scratchcards are won. Including the original set of scratchcards, 
    how many total scratchcards do you end up with?"

--- a/src/aoc_clj/2023/day06.clj
+++ b/src/aoc_clj/2023/day06.clj
@@ -43,13 +43,13 @@
     {:time (read-string (apply str times))
      :dist (read-string (apply str dists))}))
 
-(defn day06-part1-soln
+(defn part1
   "Determine the number of ways you could beat the record in each race. 
    What do you get if you multiply these numbers together?"
   [input]
   (win-count-multiplied input))
 
-(defn day06-part2-soln
+(defn part2
   "How many ways can you beat the record in this one much longer race?"
   [input]
   (winning-options-count (long-race input)))

--- a/src/aoc_clj/2023/day07.clj
+++ b/src/aoc_clj/2023/day07.clj
@@ -116,12 +116,12 @@
   [hands]
   (winnings (map jokerize-hand hands) true))
 
-(defn day07-part1-soln
+(defn part1
   "Find the rank of every hand in your set. What are the total winnings?"
   [input]
   (winnings input))
 
-(defn day07-part2-soln
+(defn part2
   "Using the new joker rule, find the rank of every hand in your set. 
    What are the new total winnings?"
   [input]

--- a/src/aoc_clj/2023/day08.clj
+++ b/src/aoc_clj/2023/day08.clj
@@ -47,13 +47,13 @@
   (->> (map #(steps-to-zzz input %) (start-nodes nodes))
        (apply math/lcm)))
 
-(defn day08-part1-soln
+(defn part1
   "Starting at AAA, follow the left/right instructions.
    How many steps are required to reach ZZZ?"
   [input]
   (steps-to-zzz input "AAA"))
 
-(defn day08-part2-soln
+(defn part2
   "Simultaneously start on every node that ends with A.
    How many steps does it take before you're only on nodes that end with Z?"
   [input]

--- a/src/aoc_clj/2023/day09.clj
+++ b/src/aoc_clj/2023/day09.clj
@@ -40,13 +40,13 @@
                  (map (comp last right-extrapolate) input))]
      (reduce + added))))
 
-(defn day09-part1-soln
+(defn part1
   "Analyze your OASIS report and extrapolate the next value for each history.
    What is the sum of these extrapolated values?"
   [input]
   (extrapolation-sum input))
 
-(defn day09-part2-soln
+(defn part2
   "Analyze your OASIS report again, this time extrapolating the previous value
    for each history. What is the sum of these extrapolated values?"
   [input]

--- a/src/aoc_clj/2023/day10.clj
+++ b/src/aoc_clj/2023/day10.clj
@@ -106,14 +106,14 @@
       geo/interior-count
       int))
 
-(defn day10-part1-soln
+(defn part1
   "Find the single giant loop starting at S. How many steps along the loop does
    it take to get from the starting position to the point farthest from the 
    starting position?"
   [input]
   (farthest-steps-from-start input))
 
-(defn day10-part2-soln
+(defn part2
   "Figure out whether you have time to search for the nest by calculating the 
    area within the loop. How many tiles are enclosed by the loop?"
   [input]

--- a/src/aoc_clj/2023/day11.clj
+++ b/src/aoc_clj/2023/day11.clj
@@ -56,13 +56,13 @@
        (map #(apply math/manhattan %))
        (reduce +)))
 
-(defn day11-part1-soln
+(defn part1
   "Expand the universe, then find the length of the shortest path between every
    pair of galaxies. What is the sum of these lengths?"
   [input]
   (pairwise-distance-sum (expanded-coords input 2)))
 
-(defn day11-part2-soln
+(defn part2
   "Starting with the same initial image, expand the universe according to these
    new rules, then find the length of the shortest path between every pair of
    galaxies. What is the sum of these lengths?"

--- a/src/aoc_clj/2023/day12.clj
+++ b/src/aoc_clj/2023/day12.clj
@@ -60,14 +60,14 @@
   [input]
   (num-arrangements-sum (map unfold input)))
 
-(defn day12-part1-soln
+(defn part1
   "For each row, count all of the different arrangements of operational and 
    broken springs that meet the given criteria. 
    What is the sum of those counts?"
   [input]
   (num-arrangements-sum input))
 
-(defn day12-part2-soln
+(defn part2
   "Unfold your condition records; what is the new sum of 
    possible arrangement counts?"
   [input]

--- a/src/aoc_clj/2023/day13.clj
+++ b/src/aoc_clj/2023/day13.clj
@@ -77,13 +77,13 @@
        (map summarize-math)
        (reduce +)))
 
-(defn day13-part1-soln
+(defn part1
   "Find the line of reflection in each of the patterns in your notes. 
    What number do you get after summarizing all of your notes?"
   [input]
   (summarize 0 input))
 
-(defn day13-part2-soln
+(defn part2
   "In each pattern, fix the smudge and find the different line of reflection. 
    What number do you get after summarizing the new reflection line in each 
    pattern in your notes?"

--- a/src/aoc_clj/2023/day15.clj
+++ b/src/aoc_clj/2023/day15.clj
@@ -108,13 +108,13 @@
        (map box-focusing-power)
        (reduce +)))
 
-(defn day15-part1-soln
+(defn part1
   "Run the HASH algorithm on each step in the initialization sequence. 
    What is the sum of the results?"
   [input]
   (hash-sum input))
 
-(defn day15-part2-soln
+(defn part2
   "With the help of an over-enthusiastic reindeer in a hard hat, follow the 
    initialization sequence. What is the focusing power of the resulting lens 
    configuration?"

--- a/src/aoc_clj/2023/day16.clj
+++ b/src/aoc_clj/2023/day16.clj
@@ -105,13 +105,13 @@
   [grid]
   (apply max (map #(energized-count grid %) (start-points grid))))
 
-(defn day16-part1-soln
+(defn part1
   "With the beam starting in the top-left heading right, 
    how many tiles end up being energized?"
   [input]
   (energized-count input part1-start))
 
-(defn day16-part2-soln
+(defn part2
   "Find the initial beam configuration that energizes the largest number of 
    tiles; how many tiles are energized in that configuration?"
   [input]

--- a/src/aoc_clj/2023/day18.clj
+++ b/src/aoc_clj/2023/day18.clj
@@ -58,13 +58,13 @@
   [steps]
   (dig-area (map interpret-hex steps)))
 
-(defn day18-part1-soln
+(defn part1
   "The Elves are concerned the lagoon won't be large enough; 
    if they follow their dig plan, how many cubic meters of lava could it hold?"
   [input]
   (dig-area input))
 
-(defn day18-part2-soln
+(defn part2
   "Convert the hexadecimal color codes into the correct instructions; 
    if the Elves follow this new dig plan, how many cubic meters of lava 
    could the lagoon hold?"

--- a/src/aoc_clj/2023/day19.clj
+++ b/src/aoc_clj/2023/day19.clj
@@ -157,14 +157,14 @@
        (map path-option-count)
        (reduce +)))
 
-(defn day19-part1-soln
+(defn part1
   "Sort through all of the parts you've been given; what do you get if you 
    add together all of the rating numbers for all of the parts that 
    ultimately get accepted?"
   [input]
   (accepted-parts-sum input))
 
-(defn day19-part2-soln
+(defn part2
   "Consider only your list of workflows; the list of part ratings that the 
    Elves wanted you to sort is no longer relevant. How many distinct 
    combinations of ratings will be accepted by the Elves' workflows?"

--- a/src/aoc_clj/2023/day20.clj
+++ b/src/aoc_clj/2023/day20.clj
@@ -220,11 +220,11 @@
        (map presses-until-single-rx-low-pulse)
        (apply math/lcm)))
 
-(defn day20-part1-soln
+(defn part1
   [input]
   (pulses-after-1000-brute-force input))
 
-(defn day20-part2-soln
+(defn part2
   [input]
   (buttons-till-rx input))
 

--- a/src/aoc_clj/2023/day21.clj
+++ b/src/aoc_clj/2023/day21.clj
@@ -38,7 +38,7 @@
       (nth n)
       count))
 
-(defn day21-part1-soln
+(defn part1
   "Starting from the garden plot marked S on your map, how many garden plots 
    could the Elf reach in exactly 64 steps?"
   [input]

--- a/src/aoc_clj/2023/day22.clj
+++ b/src/aoc_clj/2023/day22.clj
@@ -156,14 +156,14 @@
     (->> (map #(fall-number supports supported-by %) brick-ids)
          (reduce +))))
 
-(defn day22-part1-soln
+(defn part1
   "Figure how the blocks will settle based on the snapshot. 
    Once they've settled, consider disintegrating a single brick; 
    how many bricks could be safely chosen as the one to get disintegrated?"
   [input]
   (disintegratable-count input))
 
-(defn day22-part2-soln
+(defn part2
   "For each brick, determine how many other bricks would fall if that brick 
    were disintegrated. 
    What is the sum of the number of other bricks that would fall?"

--- a/src/aoc_clj/2023/day23.clj
+++ b/src/aoc_clj/2023/day23.clj
@@ -99,13 +99,13 @@
   [grid]
   (longest-path (full-graph (grid->graph grid)) [1 0] (finish grid)))
 
-(defn day23-part1-soln
+(defn part1
   "Find the longest hike you can take through the hiking trails listed on 
    our map. How many steps long is the longest hike?"
   [input]
   (longest-downslope-path input))
 
-(defn day23-part2-soln
+(defn part2
   "Find the longest hike you can take through the surprisingly dry hiking 
    trails listed on your map. How many steps long is the longest hike?"
   [input]

--- a/src/aoc_clj/2023/day24.clj
+++ b/src/aoc_clj/2023/day24.clj
@@ -137,14 +137,14 @@
 
 (def part1-limits [200000000000000 400000000000000])
 
-(defn day24-part1-soln
+(defn part1
   "Considering only the X and Y axes, check all pairs of hailstones' 
    future paths for intersections. How many of these intersections occur 
    within the test area?"
   [input]
   (intersections-within-area part1-limits input))
 
-(defn day24-part2-soln
+(defn part2
   "Determine the exact position and velocity the rock needs to have at 
    time 0 so that it perfectly collides with every hailstone. 
    What do you get if you add up the X, Y, and Z coordinates of that 

--- a/src/aoc_clj/2023/day25.clj
+++ b/src/aoc_clj/2023/day25.clj
@@ -60,7 +60,7 @@
    #{"sjr" "jlt"}
    #{"fjn" "mzb"}])
 
-(defn day25-part1-soln
+(defn part1
   "Find the three wires you need to disconnect in order to divide the 
    components into two separate groups. What do you get if you multiply the 
    sizes of these two groups together?"

--- a/src/aoc_clj/core.clj
+++ b/src/aoc_clj/core.clj
@@ -1,4 +1,5 @@
 (ns aoc-clj.core
+  "Core command-line interface to AoC solutions"
   (:require [clojure.string :as str]
             [clojure.tools.cli :refer [parse-opts]]
             [aoc-clj.utils.core :as u])
@@ -31,8 +32,8 @@
   (let [day-str (str "day"  (format "%02d" day))
         ns  (str "aoc-clj." year "." day-str)]
     {:parse (resolve-fn ns "parse")
-     :part1 (resolve-fn ns (str day-str "-part1-soln"))
-     :part2 (resolve-fn ns (str day-str "-part2-soln"))}))
+     :part1 (resolve-fn ns "part1")
+     :part2 (resolve-fn ns "part2")}))
 
 (defn -main [& args]
   (let [{:keys [options arguments summary]} (parse-opts args cli-options)]

--- a/test/aoc_clj/2015/day01_test.clj
+++ b/test/aoc_clj/2015/day01_test.clj
@@ -5,27 +5,27 @@
 
 (deftest final-floor
   (testing "Correctly determines the final floor"
-    (is (= 0  (d01/final-floor "(())")))
-    (is (= 0  (d01/final-floor "()()")))
-    (is (= 3  (d01/final-floor "(((")))
-    (is (= 3  (d01/final-floor "(()(()(")))
-    (is (= 3  (d01/final-floor "))(((((")))
-    (is (= -1 (d01/final-floor "())")))
-    (is (= -1 (d01/final-floor "))(")))
-    (is (= -3 (d01/final-floor ")))")))
-    (is (= -3 (d01/final-floor ")())())")))))
+    (is (= 0  (d01/final-floor (d01/parse ["(())"]))))
+    (is (= 0  (d01/final-floor (d01/parse ["()()"]))))
+    (is (= 3  (d01/final-floor (d01/parse ["((("]))))
+    (is (= 3  (d01/final-floor (d01/parse ["(()(()("]))))
+    (is (= 3  (d01/final-floor (d01/parse ["))((((("]))))
+    (is (= -1 (d01/final-floor (d01/parse ["())"]))))
+    (is (= -1 (d01/final-floor (d01/parse ["))("]))))
+    (is (= -3 (d01/final-floor (d01/parse [")))"]))))
+    (is (= -3 (d01/final-floor (d01/parse [")())())"]))))))
 
 (deftest first-pos-in-basement
   (testing "Finds the first position where the sum equals -1"
-    (is (= 1 (d01/first-pos-in-basement ")")))
-    (is (= 5 (d01/first-pos-in-basement "()())")))))
+    (is (= 1 (d01/first-pos-in-basement (d01/parse [")"]))))
+    (is (= 5 (d01/first-pos-in-basement (d01/parse ["()())"]))))))
 
 (def day01-input (u/parse-puzzle-input d01/parse 2015 1))
 
-(deftest day01-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day01, part1"
-    (is (= 138 (d01/day01-part1-soln day01-input)))))
+    (is (= 138 (d01/part1 day01-input)))))
 
-(deftest day01-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day01, part2"
-    (is (= 1771 (d01/day01-part2-soln day01-input)))))
+    (is (= 1771 (d01/part2 day01-input)))))

--- a/test/aoc_clj/2015/day02_test.clj
+++ b/test/aoc_clj/2015/day02_test.clj
@@ -15,10 +15,10 @@
 
 (def day02-input (u/parse-puzzle-input t/parse 2015 2))
 
-(deftest day02-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day02, part1"
-    (is (= 1598415 (t/day02-part1-soln day02-input)))))
+    (is (= 1598415 (t/part1 day02-input)))))
 
-(deftest day02-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day02, part2"
-    (is (= 3812909 (t/day02-part2-soln day02-input)))))
+    (is (= 3812909 (t/part2 day02-input)))))

--- a/test/aoc_clj/2015/day03_test.clj
+++ b/test/aoc_clj/2015/day03_test.clj
@@ -22,10 +22,10 @@
 
 (def day03-input (u/parse-puzzle-input t/parse 2015 3))
 
-(deftest day03-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day03, part1"
-    (is (= 2081 (t/day03-part1-soln day03-input)))))
+    (is (= 2081 (t/part1 day03-input)))))
 
-(deftest day03-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day03, part2"
-    (is (= 2341 (t/day03-part2-soln day03-input)))))
+    (is (= 2341 (t/part2 day03-input)))))

--- a/test/aoc_clj/2015/day04_test.clj
+++ b/test/aoc_clj/2015/day04_test.clj
@@ -13,11 +13,11 @@
 
 (def day04-input (u/parse-puzzle-input t/parse 2015 4))
 
-(deftest ^:slow day04-part1-soln
+(deftest ^:slow part1
   (testing "Reproduces the answer for day04, part1"
-    (is (= 282749 (t/day04-part1-soln day04-input)))))
+    (is (= 282749 (t/part1 day04-input)))))
 
 ;; ULTRA SLOW!
-(deftest ^:slow day04-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day04, part2"
-    (is (= 9962624 (t/day04-part2-soln day04-input)))))
+    (is (= 9962624 (t/part2 day04-input)))))

--- a/test/aoc_clj/2015/day05_test.clj
+++ b/test/aoc_clj/2015/day05_test.clj
@@ -30,10 +30,10 @@
 
 (def day05-input (u/parse-puzzle-input t/parse 2015 5))
 
-(deftest day05-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day05, part1"
-    (is (= 255 (t/day05-part1-soln day05-input)))))
+    (is (= 255 (t/part1 day05-input)))))
 
-(deftest day05-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day05, part2"
-    (is (= 55 (t/day05-part2-soln day05-input)))))
+    (is (= 55 (t/part2 day05-input)))))

--- a/test/aoc_clj/2015/day06_test.clj
+++ b/test/aoc_clj/2015/day06_test.clj
@@ -7,10 +7,10 @@
 
 ;; FIXME: 2015.day06 solution is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/2
-(deftest ^:slow day06-part1-soln
+(deftest ^:slow part1
   (testing "Reproduces the answer for day06, part1"
-    (is (= 377891 (t/day06-part1-soln day06-input)))))
+    (is (= 377891 (t/part1 day06-input)))))
 
-(deftest ^:slow day06-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day06, part2"
-    (is (= 14110788 (t/day06-part2-soln day06-input)))))
+    (is (= 14110788 (t/part2 day06-input)))))

--- a/test/aoc_clj/2015/day07_test.clj
+++ b/test/aoc_clj/2015/day07_test.clj
@@ -40,10 +40,10 @@
 
 (def day07-input (u/parse-puzzle-input t/parse 2015 7))
 
-(deftest day07-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day07, part1"
-    (is (= 3176 (t/day07-part1-soln day07-input)))))
+    (is (= 3176 (t/part1 day07-input)))))
 
-(deftest day07-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day07, part2"
-    (is (= 14710 (t/day07-part2-soln day07-input)))))
+    (is (= 14710 (t/part2 day07-input)))))

--- a/test/aoc_clj/2015/day08_test.clj
+++ b/test/aoc_clj/2015/day08_test.clj
@@ -44,10 +44,10 @@
 
 (def day08-input (u/parse-puzzle-input t/parse 2015 8))
 
-(deftest day08-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day08, part1"
-    (is (= 1371 (t/day08-part1-soln day08-input)))))
+    (is (= 1371 (t/part1 day08-input)))))
 
-(deftest day08-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day08, part2"
-    (is (= 2117 (t/day08-part2-soln day08-input)))))
+    (is (= 2117 (t/part2 day08-input)))))

--- a/test/aoc_clj/2015/day09_test.clj
+++ b/test/aoc_clj/2015/day09_test.clj
@@ -27,10 +27,10 @@
 
 (def day09-input (u/parse-puzzle-input t/parse 2015 9))
 
-(deftest day09-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day09, part1"
-    (is (= 207 (t/day09-part1-soln day09-input)))))
+    (is (= 207 (t/part1 day09-input)))))
 
-(deftest day09-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day09, part2"
-    (is (= 804 (t/day09-part2-soln day09-input)))))
+    (is (= 804 (t/part2 day09-input)))))

--- a/test/aoc_clj/2015/day10_test.clj
+++ b/test/aoc_clj/2015/day10_test.clj
@@ -12,12 +12,12 @@
 
 (def day10-input (u/parse-puzzle-input t/parse 2015 10))
 
-(deftest day10-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day10, part1"
-    (is (= 252594 (t/day10-part1-soln day10-input)))))
+    (is (= 252594 (t/part1 day10-input)))))
 
 ;; FIXME: 2015.day10 solution is slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/5
-(deftest ^:slow day10-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day10, part2"
-    (is (= 3579328 (t/day10-part2-soln day10-input)))))
+    (is (= 3579328 (t/part2 day10-input)))))

--- a/test/aoc_clj/2015/day11_test.clj
+++ b/test/aoc_clj/2015/day11_test.clj
@@ -49,10 +49,10 @@
 
 (def day11-input (u/parse-puzzle-input t/parse 2015 11))
 
-(deftest ^:slow day11-part1-soln
+(deftest ^:slow part1
   (testing "Reproduces the answer for day11, part1"
-    (is (= "hxbxxyzz" (t/day11-part1-soln day11-input)))))
+    (is (= "hxbxxyzz" (t/part1 day11-input)))))
 
-(deftest ^:slow day11-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day11, part2"
-    (is (= "hxcaabcc" (t/day11-part2-soln day11-input)))))
+    (is (= "hxcaabcc" (t/part2 day11-input)))))

--- a/test/aoc_clj/2015/day12_test.clj
+++ b/test/aoc_clj/2015/day12_test.clj
@@ -12,10 +12,10 @@
 
 (def day12-input (u/parse-puzzle-input t/parse 2015 12))
 
-(deftest day12-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day12, part1"
-    (is (= 111754 (t/day12-part1-soln day12-input)))))
+    (is (= 111754 (t/part1 day12-input)))))
 
-(deftest day12-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day12, part2"
-    (is (= 65402 (t/day12-part2-soln day12-input)))))
+    (is (= 65402 (t/part2 day12-input)))))

--- a/test/aoc_clj/2015/day13_test.clj
+++ b/test/aoc_clj/2015/day13_test.clj
@@ -23,10 +23,10 @@
 
 (def day13-input (u/parse-puzzle-input t/parse 2015 13))
 
-(deftest day13-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day13, part1"
-    (is (= 709 (t/day13-part1-soln day13-input)))))
+    (is (= 709 (t/part1 day13-input)))))
 
-(deftest day13-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day13, part2"
-    (is (= 668 (t/day13-part2-soln day13-input)))))
+    (is (= 668 (t/part2 day13-input)))))

--- a/test/aoc_clj/2015/day14_test.clj
+++ b/test/aoc_clj/2015/day14_test.clj
@@ -19,10 +19,10 @@
 
 (def day14-input (u/parse-puzzle-input t/parse 2015 14))
 
-(deftest day14-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day14, part1"
-    (is (= 2660 (t/day14-part1-soln day14-input)))))
+    (is (= 2660 (t/part1 day14-input)))))
 
-(deftest day14-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day14, part2"
-    (is (= 1256 (t/day14-part2-soln day14-input)))))
+    (is (= 1256 (t/part2 day14-input)))))

--- a/test/aoc_clj/2015/day15_test.clj
+++ b/test/aoc_clj/2015/day15_test.clj
@@ -28,10 +28,10 @@
 
 (def day15-input (u/parse-puzzle-input t/parse 2015 15))
 
-(deftest day15-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day15, part1"
-    (is (= 21367368 (t/day15-part1-soln day15-input)))))
+    (is (= 21367368 (t/part1 day15-input)))))
 
-(deftest day15-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day15, part2"
-    (is (= 1766400 (t/day15-part2-soln day15-input)))))
+    (is (= 1766400 (t/part2 day15-input)))))

--- a/test/aoc_clj/2015/day16_test.clj
+++ b/test/aoc_clj/2015/day16_test.clj
@@ -5,10 +5,10 @@
 
 (def day16-input (u/parse-puzzle-input t/parse 2015 16))
 
-(deftest day16-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day16, part1"
-    (is (= 213 (t/day16-part1-soln day16-input)))))
+    (is (= 213 (t/part1 day16-input)))))
 
-(deftest day16-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day16, part2"
-    (is (= 323 (t/day16-part2-soln day16-input)))))
+    (is (= 323 (t/part2 day16-input)))))

--- a/test/aoc_clj/2015/day17_test.clj
+++ b/test/aoc_clj/2015/day17_test.clj
@@ -17,10 +17,10 @@
 
 ;; FIXME: 2015.day17 solution is slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/6
-(deftest ^:slow day17-part1-soln
+(deftest ^:slow part1
   (testing "Reproduces the answer for day17, part1"
-    (is (= 654 (t/day17-part1-soln day17-input)))))
+    (is (= 654 (t/part1 day17-input)))))
 
-(deftest ^:slow day17-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day17, part2"
-    (is (= 57 (t/day17-part2-soln day17-input)))))
+    (is (= 57 (t/part2 day17-input)))))

--- a/test/aoc_clj/2015/day18_test.clj
+++ b/test/aoc_clj/2015/day18_test.clj
@@ -25,10 +25,10 @@
 
 ;; FIXME: 2015.day18 solution is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/4
-(deftest ^:slow day18-part1-soln
+(deftest ^:slow part1
   (testing "Reproduces the answer for day18, part1"
-    (is (= 1061 (t/day18-part1-soln day18-input)))))
+    (is (= 1061 (t/part1 day18-input)))))
 
-(deftest ^:slow day18-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day18, part2"
-    (is (= 1006 (t/day18-part2-soln day18-input)))))
+    (is (= 1006 (t/part2 day18-input)))))

--- a/test/aoc_clj/2015/day19_test.clj
+++ b/test/aoc_clj/2015/day19_test.clj
@@ -35,10 +35,10 @@
 
 (def day19-input (u/parse-puzzle-input t/parse 2015 19))
 
-(deftest day19-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day19, part1"
-    (is (= 518 (t/day19-part1-soln day19-input)))))
+    (is (= 518 (t/part1 day19-input)))))
 
-(deftest day19-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day19, part2"
-    (is (= 200 (t/day19-part2-soln day19-input)))))
+    (is (= 200 (t/part2 day19-input)))))

--- a/test/aoc_clj/2015/day20_test.clj
+++ b/test/aoc_clj/2015/day20_test.clj
@@ -10,10 +10,10 @@
 
 (def day20-input (u/parse-puzzle-input t/parse 2015 20))
 
-(deftest day20-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day20, part1"
-    (is (= 776160 (t/day20-part1-soln day20-input)))))
+    (is (= 776160 (t/part1 day20-input)))))
 
-(deftest day20-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day20, part2"
-    (is (= 786240 (t/day20-part2-soln day20-input)))))
+    (is (= 786240 (t/part2 day20-input)))))

--- a/test/aoc_clj/2015/day21_test.clj
+++ b/test/aoc_clj/2015/day21_test.clj
@@ -15,10 +15,10 @@
 
 (def day21-input (u/parse-puzzle-input t/parse 2015 21))
 
-(deftest day21-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day21, part1"
-    (is (= 78 (t/day21-part1-soln day21-input)))))
+    (is (= 78 (t/part1 day21-input)))))
 
-(deftest day21-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day21, part2"
-    (is (= 148 (t/day21-part2-soln day21-input)))))
+    (is (= 148 (t/part2 day21-input)))))

--- a/test/aoc_clj/2015/day22_test.clj
+++ b/test/aoc_clj/2015/day22_test.clj
@@ -29,10 +29,10 @@
 
 ;; (def day22-input (u/parse-puzzle-input t/parse 2015 22))
 
-(deftest day22-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day22, part1"
-    (is (= 1269 (t/day22-part1-soln)))))
+    (is (= 1269 (t/part1)))))
 
-(deftest day22-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day22, part2"
-    (is (= 1309 (t/day22-part2-soln)))))
+    (is (= 1309 (t/part2)))))

--- a/test/aoc_clj/2015/day23_test.clj
+++ b/test/aoc_clj/2015/day23_test.clj
@@ -17,10 +17,10 @@
 
 (def day23-input (u/parse-puzzle-input t/parse 2015 23))
 
-(deftest day23-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day23, part1"
-    (is (= 184 (t/day23-part1-soln day23-input)))))
+    (is (= 184 (t/part1 day23-input)))))
 
-(deftest day23-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day23, part2"
-    (is (= 231 (t/day23-part2-soln day23-input)))))
+    (is (= 231 (t/part2 day23-input)))))

--- a/test/aoc_clj/2015/day24_test.clj
+++ b/test/aoc_clj/2015/day24_test.clj
@@ -12,10 +12,10 @@
 
 (def day24-input (u/parse-puzzle-input t/parse 2015 24))
 
-(deftest day24-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day24, part1"
-    (is (= 11846773891 (t/day24-part1-soln day24-input)))))
+    (is (= 11846773891 (t/part1 day24-input)))))
 
-(deftest day24-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day24, part1"
-    (is (= 80393059 (t/day24-part2-soln day24-input)))))
+    (is (= 80393059 (t/part2 day24-input)))))

--- a/test/aoc_clj/2015/day25_test.clj
+++ b/test/aoc_clj/2015/day25_test.clj
@@ -28,6 +28,6 @@
 
 (def day25-input (u/parse-puzzle-input t/parse 2015 25))
 
-(deftest day25-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day25, part1"
-    (is (= 9132360 (t/day25-part1-soln day25-input)))))
+    (is (= 9132360 (t/part1 day25-input)))))

--- a/test/aoc_clj/2016/day01_test.clj
+++ b/test/aoc_clj/2016/day01_test.clj
@@ -28,10 +28,10 @@
 
 (def day01-input (u/parse-puzzle-input t/parse 2016 1))
 
-(deftest day01-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day01, part1"
-    (is (= 241 (t/day01-part1-soln day01-input)))))
+    (is (= 241 (t/part1 day01-input)))))
 
-(deftest day01-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day01, part2"
-    (is (= 116 (t/day01-part2-soln day01-input)))))
+    (is (= 116 (t/part2 day01-input)))))

--- a/test/aoc_clj/2016/day02_test.clj
+++ b/test/aoc_clj/2016/day02_test.clj
@@ -17,10 +17,10 @@
 
 (def day02-input (u/parse-puzzle-input t/parse 2016 2))
 
-(deftest day02-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day02, part1"
-    (is (= "18843" (t/day02-part1-soln day02-input)))))
+    (is (= "18843" (t/part1 day02-input)))))
 
-(deftest day02-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day02, part2"
-    (is (= "67BB9" (t/day02-part2-soln day02-input)))))
+    (is (= "67BB9" (t/part2 day02-input)))))

--- a/test/aoc_clj/2016/day03_test.clj
+++ b/test/aoc_clj/2016/day03_test.clj
@@ -23,10 +23,10 @@
 
 (def day03-input (u/parse-puzzle-input t/parse 2016 3))
 
-(deftest day03-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day03, part1"
-    (is (= 869 (t/day03-part1-soln day03-input)))))
+    (is (= 869 (t/part1 day03-input)))))
 
-(deftest day03-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day03, part2"
-    (is (= 1544 (t/day03-part2-soln day03-input)))))
+    (is (= 1544 (t/part2 day03-input)))))

--- a/test/aoc_clj/2016/day04_test.clj
+++ b/test/aoc_clj/2016/day04_test.clj
@@ -21,10 +21,10 @@
 
 (def day04-input (u/parse-puzzle-input t/parse 2016 4))
 
-(deftest day04-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day04, part1"
-    (is (= 361724 (t/day04-part1-soln day04-input)))))
+    (is (= 361724 (t/part1 day04-input)))))
 
-(deftest day04-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day04, part2"
-    (is (= 482 (t/day04-part2-soln day04-input)))))
+    (is (= 482 (t/part2 day04-input)))))

--- a/test/aoc_clj/2016/day05_test.clj
+++ b/test/aoc_clj/2016/day05_test.clj
@@ -22,10 +22,10 @@
 
 (def day05-input (u/parse-puzzle-input t/parse 2016 5))
 
-(deftest day05-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day05, part1"
-    (is (= "f97c354d" (t/day05-part1-soln day05-input)))))
+    (is (= "f97c354d" (t/part1 day05-input)))))
 
-(deftest day05-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day05, part2"
-    (is (= "863dde27" (t/day05-part2-soln day05-input)))))
+    (is (= "863dde27" (t/part2 day05-input)))))

--- a/test/aoc_clj/2016/day06_test.clj
+++ b/test/aoc_clj/2016/day06_test.clj
@@ -31,10 +31,10 @@
 
 (def day06-input (u/parse-puzzle-input t/parse 2016 6))
 
-(deftest day06-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day06, part1"
-    (is (= "agmwzecr" (t/day06-part1-soln day06-input)))))
+    (is (= "agmwzecr" (t/part1 day06-input)))))
 
-(deftest day06-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day06, part2"
-    (is (= "owlaxqvq" (t/day06-part2-soln day06-input)))))
+    (is (= "owlaxqvq" (t/part2 day06-input)))))

--- a/test/aoc_clj/2016/day07_test.clj
+++ b/test/aoc_clj/2016/day07_test.clj
@@ -36,10 +36,10 @@
 
 (def day07-input (u/parse-puzzle-input t/parse 2016 7))
 
-(deftest day07-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day07, part1"
-    (is (= 110 (t/day07-part1-soln day07-input)))))
+    (is (= 110 (t/part1 day07-input)))))
 
-(deftest day07-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day07, part2"
-    (is (= 242 (t/day07-part2-soln day07-input)))))
+    (is (= 242 (t/part2 day07-input)))))

--- a/test/aoc_clj/2016/day08_test.clj
+++ b/test/aoc_clj/2016/day08_test.clj
@@ -21,10 +21,10 @@
 
 (def day08-input (u/parse-puzzle-input t/parse 2016 8))
 
-(deftest day08-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day08, part1"
-    (is (= 128 (t/day08-part1-soln day08-input)))))
+    (is (= 128 (t/part1 day08-input)))))
 
-(deftest day08-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day08, part2"
-    (is (= "EOARGPHYAO" (t/day08-part2-soln day08-input)))))
+    (is (= "EOARGPHYAO" (t/part2 day08-input)))))

--- a/test/aoc_clj/2016/day09_test.clj
+++ b/test/aoc_clj/2016/day09_test.clj
@@ -21,10 +21,10 @@
 
 (def day09-input (u/parse-puzzle-input t/parse 2016 9))
 
-(deftest day09-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day09, part1"
-    (is (= 112830 (t/day09-part1-soln day09-input)))))
+    (is (= 112830 (t/part1 day09-input)))))
 
-(deftest day09-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day09, part2"
-    (is (= 10931789799 (t/day09-part2-soln day09-input)))))
+    (is (= 10931789799 (t/part2 day09-input)))))

--- a/test/aoc_clj/2016/day10_test.clj
+++ b/test/aoc_clj/2016/day10_test.clj
@@ -20,10 +20,10 @@
 
 (def day10-input (u/parse-puzzle-input t/parse 2016 10))
 
-(deftest day10-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day10, part1"
-    (is (= 93 (t/day10-part1-soln day10-input)))))
+    (is (= 93 (t/part1 day10-input)))))
 
-(deftest day10-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day10, part2"
-    (is (= 47101 (t/day10-part2-soln day10-input)))))
+    (is (= 47101 (t/part2 day10-input)))))

--- a/test/aoc_clj/2016/day11_test.clj
+++ b/test/aoc_clj/2016/day11_test.clj
@@ -33,10 +33,10 @@ The fourth floor contains nothing relevant."
 
 ;; FIXME: Implementation is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/31
-(deftest ^:slow day11-part1-soln
+(deftest ^:slow part1
   (testing "Reproduces the answer for day11, part1"
-    (is (= 31 (t/day11-part1-soln day11-input)))))
+    (is (= 31 (t/part1 day11-input)))))
 
-(deftest ^:slow day11-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day11, part2"
-    (is (= 55 (t/day11-part2-soln day11-input)))))
+    (is (= 55 (t/part2 day11-input)))))

--- a/test/aoc_clj/2016/day12_test.clj
+++ b/test/aoc_clj/2016/day12_test.clj
@@ -19,10 +19,10 @@
 
 (def day12-input (u/parse-puzzle-input t/parse 2016 12))
 
-(deftest day12-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day12, part1"
-    (is (= 318020 (t/day12-part1-soln day12-input)))))
+    (is (= 318020 (t/part1 day12-input)))))
 
-(deftest ^:slow day12-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day12, part2"
-    (is (= 9227674 (t/day12-part2-soln day12-input)))))
+    (is (= 9227674 (t/part2 day12-input)))))

--- a/test/aoc_clj/2016/day13_test.clj
+++ b/test/aoc_clj/2016/day13_test.clj
@@ -22,10 +22,10 @@
 
 ;; (def day13-input (u/parse-puzzle-input t/parse 2016 13))
 
-;; (deftest day13-part1-soln
+;; (deftest part1-test
 ;;   (testing "Reproduces the answer for day13, part1"
-;;     (is (= 0 (t/day13-part1-soln)))))
+;;     (is (= 0 (t/part1)))))
 
-;; (deftest day13-part2-soln
+;; (deftest part2-test
 ;;   (testing "Reproduces the answer for day13, part2"
-;;     (is (= 0 (t/day13-part2-soln)))))
+;;     (is (= 0 (t/part2)))))

--- a/test/aoc_clj/2018/day01_test.clj
+++ b/test/aoc_clj/2018/day01_test.clj
@@ -5,10 +5,10 @@
 
 (def day01-input (u/parse-puzzle-input t/parse 2018 1))
 
-(deftest day01-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day01, part1"
-    (is (= 543 (t/day01-part1-soln day01-input)))))
+    (is (= 543 (t/part1 day01-input)))))
 
-(deftest day01-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day01, part2"
-    (is (= 621 (t/day01-part2-soln day01-input)))))
+    (is (= 621 (t/part2 day01-input)))))

--- a/test/aoc_clj/2018/day02_test.clj
+++ b/test/aoc_clj/2018/day02_test.clj
@@ -5,10 +5,10 @@
 
 (def day02-input (u/parse-puzzle-input t/parse 2018 2))
 
-(deftest day02-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day02, part1"
-    (is (= 5478 (t/day02-part1-soln day02-input)))))
+    (is (= 5478 (t/part1 day02-input)))))
 
-(deftest day02-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day02, part2"
-    (is (= "qyzphxoiseldjrntfygvdmanu" (t/day02-part2-soln day02-input)))))
+    (is (= "qyzphxoiseldjrntfygvdmanu" (t/part2 day02-input)))))

--- a/test/aoc_clj/2018/day03_test.clj
+++ b/test/aoc_clj/2018/day03_test.clj
@@ -5,10 +5,10 @@
 
 (def day03-input (u/parse-puzzle-input t/parse 2018 3))
 
-(deftest day03-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day03, part1"
-    (is (= 116489 (t/day03-part1-soln day03-input)))))
+    (is (= 116489 (t/part1 day03-input)))))
 
-(deftest day03-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day03, part2"
-    (is (= "#1260" (t/day03-part2-soln day03-input)))))
+    (is (= "#1260" (t/part2 day03-input)))))

--- a/test/aoc_clj/2018/day04_test.clj
+++ b/test/aoc_clj/2018/day04_test.clj
@@ -39,10 +39,10 @@
 
 (def day04-input (u/parse-puzzle-input t/parse 2018 4))
 
-(deftest day04-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day04, part1"
-    (is (= 74743 (t/day04-part1-soln day04-input)))))
+    (is (= 74743 (t/part1 day04-input)))))
 
-(deftest day04-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day04, part2"
-    (is (= 132484 (t/day04-part2-soln day04-input)))))
+    (is (= 132484 (t/part2 day04-input)))))

--- a/test/aoc_clj/2019/day01_test.clj
+++ b/test/aoc_clj/2019/day01_test.clj
@@ -18,10 +18,10 @@
 
 (def day01-input (u/parse-puzzle-input t/parse 2019 1))
 
-(deftest day01-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 3152038 (t/day01-part1-soln day01-input)))))
+    (is (= 3152038 (t/part1 day01-input)))))
 
-(deftest day01-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= 4725210 (t/day01-part2-soln day01-input)))))
+    (is (= 4725210 (t/part2 day01-input)))))

--- a/test/aoc_clj/2019/day02_test.clj
+++ b/test/aoc_clj/2019/day02_test.clj
@@ -5,10 +5,10 @@
 
 (def day02-input (u/parse-puzzle-input t/parse 2019 2))
 
-(deftest day02-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 3085697 (t/day02-part1-soln day02-input)))))
+    (is (= 3085697 (t/part1 day02-input)))))
 
-(deftest day02-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= 9425 (t/day02-part2-soln day02-input)))))
+    (is (= 9425 (t/part2 day02-input)))))

--- a/test/aoc_clj/2019/day03_test.clj
+++ b/test/aoc_clj/2019/day03_test.clj
@@ -52,10 +52,10 @@
 
 (def day03-input (u/parse-puzzle-input t/parse 2019 3))
 
-(deftest day03-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 375 (t/day03-part1-soln day03-input)))))
+    (is (= 375 (t/part1 day03-input)))))
 
-(deftest day03-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= 14746 (t/day03-part2-soln day03-input)))))
+    (is (= 14746 (t/part2 day03-input)))))

--- a/test/aoc_clj/2019/day03_test.clj
+++ b/test/aoc_clj/2019/day03_test.clj
@@ -38,13 +38,13 @@
 (def dist3 135)
 (def steps3 410)
 
-(deftest part1-test
+(deftest closest-intersection-dist-test
   (testing "Find closest intersection of the wire paths"
     (is (= dist1 (t/closest-intersection-dist input1)))
     (is (= dist2 (t/closest-intersection-dist input2)))
     (is (= dist3 (t/closest-intersection-dist input3)))))
 
-(deftest part2-test
+(deftest shortest-steps-to-intersection-test
   (testing "Find fewest number of steps to first intersection of the wire paths"
     (is (= steps1 (t/shortest-steps-to-intersection input1)))
     (is (= steps2 (t/shortest-steps-to-intersection input2)))

--- a/test/aoc_clj/2019/day04_test.clj
+++ b/test/aoc_clj/2019/day04_test.clj
@@ -25,10 +25,10 @@
 
 (def day04-input (u/parse-puzzle-input t/parse 2019 4))
 
-(deftest day04-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 1330 (t/day04-part1-soln day04-input)))))
+    (is (= 1330 (t/part1 day04-input)))))
 
-(deftest day01-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= 876 (t/day04-part2-soln day04-input)))))
+    (is (= 876 (t/part2 day04-input)))))

--- a/test/aoc_clj/2019/day05_test.clj
+++ b/test/aoc_clj/2019/day05_test.clj
@@ -5,10 +5,10 @@
 
 (def day05-input (u/parse-puzzle-input t/parse 2019 5))
 
-(deftest day05-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 12234644 (t/day05-part1-soln day05-input)))))
+    (is (= 12234644 (t/part1 day05-input)))))
 
-(deftest day05-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= 3508186 (t/day05-part2-soln day05-input)))))
+    (is (= 3508186 (t/part2 day05-input)))))

--- a/test/aoc_clj/2019/day06_test.clj
+++ b/test/aoc_clj/2019/day06_test.clj
@@ -35,10 +35,10 @@
 
 (def day06-input (u/parse-puzzle-input t/parse 2019 6))
 
-(deftest day06-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 261306 (t/day06-part1-soln day06-input)))))
+    (is (= 261306 (t/part1 day06-input)))))
 
-(deftest day06-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= 382 (t/day06-part2-soln day06-input)))))
+    (is (= 382 (t/part2 day06-input)))))

--- a/test/aoc_clj/2019/day07_test.clj
+++ b/test/aoc_clj/2019/day07_test.clj
@@ -52,10 +52,10 @@
 
 (def day07-input (u/parse-puzzle-input t/parse 2019 7))
 
-(deftest day07-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 567045 (t/day07-part1-soln day07-input)))))
+    (is (= 567045 (t/part1 day07-input)))))
 
-(deftest day07-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= 39016654 (t/day07-part2-soln day07-input)))))
+    (is (= 39016654 (t/part2 day07-input)))))

--- a/test/aoc_clj/2019/day08_test.clj
+++ b/test/aoc_clj/2019/day08_test.clj
@@ -18,10 +18,10 @@
     (is (= '(0 1 1 0) (t/decode-image [0 2 2 2 1 1 2 2 2 2 1 2 0 0 0 0] 2 2)))
     (is (= decoded-output (t/decode-image day08-input 25 6)))))
 
-(deftest day08-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 2016 (t/day08-part1-soln day08-input)))))
+    (is (= 2016 (t/part1 day08-input)))))
 
-(deftest day08-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= "HZCZU" (t/day08-part2-soln day08-input)))))
+    (is (= "HZCZU" (t/part2 day08-input)))))

--- a/test/aoc_clj/2019/day09_test.clj
+++ b/test/aoc_clj/2019/day09_test.clj
@@ -5,10 +5,10 @@
 
 (def day09-input (u/parse-puzzle-input t/parse 2019 9))
 
-(deftest day09-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 3742852857 (t/day09-part1-soln day09-input)))))
+    (is (= 3742852857 (t/part1 day09-input)))))
 
-(deftest day09-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= 73439 (t/day09-part2-soln day09-input)))))
+    (is (= 73439 (t/part2 day09-input)))))

--- a/test/aoc_clj/2019/day10_test.clj
+++ b/test/aoc_clj/2019/day10_test.clj
@@ -107,10 +107,10 @@
 
 (def day10-input (u/parse-puzzle-input t/parse 2019 10))
 
-(deftest day10-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 253 (second (t/day10-part1-soln day10-input))))))
+    (is (= 253 (second (t/part1 day10-input))))))
 
-(deftest day10-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= 815 (t/day10-part2-soln day10-input)))))
+    (is (= 815 (t/part2 day10-input)))))

--- a/test/aoc_clj/2019/day11_test.clj
+++ b/test/aoc_clj/2019/day11_test.clj
@@ -5,10 +5,10 @@
 
 (def day11-input (u/parse-puzzle-input t/parse 2019 11))
 
-(deftest day11-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 2539 (t/day11-part1-soln day11-input)))))
+    (is (= 2539 (t/part1 day11-input)))))
 
-(deftest day11-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= "ZLEBKJRA" (t/day11-part2-soln day11-input)))))
+    (is (= "ZLEBKJRA" (t/part2 day11-input)))))

--- a/test/aoc_clj/2019/day12_test.clj
+++ b/test/aoc_clj/2019/day12_test.clj
@@ -28,12 +28,12 @@
 
 (def day12-input (u/parse-puzzle-input t/parse 2019 12))
 
-(deftest day12-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 8310 (t/day12-part1-soln day12-input)))))
+    (is (= 8310 (t/part1 day12-input)))))
 
 ;; FIXME: Test is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/15
-(deftest ^:slow day12-part2-soln-test
+(deftest ^:slow part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= 319290382980408 (t/day12-part2-soln day12-input)))))
+    (is (= 319290382980408 (t/part2 day12-input)))))

--- a/test/aoc_clj/2019/day13_test.clj
+++ b/test/aoc_clj/2019/day13_test.clj
@@ -5,10 +5,10 @@
 
 (def day13-input (u/parse-puzzle-input t/parse 2019 13))
 
-(deftest day13-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 230 (t/day13-part1-soln day13-input)))))
+    (is (= 230 (t/part1 day13-input)))))
 
-(deftest day13-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= 11140 (t/day13-part2-soln day13-input)))))
+    (is (= 11140 (t/part2 day13-input)))))

--- a/test/aoc_clj/2019/day14_test.clj
+++ b/test/aoc_clj/2019/day14_test.clj
@@ -85,10 +85,10 @@
 
 (def day14-input (u/parse-puzzle-input t/parse 2019 14))
 
-(deftest day14-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the solution to part 1"
-    (is (= 278404 (t/day14-part1-soln day14-input)))))
+    (is (= 278404 (t/part1 day14-input)))))
 
-(deftest day14-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the solution to part 2"
-    (is (= 4436981 (t/day14-part2-soln day14-input)))))
+    (is (= 4436981 (t/part2 day14-input)))))

--- a/test/aoc_clj/2019/day15_test.clj
+++ b/test/aoc_clj/2019/day15_test.clj
@@ -5,10 +5,10 @@
 
 (def day15-input (u/parse-puzzle-input t/parse 2019 15))
 
-(deftest day15-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 280 (t/day15-part1-soln day15-input)))))
+    (is (= 280 (t/part1 day15-input)))))
 
-(deftest day15-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the answer for part1"
-    (is (= 400 (t/day15-part2-soln day15-input)))))
+    (is (= 400 (t/part2 day15-input)))))

--- a/test/aoc_clj/2019/day16_test.clj
+++ b/test/aoc_clj/2019/day16_test.clj
@@ -43,12 +43,12 @@
 
 (def day16-input (u/parse-puzzle-input t/parse 2019 16))
 
-(deftest day16-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= "70856418" (t/day16-part1-soln day16-input)))))
+    (is (= "70856418" (t/part1 day16-input)))))
 
 ;; FIXME: test is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/17
-(deftest ^:slow day16-part2-soln-test
+(deftest ^:slow part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= "87766336" (t/day16-part2-soln day16-input)))))
+    (is (= "87766336" (t/part2 day16-input)))))

--- a/test/aoc_clj/2019/day17_test.clj
+++ b/test/aoc_clj/2019/day17_test.clj
@@ -20,10 +20,10 @@
 
 (def day17-input (u/parse-puzzle-input t/parse 2019 17))
 
-(deftest day17-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 7584 (t/day17-part1-soln day17-input)))))
+    (is (= 7584 (t/part1 day17-input)))))
 
-(deftest day17-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= 1016738 (t/day17-part2-soln day17-input)))))
+    (is (= 1016738 (t/part2 day17-input)))))

--- a/test/aoc_clj/2019/day18_test.clj
+++ b/test/aoc_clj/2019/day18_test.clj
@@ -104,8 +104,8 @@
 
 (deftest ^:slow day18-part1-test
   (testing "Can reproduce the solution for part1"
-    (is (= 7048 (t/day18-part1-soln day18-input)))))
+    (is (= 7048 (t/part1 day18-input)))))
 
 (deftest ^:slow day18-part2-test
   (testing "Can reproduce the solution for part2"
-    (is (= 1836 (t/day18-part2-soln day18-input)))))
+    (is (= 1836 (t/part2 day18-input)))))

--- a/test/aoc_clj/2019/day19_test.clj
+++ b/test/aoc_clj/2019/day19_test.clj
@@ -7,8 +7,8 @@
 
 (deftest day19-part1-test
   (testing "Can reproduce the solution for part1"
-    (is (= 150 (t/day19-part1-soln day19-input)))))
+    (is (= 150 (t/part1 day19-input)))))
 
 (deftest day19-part2-test
   (testing "Can reproduce the solution for part2"
-    (is (= 12201460 (t/day19-part2-soln day19-input)))))
+    (is (= 12201460 (t/part2 day19-input)))))

--- a/test/aoc_clj/2019/day20_test.clj
+++ b/test/aoc_clj/2019/day20_test.clj
@@ -143,10 +143,10 @@
 
 (def day20-input (u/parse-puzzle-input t/parse 2019 20))
 
-(deftest day20-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the solution for part1"
-    (is (= 578 (t/day20-part1-soln day20-input)))))
+    (is (= 578 (t/part1 day20-input)))))
 
-(deftest day20-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the solution for part2"
-    (is (= 6592 (t/day20-part2-soln day20-input)))))
+    (is (= 6592 (t/part2 day20-input)))))

--- a/test/aoc_clj/2019/day21_test.clj
+++ b/test/aoc_clj/2019/day21_test.clj
@@ -5,10 +5,10 @@
 
 (def day21-input (u/parse-puzzle-input t/parse 2019 21))
 
-(deftest day21-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 19352864 (t/day21-part1-soln day21-input)))))
+    (is (= 19352864 (t/part1 day21-input)))))
 
-(deftest day21-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= 1142488337 (t/day21-part2-soln day21-input)))))
+    (is (= 1142488337 (t/part2 day21-input)))))

--- a/test/aoc_clj/2019/day22_test.clj
+++ b/test/aoc_clj/2019/day22_test.clj
@@ -45,10 +45,10 @@
 
 (def day22-input (u/parse-puzzle-input t/parse 2019 22))
 
-(deftest day22-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 2306 (t/day22-part1-soln day22-input)))))
+    (is (= 2306 (t/part1 day22-input)))))
 
-(deftest day22-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= 12545532223512 (t/day22-part2-soln day22-input)))))
+    (is (= 12545532223512 (t/part2 day22-input)))))

--- a/test/aoc_clj/2019/day23_test.clj
+++ b/test/aoc_clj/2019/day23_test.clj
@@ -5,10 +5,10 @@
 
 (def day23-input (u/parse-puzzle-input t/parse 2019 23))
 
-(deftest day23-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 23886 (t/day23-part1-soln day23-input)))))
+    (is (= 23886 (t/part1 day23-input)))))
 
-(deftest day21-part2-soln-test
+(deftest part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= 18333 (t/day23-part2-soln day23-input)))))
+    (is (= 18333 (t/part2 day23-input)))))

--- a/test/aoc_clj/2019/day24_test.clj
+++ b/test/aoc_clj/2019/day24_test.clj
@@ -67,12 +67,12 @@
 
 (def day24-input (u/parse-puzzle-input t/parse 2019 24))
 
-(deftest day24-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 17863711 (t/day24-part1-soln day24-input)))))
+    (is (= 17863711 (t/part1 day24-input)))))
 
 ;; FIXME: 2019 Day 24 part 2 solutiion is a bit slow to test
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/24
-(deftest ^:slow day24-part2-soln-test
+(deftest ^:slow part2-test
   (testing "Can reproduce the answer for part2"
-    (is (= 1937 (t/day24-part2-soln day24-input)))))
+    (is (= 1937 (t/part2 day24-input)))))

--- a/test/aoc_clj/2019/day25_test.clj
+++ b/test/aoc_clj/2019/day25_test.clj
@@ -6,6 +6,6 @@
 (def day25-input (u/parse-puzzle-input t/parse 2019 25))
 (def day25-cmds  (u/puzzle-input "inputs/2019/day25-cmds.txt"))
 
-(deftest day25-part1-soln-test
+(deftest part1-test
   (testing "Can reproduce the answer for part1"
-    (is (= 16410 (t/day25-part1-soln day25-input day25-cmds)))))
+    (is (= 16410 (t/part1 day25-input day25-cmds)))))

--- a/test/aoc_clj/2020/day01_test.clj
+++ b/test/aoc_clj/2020/day01_test.clj
@@ -15,10 +15,10 @@
 
 (def day01-input (u/parse-puzzle-input t/parse 2020 1))
 
-(deftest day01-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day01, part1"
-    (is (= 989824 (t/day01-part1-soln day01-input)))))
+    (is (= 989824 (t/part1 day01-input)))))
 
-(deftest day01-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day01, part2"
-    (is (= 66432240 (t/day02-part2-soln day01-input)))))
+    (is (= 66432240 (t/part2 day01-input)))))

--- a/test/aoc_clj/2020/day02_test.clj
+++ b/test/aoc_clj/2020/day02_test.clj
@@ -26,10 +26,10 @@
 
 (def day02-input (u/parse-puzzle-input t/parse 2020 2))
 
-(deftest day02-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day02, part1"
-    (is (= 418 (t/day02-part1-soln day02-input)))))
+    (is (= 418 (t/part1 day02-input)))))
 
-(deftest day02-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day02, part2"
-    (is (= 616 (t/day02-part2-soln day02-input)))))
+    (is (= 616 (t/part2 day02-input)))))

--- a/test/aoc_clj/2020/day03_test.clj
+++ b/test/aoc_clj/2020/day03_test.clj
@@ -30,10 +30,10 @@
 
 (def day03-input (u/parse-puzzle-input t/parse 2020 3))
 
-(deftest day03-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day03, part1"
-    (is (= 191 (t/day03-part1-soln day03-input)))))
+    (is (= 191 (t/part1 day03-input)))))
 
-(deftest day03-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day03, part2"
-    (is (= 1478615040 (t/day03-part2-soln day03-input)))))
+    (is (= 1478615040 (t/part2 day03-input)))))

--- a/test/aoc_clj/2020/day04_test.clj
+++ b/test/aoc_clj/2020/day04_test.clj
@@ -108,10 +108,10 @@
 
 (def day04-input (u/parse-puzzle-input t/parse 2020 4))
 
-(deftest day04-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day04, part1"
-    (is (= 192 (t/day04-part1-soln day04-input)))))
+    (is (= 192 (t/part1 day04-input)))))
 
-(deftest day04-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day04, part2"
-    (is (= 101 (t/day04-part2-soln day04-input)))))
+    (is (= 101 (t/part2 day04-input)))))

--- a/test/aoc_clj/2020/day05_test.clj
+++ b/test/aoc_clj/2020/day05_test.clj
@@ -17,10 +17,10 @@
 
 (def day05-input (u/parse-puzzle-input t/parse 2020 5))
 
-(deftest day05-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day05, part1"
-    (is (= 858 (t/day05-part1-soln day05-input)))))
+    (is (= 858 (t/part1 day05-input)))))
 
-(deftest day05-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day05, part2"
-    (is (= 557 (t/day05-part2-soln day05-input)))))
+    (is (= 557 (t/part2 day05-input)))))

--- a/test/aoc_clj/2020/day06_test.clj
+++ b/test/aoc_clj/2020/day06_test.clj
@@ -39,10 +39,10 @@
 
 (def day06-input (u/parse-puzzle-input t/parse 2020 6))
 
-(deftest day06-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day06, part1"
-    (is (= 6170 (t/day06-part1-soln day06-input)))))
+    (is (= 6170 (t/part1 day06-input)))))
 
-(deftest day06-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day06, part2"
-    (is (= 2947 (t/day06-part2-soln day06-input)))))
+    (is (= 2947 (t/part2 day06-input)))))

--- a/test/aoc_clj/2020/day07_test.clj
+++ b/test/aoc_clj/2020/day07_test.clj
@@ -37,10 +37,10 @@
 
 (def day07-input (u/parse-puzzle-input t/parse 2020 7))
 
-(deftest day07-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day07, part1"
-    (is (= 372 (t/day07-part1-soln day07-input)))))
+    (is (= 372 (t/part1 day07-input)))))
 
-(deftest day07-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day07, part2"
-    (is (= 8015 (t/day07-part2-soln day07-input)))))
+    (is (= 8015 (t/part2 day07-input)))))

--- a/test/aoc_clj/2020/day08_test.clj
+++ b/test/aoc_clj/2020/day08_test.clj
@@ -25,10 +25,10 @@
 
 (def day08-input (u/parse-puzzle-input t/parse 2020 8))
 
-(deftest day08-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day08, part1"
-    (is (= 1451 (t/day08-part1-soln day08-input)))))
+    (is (= 1451 (t/part1 day08-input)))))
 
-(deftest day08-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day08, part2"
-    (is (= 1160 (t/day08-part2-soln day08-input)))))
+    (is (= 1160 (t/part2 day08-input)))))

--- a/test/aoc_clj/2020/day09_test.clj
+++ b/test/aoc_clj/2020/day09_test.clj
@@ -36,10 +36,10 @@
 
 (def day09-input (u/parse-puzzle-input t/parse 2020 9))
 
-(deftest day09-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day09, part1"
-    (is (= 22406676 (t/day09-part1-soln day09-input)))))
+    (is (= 22406676 (t/part1 day09-input)))))
 
-(deftest day09-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day09, part2"
-    (is (= 2942387 (t/day09-part2-soln day09-input)))))
+    (is (= 2942387 (t/part2 day09-input)))))

--- a/test/aoc_clj/2020/day10_test.clj
+++ b/test/aoc_clj/2020/day10_test.clj
@@ -63,10 +63,10 @@
 
 (def day10-input (u/parse-puzzle-input t/parse 2020 10))
 
-(deftest day10-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day10, part1"
-    (is (= 2760 (t/day10-part1-soln day10-input)))))
+    (is (= 2760 (t/part1 day10-input)))))
 
-(deftest day10-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day10, part2"
-    (is (= 13816758796288 (t/day10-part2-soln day10-input)))))
+    (is (= 13816758796288 (t/part2 day10-input)))))

--- a/test/aoc_clj/2020/day11_test.clj
+++ b/test/aoc_clj/2020/day11_test.clj
@@ -28,10 +28,10 @@
 
 ;; FIXME: 2020.day11 too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/12
-(deftest ^:slow day11-part1-soln
+(deftest ^:slow part1
   (testing "Reproduces the answer for day11, part1"
-    (is (= 2222 (t/day11-part1-soln day11-input)))))
+    (is (= 2222 (t/part1 day11-input)))))
 
-(deftest ^:slow day11-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day11, part2"
-    (is (= 2032 (t/day11-part2-soln day11-input)))))
+    (is (= 2032 (t/part2 day11-input)))))

--- a/test/aoc_clj/2020/day12_test.clj
+++ b/test/aoc_clj/2020/day12_test.clj
@@ -16,10 +16,10 @@
 
 (def day12-input (u/parse-puzzle-input t/parse 2020 12))
 
-(deftest day12-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day12, part1"
-    (is (= 1533 (t/day12-part1-soln day12-input)))))
+    (is (= 1533 (t/part1 day12-input)))))
 
-(deftest day12-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day12, part2"
-    (is (= 25235 (t/day12-part2-soln day12-input)))))
+    (is (= 25235 (t/part2 day12-input)))))

--- a/test/aoc_clj/2020/day13_test.clj
+++ b/test/aoc_clj/2020/day13_test.clj
@@ -25,10 +25,10 @@
 
 (def day13-input (u/parse-puzzle-input t/parse 2020 13))
 
-(deftest day13-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day13, part1"
-    (is (= 104 (t/day13-part1-soln day13-input)))))
+    (is (= 104 (t/part1 day13-input)))))
 
-(deftest day13-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day13, part2"
-    (is (= 842186186521918N (t/day13-part2-soln day13-input)))))
+    (is (= 842186186521918N (t/part2 day13-input)))))

--- a/test/aoc_clj/2020/day14_test.clj
+++ b/test/aoc_clj/2020/day14_test.clj
@@ -19,10 +19,10 @@
 
 (def day14-input (u/parse-puzzle-input t/parse 2020 14))
 
-(deftest day14-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day14, part1"
-    (is (= 6631883285184 (t/day14-part1-soln day14-input)))))
+    (is (= 6631883285184 (t/part1 day14-input)))))
 
-(deftest day14-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day14, part2"
-    (is (= 3161838538691 (t/day14-part2-soln day14-input)))))
+    (is (= 3161838538691 (t/part2 day14-input)))))

--- a/test/aoc_clj/2020/day15_test.clj
+++ b/test/aoc_clj/2020/day15_test.clj
@@ -23,10 +23,10 @@
 
 (def day15-input (u/parse-puzzle-input t/parse 2020 15))
 
-(deftest day15-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day15, part1"
-    (is (= 1428 (t/day15-part1-soln day15-input)))))
+    (is (= 1428 (t/part1 day15-input)))))
 
-(deftest ^:slow day15-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day15, part2"
-    (is (= 3718541 (t/day15-part2-soln day15-input)))))
+    (is (= 3718541 (t/part2 day15-input)))))

--- a/test/aoc_clj/2020/day16_test.clj
+++ b/test/aoc_clj/2020/day16_test.clj
@@ -34,10 +34,10 @@
 
 (def day16-input (u/parse-puzzle-input t/parse 2020 16))
 
-(deftest day16-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day16, part1"
-    (is (= 25961 (t/day16-part1-soln day16-input)))))
+    (is (= 25961 (t/part1 day16-input)))))
 
-(deftest day16-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day16, part2"
-    (is (= 603409823791 (t/day16-part2-soln day16-input)))))
+    (is (= 603409823791 (t/part2 day16-input)))))

--- a/test/aoc_clj/2020/day17_test.clj
+++ b/test/aoc_clj/2020/day17_test.clj
@@ -11,10 +11,10 @@
 
 (def day17-input (u/parse-puzzle-input t/parse 2020 17))
 
-(deftest day17-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day17, part1"
-    (is (= 267 (t/day17-part1-soln day17-input)))))
+    (is (= 267 (t/part1 day17-input)))))
 
-(deftest ^:slow day17-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day17, part2"
-    (is (= 1812 (t/day17-part2-soln day17-input)))))
+    (is (= 1812 (t/part2 day17-input)))))

--- a/test/aoc_clj/2020/day18_test.clj
+++ b/test/aoc_clj/2020/day18_test.clj
@@ -30,10 +30,10 @@
 
 (def day18-input (u/parse-puzzle-input t/parse 2020 18))
 
-(deftest day18-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day18, part1"
-    (is (= 69490582260 (t/day18-part1-soln day18-input)))))
+    (is (= 69490582260 (t/part1 day18-input)))))
 
-(deftest day18-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day18, part2"
-    (is (= 362464596624526 (t/day18-part2-soln day18-input)))))
+    (is (= 362464596624526 (t/part2 day18-input)))))

--- a/test/aoc_clj/2020/day19_test.clj
+++ b/test/aoc_clj/2020/day19_test.clj
@@ -79,10 +79,10 @@
 
 (def day19-input (u/parse-puzzle-input t/parse 2020 19))
 
-(deftest day19-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day19, part1"
-    (is (= 220 (t/day19-part1-soln day19-input)))))
+    (is (= 220 (t/part1 day19-input)))))
 
-(deftest day19-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day19, part2"
-    (is (= 439 (t/day19-part2-soln day19-input)))))
+    (is (= 439 (t/part2 day19-input)))))

--- a/test/aoc_clj/2020/day20_test.clj
+++ b/test/aoc_clj/2020/day20_test.clj
@@ -208,10 +208,10 @@ Tile 3079:
 
 (def day20-input (u/parse-puzzle-input t/parse 2020 20))
 
-(deftest day20-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day20, part1"
-    (is (= 79412832860579 (t/day20-part1-soln day20-input)))))
+    (is (= 79412832860579 (t/part1 day20-input)))))
 
-(deftest day20-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day20, part2"
-    (is (= 2155 (t/day20-part2-soln day20-input)))))
+    (is (= 2155 (t/part2 day20-input)))))

--- a/test/aoc_clj/2020/day21_test.clj
+++ b/test/aoc_clj/2020/day21_test.clj
@@ -12,11 +12,11 @@
 
 (def day21-input (u/parse-puzzle-input t/parse 2020 21))
 
-(deftest day21-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day21, part1"
-    (is (= 2280 (t/day21-part1-soln day21-input)))))
+    (is (= 2280 (t/part1 day21-input)))))
 
-(deftest day21-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day21, part2"
     (is (= "vfvvnm,bvgm,rdksxt,xknb,hxntcz,bktzrz,srzqtccv,gbtmdb"
-           (t/day21-part2-soln day21-input)))))
+           (t/part2 day21-input)))))

--- a/test/aoc_clj/2020/day22_test.clj
+++ b/test/aoc_clj/2020/day22_test.clj
@@ -49,12 +49,12 @@ Player 2:
 
 (def day22-input (u/parse-puzzle-input t/parse 2020 22))
 
-(deftest day22-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day22, part1"
-    (is (= 33772 (t/day22-part1-soln day22-input)))))
+    (is (= 33772 (t/part1 day22-input)))))
 
 ;; FIXME: 2020.day22 part 2 too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/13
-(deftest ^:slow day22-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day22, part2"
-    (is (= 35070 (t/day22-part2-soln day22-input)))))
+    (is (= 35070 (t/part2 day22-input)))))

--- a/test/aoc_clj/2020/day23_test.clj
+++ b/test/aoc_clj/2020/day23_test.clj
@@ -26,10 +26,10 @@
 
 (def day23-input (u/parse-puzzle-input t/parse 2020 23))
 
-(deftest day23-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day23, part1"
-    (is (= "62934785" (t/day23-part1-soln day23-input)))))
+    (is (= "62934785" (t/part1 day23-input)))))
 
-(deftest ^:slow day23-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day23, part2"
-    (is (= 693659135400 (t/day23-part2-soln day23-input)))))
+    (is (= 693659135400 (t/part2 day23-input)))))

--- a/test/aoc_clj/2020/day24_test.clj
+++ b/test/aoc_clj/2020/day24_test.clj
@@ -51,12 +51,12 @@
 
 (def day24-input (u/parse-puzzle-input t/parse 2020 24))
 
-(deftest day24-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day24, part1"
-    (is (= 436 (t/day24-part1-soln day24-input)))))
+    (is (= 436 (t/part1 day24-input)))))
 
 ;; FIXME: 2020.day24 part 2 too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/14
-(deftest ^:slow day24-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day24, part2"
-    (is (= 4133 (t/day24-part2-soln day24-input)))))
+    (is (= 4133 (t/part2 day24-input)))))

--- a/test/aoc_clj/2020/day25_test.clj
+++ b/test/aoc_clj/2020/day25_test.clj
@@ -13,6 +13,6 @@
 
 (def day25-input (u/parse-puzzle-input t/parse 2020 25))
 
-(deftest day25-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day25, part1"
-    (is (= 6421487 (t/day25-part1-soln day25-input)))))
+    (is (= 6421487 (t/part1 day25-input)))))

--- a/test/aoc_clj/2021/day01_test.clj
+++ b/test/aoc_clj/2021/day01_test.clj
@@ -33,10 +33,10 @@
 
 (def day01-input (u/parse-puzzle-input t/parse 2021 1))
 
-(deftest day01-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day01, part1"
-    (is (= 1292 (t/day01-part1-soln day01-input)))))
+    (is (= 1292 (t/part1 day01-input)))))
 
-(deftest day01-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day01, part2"
-    (is (= 1262 (t/day01-part2-soln day01-input)))))
+    (is (= 1262 (t/part2 day01-input)))))

--- a/test/aoc_clj/2021/day02_test.clj
+++ b/test/aoc_clj/2021/day02_test.clj
@@ -22,10 +22,10 @@
 
 (def day02-input (u/parse-puzzle-input t/parse 2021 2))
 
-(deftest day02-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day02, part1"
-    (is (= 2272262 (t/day02-part1-soln day02-input)))))
+    (is (= 2272262 (t/part1 day02-input)))))
 
-(deftest day02-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day02, part2"
-    (is (= 2134882034 (t/day02-part2-soln day02-input)))))
+    (is (= 2134882034 (t/part2 day02-input)))))

--- a/test/aoc_clj/2021/day03_test.clj
+++ b/test/aoc_clj/2021/day03_test.clj
@@ -27,10 +27,10 @@
 
 (def day03-input (u/parse-puzzle-input t/parse 2021 3))
 
-(deftest day03-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day03, part1"
-    (is (= 3959450 (t/day03-part1-soln day03-input)))))
+    (is (= 3959450 (t/part1 day03-input)))))
 
-(deftest day03-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day03, part2"
-    (is (= 7440311 (t/day03-part2-soln day03-input)))))
+    (is (= 7440311 (t/part2 day03-input)))))

--- a/test/aoc_clj/2021/day04_test.clj
+++ b/test/aoc_clj/2021/day04_test.clj
@@ -35,10 +35,10 @@
 
 (def day04-input (u/parse-puzzle-input t/parse 2021 4))
 
-(deftest day04-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day04, part1"
-    (is (= 23177 (t/day04-part1-soln day04-input)))))
+    (is (= 23177 (t/part1 day04-input)))))
 
-(deftest day04-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day04, part2"
-    (is (= 6804 (t/day04-part2-soln day04-input)))))
+    (is (= 6804 (t/part2 day04-input)))))

--- a/test/aoc_clj/2021/day05_test.clj
+++ b/test/aoc_clj/2021/day05_test.clj
@@ -37,10 +37,10 @@
 
 (def day05-input (u/parse-puzzle-input t/parse 2021 5))
 
-(deftest day05-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day05, part1"
-    (is (= 7674 (t/day05-part1-soln day05-input)))))
+    (is (= 7674 (t/part1 day05-input)))))
 
-(deftest day05-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day05, part2"
-    (is (= 20898 (t/day05-part2-soln day05-input)))))
+    (is (= 20898 (t/part2 day05-input)))))

--- a/test/aoc_clj/2021/day06_test.clj
+++ b/test/aoc_clj/2021/day06_test.clj
@@ -14,10 +14,10 @@
 
 (def day06-input (u/parse-puzzle-input t/parse 2021 6))
 
-(deftest day06-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day06, part1"
-    (is (= 386755 (t/day06-part1-soln day06-input)))))
+    (is (= 386755 (t/part1 day06-input)))))
 
-(deftest day06-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day06, part2"
-    (is (= 1732731810807 (t/day06-part2-soln day06-input)))))
+    (is (= 1732731810807 (t/part2 day06-input)))))

--- a/test/aoc_clj/2021/day07_test.clj
+++ b/test/aoc_clj/2021/day07_test.clj
@@ -15,10 +15,10 @@
 
 (def day07-input (u/parse-puzzle-input t/parse 2021 7))
 
-(deftest day07-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day07, part1"
-    (is (= 349769 (t/day07-part1-soln day07-input)))))
+    (is (= 349769 (t/part1 day07-input)))))
 
-(deftest day07-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day07, part2"
-    (is (= 99540554 (t/day07-part2-soln day07-input)))))
+    (is (= 99540554 (t/part2 day07-input)))))

--- a/test/aoc_clj/2021/day08_test.clj
+++ b/test/aoc_clj/2021/day08_test.clj
@@ -35,10 +35,10 @@
 
 (def day08-input (u/parse-puzzle-input t/parse 2021 8))
 
-(deftest day08-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day08, part1"
-    (is (= 493 (t/day08-part1-soln day08-input)))))
+    (is (= 493 (t/part1 day08-input)))))
 
-(deftest day08-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day08, part2"
-    (is (= 1010460 (t/day08-part2-soln day08-input)))))
+    (is (= 1010460 (t/part2 day08-input)))))

--- a/test/aoc_clj/2021/day09_test.clj
+++ b/test/aoc_clj/2021/day09_test.clj
@@ -21,10 +21,10 @@
 
 (def day09-input (u/parse-puzzle-input t/parse 2021 9))
 
-(deftest day09-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day09, part1"
-    (is (= 588 (t/day09-part1-soln day09-input)))))
+    (is (= 588 (t/part1 day09-input)))))
 
-(deftest day09-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day09, part2"
-    (is (= 964712 (t/day09-part2-soln day09-input)))))
+    (is (= 964712 (t/part2 day09-input)))))

--- a/test/aoc_clj/2021/day10_test.clj
+++ b/test/aoc_clj/2021/day10_test.clj
@@ -30,10 +30,10 @@
 
 (def day10-input (u/parse-puzzle-input t/parse 2021 10))
 
-(deftest day10-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day10, part1"
-    (is (= 394647 (t/day10-part1-soln day10-input)))))
+    (is (= 394647 (t/part1 day10-input)))))
 
-(deftest day10-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day10, part2"
-    (is (= 2380061249 (t/day10-part2-soln day10-input)))))
+    (is (= 2380061249 (t/part2 day10-input)))))

--- a/test/aoc_clj/2021/day11_test.clj
+++ b/test/aoc_clj/2021/day11_test.clj
@@ -26,10 +26,10 @@
 
 (def day11-input (u/parse-puzzle-input t/parse 2021 11))
 
-(deftest day11-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day11, part1"
-    (is (= 1634 (t/day11-part1-soln day11-input)))))
+    (is (= 1634 (t/part1 day11-input)))))
 
-(deftest day11-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day11, part2"
-    (is (= 210 (t/day11-part2-soln day11-input)))))
+    (is (= 210 (t/part2 day11-input)))))

--- a/test/aoc_clj/2021/day12_test.clj
+++ b/test/aoc_clj/2021/day12_test.clj
@@ -61,10 +61,10 @@
 
 (def day12-input (u/parse-puzzle-input t/parse 2021 12))
 
-(deftest day12-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day12, part1"
-    (is (= 5874 (t/day12-part1-soln day12-input)))))
+    (is (= 5874 (t/part1 day12-input)))))
 
-(deftest ^:slow day12-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day12, part2"
-    (is (= 153592 (t/day12-part2-soln day12-input)))))
+    (is (= 153592 (t/part2 day12-input)))))

--- a/test/aoc_clj/2021/day13_test.clj
+++ b/test/aoc_clj/2021/day13_test.clj
@@ -42,10 +42,10 @@
 
 (def day13-input (u/parse-puzzle-input t/parse 2021 13))
 
-(deftest day13-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day13, part1"
-    (is (= 621 (t/day13-part1-soln day13-input)))))
+    (is (= 621 (t/part1 day13-input)))))
 
-(deftest day13-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day13, part2"
-    (is (= "HKUJGAJZ" (t/day13-part2-soln day13-input)))))
+    (is (= "HKUJGAJZ" (t/part2 day13-input)))))

--- a/test/aoc_clj/2021/day14_test.clj
+++ b/test/aoc_clj/2021/day14_test.clj
@@ -46,10 +46,10 @@
 
 (def day14-input (u/parse-puzzle-input t/parse 2021 14))
 
-(deftest day14-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day14, part1"
-    (is (= 2712 (t/day14-part1-soln day14-input)))))
+    (is (= 2712 (t/part1 day14-input)))))
 
-(deftest day14-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day14, part2"
-    (is (= 8336623059567 (t/day14-part2-soln day14-input)))))
+    (is (= 8336623059567 (t/part2 day14-input)))))

--- a/test/aoc_clj/2021/day15_test.clj
+++ b/test/aoc_clj/2021/day15_test.clj
@@ -31,10 +31,10 @@
 
 (def day15-input (u/parse-puzzle-input t/parse 2021 15))
 
-(deftest day15-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day15, part1"
-    (is (= 508 (t/day15-part1-soln day15-input)))))
+    (is (= 508 (t/part1 day15-input)))))
 
-(deftest day15-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day15, part2"
-    (is (= 2872 (t/day15-part2-soln day15-input)))))
+    (is (= 2872 (t/part2 day15-input)))))

--- a/test/aoc_clj/2021/day16_test.clj
+++ b/test/aoc_clj/2021/day16_test.clj
@@ -55,10 +55,10 @@
 
 (def day16-input (u/parse-puzzle-input t/parse 2021 16))
 
-(deftest day16-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day16, part1"
-    (is (= 981 (t/day16-part1-soln day16-input)))))
+    (is (= 981 (t/part1 day16-input)))))
 
-(deftest day16-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day16, part2"
-    (is (= 299227024091 (t/day16-part2-soln day16-input)))))
+    (is (= 299227024091 (t/part2 day16-input)))))

--- a/test/aoc_clj/2021/day17_test.clj
+++ b/test/aoc_clj/2021/day17_test.clj
@@ -20,10 +20,10 @@
 
 (def day17-input (u/parse-puzzle-input t/parse 2021 17))
 
-(deftest day17-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day17, part1"
-    (is (= 2701 (t/day17-part1-soln day17-input)))))
+    (is (= 2701 (t/part1 day17-input)))))
 
-(deftest day17-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day17, part2"
-    (is (= 1070 (t/day17-part2-soln day17-input)))))
+    (is (= 1070 (t/part2 day17-input)))))

--- a/test/aoc_clj/2021/day18_test.clj
+++ b/test/aoc_clj/2021/day18_test.clj
@@ -96,10 +96,10 @@
 
 (def day18-input (u/parse-puzzle-input t/parse 2021 18))
 
-(deftest day18-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day18, part1"
-    (is (= 3647 (t/day18-part1-soln day18-input)))))
+    (is (= 3647 (t/part1 day18-input)))))
 
-(deftest ^:slow day18-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day18, part2"
-    (is (= 4600 (t/day18-part2-soln day18-input)))))
+    (is (= 4600 (t/part2 day18-input)))))

--- a/test/aoc_clj/2021/day19_test.clj
+++ b/test/aoc_clj/2021/day19_test.clj
@@ -34,10 +34,10 @@
 
 ;; FIXME: 2021.day19 is too slow to unit test
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/7
-(deftest ^:slow day19-part1-soln
+(deftest ^:slow part1
   (testing "Reproduces the answer for day19, part1"
-    (is (= 449 (t/day19-part1-soln day19-input)))))
+    (is (= 449 (t/part1 day19-input)))))
 
-(deftest ^:slow day19-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day19, part2"
-    (is (= 13128 (t/day19-part2-soln day19-input)))))
+    (is (= 13128 (t/part2 day19-input)))))

--- a/test/aoc_clj/2021/day20_test.clj
+++ b/test/aoc_clj/2021/day20_test.clj
@@ -20,12 +20,12 @@
 
 (def day20-input (u/parse-puzzle-input t/parse 2021 20))
 
-(deftest day20-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day20, part1"
-    (is (= 5097 (t/day20-part1-soln day20-input)))))
+    (is (= 5097 (t/part1 day20-input)))))
 
 ;; FIXME: 2021.day20 part 2 is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/10
-(deftest ^:slow day20-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day20, part2"
-    (is (= 17987 (t/day20-part2-soln day20-input)))))
+    (is (= 17987 (t/part2 day20-input)))))

--- a/test/aoc_clj/2021/day21_test.clj
+++ b/test/aoc_clj/2021/day21_test.clj
@@ -29,10 +29,10 @@
 
 (def day21-input (u/parse-puzzle-input t/parse 2021 21))
 
-(deftest day21-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day21, part1"
-    (is (= 707784 (t/day21-part1-soln day21-input)))))
+    (is (= 707784 (t/part1 day21-input)))))
 
-(deftest day21-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day21, part2"
-    (is (= 157595953724471 (t/day21-part2-soln day21-input)))))
+    (is (= 157595953724471 (t/part2 day21-input)))))

--- a/test/aoc_clj/2021/day22_test.clj
+++ b/test/aoc_clj/2021/day22_test.clj
@@ -49,12 +49,12 @@
 
 (def day22-input (u/parse-puzzle-input t/parse 2021 22))
 
-(deftest day22-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day22, part1"
-    (is (= 503864 (t/day22-part1-soln day22-input)))))
+    (is (= 503864 (t/part1 day22-input)))))
 
 ;; FIXME 2021.day22 part2 is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/8
-(deftest ^:slow day22-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day22, part2"
-    (is (= 1255547543528356 (t/day22-part2-soln day22-input)))))
+    (is (= 1255547543528356 (t/part2 day22-input)))))

--- a/test/aoc_clj/2021/day23_test.clj
+++ b/test/aoc_clj/2021/day23_test.clj
@@ -71,10 +71,10 @@
 
 (def day23-input (u/parse-puzzle-input t/parse 2021 23))
 
-(deftest day23-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day23, part1"
-    (is (= 16489 (t/day23-part1-soln day23-input)))))
+    (is (= 16489 (t/part1 day23-input)))))
 
-(deftest day23-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day23, part2"
-    (is (= 43413 (t/day23-part2-soln day23-input)))))
+    (is (= 43413 (t/part2 day23-input)))))

--- a/test/aoc_clj/2021/day24_test.clj
+++ b/test/aoc_clj/2021/day24_test.clj
@@ -31,12 +31,12 @@
 
 (def day24-input (u/parse-puzzle-input t/parse 2021 24))
 
-(deftest day24-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day24, part1"
-    (is (= 98998519596997 (t/day24-part1-soln day24-input)))))
+    (is (= 98998519596997 (t/part1 day24-input)))))
 
 ;; FIXME: 2021.day24 part 2 solution is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/11
-(deftest ^:slow day24-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day24, part2"
-    (is (= 31521119151421 (t/day24-part2-soln day24-input)))))
+    (is (= 31521119151421 (t/part2 day24-input)))))

--- a/test/aoc_clj/2021/day25_test.clj
+++ b/test/aoc_clj/2021/day25_test.clj
@@ -23,7 +23,7 @@
 
 ;; FIXME: 2021.day25 solution is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/9
-(deftest ^:slow day25-part1-soln
+(deftest ^:slow part1
   (testing "Reproduces the answer for day25, part1"
-    (is (= 429 (t/day25-part1-soln day25-input)))))
+    (is (= 429 (t/part1 day25-input)))))
 

--- a/test/aoc_clj/2022/day01_test.clj
+++ b/test/aoc_clj/2022/day01_test.clj
@@ -32,10 +32,10 @@
 
 (def day01-input (u/parse-puzzle-input t/parse 2022 1))
 
-(deftest day01-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day01, part1"
-    (is (= 70116 (t/day01-part1-soln day01-input)))))
+    (is (= 70116 (t/part1 day01-input)))))
 
-(deftest day01-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day01, part2"
-    (is (= 206582 (t/day01-part2-soln day01-input)))))
+    (is (= 206582 (t/part2 day01-input)))))

--- a/test/aoc_clj/2022/day02_test.clj
+++ b/test/aoc_clj/2022/day02_test.clj
@@ -34,10 +34,10 @@
 
 (def day02-input (u/parse-puzzle-input t/parse 2022 2))
 
-(deftest day02-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day02, part1"
-    (is (= 11906 (t/day02-part1-soln day02-input)))))
+    (is (= 11906 (t/part1 day02-input)))))
 
-(deftest day02-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day02, part2"
-    (is (= 11186 (t/day02-part2-soln day02-input)))))
+    (is (= 11186 (t/part2 day02-input)))))

--- a/test/aoc_clj/2022/day03_test.clj
+++ b/test/aoc_clj/2022/day03_test.clj
@@ -35,10 +35,10 @@
 
 (def day03-input (u/parse-puzzle-input t/parse 2022 3))
 
-(deftest day03-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day03, part1"
-    (is (= 7597 (t/day03-part1-soln day03-input)))))
+    (is (= 7597 (t/part1 day03-input)))))
 
-(deftest day03-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day03, part2"
-    (is (= 2607 (t/day03-part2-soln day03-input)))))
+    (is (= 2607 (t/part2 day03-input)))))

--- a/test/aoc_clj/2022/day04_test.clj
+++ b/test/aoc_clj/2022/day04_test.clj
@@ -24,10 +24,10 @@
 
 (def day04-input (u/parse-puzzle-input t/parse 2022 4))
 
-(deftest day04-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day04, part1"
-    (is (= 584 (t/day04-part1-soln day04-input)))))
+    (is (= 584 (t/part1 day04-input)))))
 
-(deftest day04-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day04, part2"
-    (is (= 933 (t/day04-part2-soln day04-input)))))
+    (is (= 933 (t/part2 day04-input)))))

--- a/test/aoc_clj/2022/day05_test.clj
+++ b/test/aoc_clj/2022/day05_test.clj
@@ -108,10 +108,10 @@
 
 (def day05-input (u/parse-puzzle-input t/parse 2022 5))
 
-(deftest day05-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day05, part1"
-    (is (= "CNSZFDVLJ" (t/day05-part1-soln day05-input)))))
+    (is (= "CNSZFDVLJ" (t/part1 day05-input)))))
 
-(deftest day05-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day05, part2"
-    (is (= "QNDWLMGNS" (t/day05-part2-soln day05-input)))))
+    (is (= "QNDWLMGNS" (t/part2 day05-input)))))

--- a/test/aoc_clj/2022/day06_test.clj
+++ b/test/aoc_clj/2022/day06_test.clj
@@ -33,10 +33,10 @@
 
 (def day06-input (u/parse-puzzle-input t/parse 2022 6))
 
-(deftest day06-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day06, part1"
-    (is (= 1855 (t/day06-part1-soln day06-input)))))
+    (is (= 1855 (t/part1 day06-input)))))
 
-(deftest day06-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day06, part2"
-    (is (= 3256 (t/day06-part2-soln day06-input)))))
+    (is (= 3256 (t/part2 day06-input)))))

--- a/test/aoc_clj/2022/day07_test.clj
+++ b/test/aoc_clj/2022/day07_test.clj
@@ -71,10 +71,10 @@
 
 (def day07-input (u/parse-puzzle-input t/parse 2022 7))
 
-(deftest day07-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day07, part1"
-    (is (= 1306611 (t/day07-part1-soln day07-input)))))
+    (is (= 1306611 (t/part1 day07-input)))))
 
-(deftest day07-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day07, part2"
-    (is (= 13210366 (t/day07-part2-soln day07-input)))))
+    (is (= 13210366 (t/part2 day07-input)))))

--- a/test/aoc_clj/2022/day08_test.clj
+++ b/test/aoc_clj/2022/day08_test.clj
@@ -60,10 +60,10 @@
 
 (def day08-input (u/parse-puzzle-input t/parse 2022 8))
 
-(deftest day08-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day08, part1"
-    (is (= 1538 (t/day08-part1-soln day08-input)))))
+    (is (= 1538 (t/part1 day08-input)))))
 
-(deftest day08-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day08, part2"
-    (is (= 496125 (t/day08-part2-soln day08-input)))))
+    (is (= 496125 (t/part2 day08-input)))))

--- a/test/aoc_clj/2022/day09_test.clj
+++ b/test/aoc_clj/2022/day09_test.clj
@@ -55,10 +55,10 @@
 
 (def day09-input (u/parse-puzzle-input t/parse 2022 9))
 
-(deftest day09-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day09, part1"
-    (is (= 5874 (t/day09-part1-soln day09-input)))))
+    (is (= 5874 (t/part1 day09-input)))))
 
-(deftest day09-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day09, part2"
-    (is (= 2467 (t/day09-part2-soln day09-input)))))
+    (is (= 2467 (t/part2 day09-input)))))

--- a/test/aoc_clj/2022/day10_test.clj
+++ b/test/aoc_clj/2022/day10_test.clj
@@ -185,10 +185,10 @@
 
 (def day10-input (u/parse-puzzle-input t/parse 2022 10))
 
-(deftest day10-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day10, part1"
-    (is (= 16020 (t/day10-part1-soln day10-input)))))
+    (is (= 16020 (t/part1 day10-input)))))
 
-(deftest day10-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day10, part2"
-    (is (= "ECZUZALR" (t/day10-part2-soln day10-input)))))
+    (is (= "ECZUZALR" (t/part2 day10-input)))))

--- a/test/aoc_clj/2022/day11_test.clj
+++ b/test/aoc_clj/2022/day11_test.clj
@@ -108,10 +108,10 @@
 
 (def day11-input (u/parse-puzzle-input t/parse 2022 11))
 
-(deftest day11-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day11, part1"
-    (is (= 112221 (t/day11-part1-soln day11-input)))))
+    (is (= 112221 (t/part1 day11-input)))))
 
-(deftest day11-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day11, part2"
-    (is (= 25272176808 (t/day11-part2-soln day11-input)))))
+    (is (= 25272176808 (t/part2 day11-input)))))

--- a/test/aoc_clj/2022/day12_test.clj
+++ b/test/aoc_clj/2022/day12_test.clj
@@ -21,10 +21,10 @@
 
 (def day12-input (u/parse-puzzle-input t/parse 2022 12))
 
-(deftest day12-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day12, part1"
-    (is (= 408 (t/day12-part1-soln day12-input)))))
+    (is (= 408 (t/part1 day12-input)))))
 
-(deftest day12-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day12, part2"
-    (is (= 399 (t/day12-part2-soln day12-input)))))
+    (is (= 399 (t/part2 day12-input)))))

--- a/test/aoc_clj/2022/day13_test.clj
+++ b/test/aoc_clj/2022/day13_test.clj
@@ -91,10 +91,10 @@
 
 (def day13-input (u/parse-puzzle-input t/parse 2022 13))
 
-(deftest day13-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day13, part1"
-    (is (= 5503 (t/day13-part1-soln day13-input)))))
+    (is (= 5503 (t/part1 day13-input)))))
 
-(deftest day13-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day13, part2"
-    (is (= 20952 (t/day13-part2-soln day13-input)))))
+    (is (= 20952 (t/part2 day13-input)))))

--- a/test/aoc_clj/2022/day14_test.clj
+++ b/test/aoc_clj/2022/day14_test.clj
@@ -75,10 +75,10 @@
 
 (def day14-input (u/parse-puzzle-input t/parse 2022 14))
 
-(deftest day14-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day14, part1"
-    (is (= 913 (t/day14-part1-soln day14-input)))))
+    (is (= 913 (t/part1 day14-input)))))
 
-(deftest day14-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day14, part2"
-    (is (= 30762 (t/day14-part2-soln day14-input)))))
+    (is (= 30762 (t/part2 day14-input)))))

--- a/test/aoc_clj/2022/day15_test.clj
+++ b/test/aoc_clj/2022/day15_test.clj
@@ -53,10 +53,10 @@
 
 (def day15-input (u/parse-puzzle-input t/parse 2022 15))
 
-(deftest day15-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day15, part1"
-    (is (= 4907780 (t/day15-part1-soln day15-input)))))
+    (is (= 4907780 (t/part1 day15-input)))))
 
-(deftest day15-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day15, part2"
-    (is (= 13639962836448 (t/day15-part2-soln day15-input)))))
+    (is (= 13639962836448 (t/part2 day15-input)))))

--- a/test/aoc_clj/2022/day16_test.clj
+++ b/test/aoc_clj/2022/day16_test.clj
@@ -52,10 +52,10 @@
 ;; FIXME: The implementation is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/28
 
-(deftest ^:slow day16-part1-soln
+(deftest ^:slow part1
   (testing "Reproduces the answer for day16, part1"
-    (is (= 1701 (t/day16-part1-soln day16-input)))))
+    (is (= 1701 (t/part1 day16-input)))))
 
-(deftest ^:slow day16-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day16, part2"
-    (is (= 2455 (t/day16-part2-soln day16-input)))))
+    (is (= 2455 (t/part2 day16-input)))))

--- a/test/aoc_clj/2022/day17_test.clj
+++ b/test/aoc_clj/2022/day17_test.clj
@@ -27,10 +27,10 @@
 
 (def day17-input (u/parse-puzzle-input t/parse 2022 17))
 
-(deftest day17-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day17, part1"
-    (is (= 3171 (t/day17-part1-soln day17-input)))))
+    (is (= 3171 (t/part1 day17-input)))))
 
-(deftest day17-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day17, part2"
-    (is (= 1586627906921 (t/day17-part2-soln day17-input)))))
+    (is (= 1586627906921 (t/part2 day17-input)))))

--- a/test/aoc_clj/2022/day18_test.clj
+++ b/test/aoc_clj/2022/day18_test.clj
@@ -35,10 +35,10 @@
 
 (def day18-input (u/parse-puzzle-input t/parse 2022 18))
 
-(deftest day18-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day18, part1"
-    (is (= 3390 (t/day18-part1-soln day18-input)))))
+    (is (= 3390 (t/part1 day18-input)))))
 
-(deftest day18-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day18, part2"
-    (is (= 2058 (t/day18-part2-soln day18-input)))))
+    (is (= 2058 (t/part2 day18-input)))))

--- a/test/aoc_clj/2022/day19_test.clj
+++ b/test/aoc_clj/2022/day19_test.clj
@@ -42,10 +42,10 @@
 
 ;; FIXME: Solution is too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/33
-(deftest ^:slow day19-part1-soln
+(deftest ^:slow part1
   (testing "Reproduces the answer for day19, part1"
-    (is (= 1395 (t/day19-part1-soln day19-input)))))
+    (is (= 1395 (t/part1 day19-input)))))
 
-(deftest ^:slow day19-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day19, part2"
-    (is (= 2700 (t/day19-part2-soln day19-input)))))
+    (is (= 2700 (t/part2 day19-input)))))

--- a/test/aoc_clj/2022/day20_test.clj
+++ b/test/aoc_clj/2022/day20_test.clj
@@ -45,10 +45,10 @@
 
 ;; FIXME: Implementation is far too slow
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/29
-(deftest ^:slow day20-part1-soln
+(deftest ^:slow part1
   (testing "Reproduces the answer for day20, part1"
-    (is (= 9866 (t/day20-part1-soln day20-input)))))
+    (is (= 9866 (t/part1 day20-input)))))
 
-(deftest ^:slow day20-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day20, part2"
-    (is (= 12374299815791 (t/day20-part2-soln day20-input)))))
+    (is (= 12374299815791 (t/part2 day20-input)))))

--- a/test/aoc_clj/2022/day21_test.clj
+++ b/test/aoc_clj/2022/day21_test.clj
@@ -62,10 +62,10 @@
 
 (def day21-input (u/parse-puzzle-input t/parse 2022 21))
 
-(deftest day21-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day21, part1"
-    (is (= 63119856257960 (t/day21-part1-soln day21-input)))))
+    (is (= 63119856257960 (t/part1 day21-input)))))
 
-(deftest day21-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day21, part2"
-    (is (= 3006709232464 (t/day21-part2-soln day21-input)))))
+    (is (= 3006709232464 (t/part2 day21-input)))))

--- a/test/aoc_clj/2022/day22_test.clj
+++ b/test/aoc_clj/2022/day22_test.clj
@@ -84,10 +84,10 @@
 
 (def day22-input (u/parse-puzzle-input t/parse 2022 22))
 
-(deftest day22-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day22, part1"
-    (is (= 1428 (t/day22-part1-soln day22-input)))))
+    (is (= 1428 (t/part1 day22-input)))))
 
-(deftest day22-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day22, part2"
-    (is (= 142380 (t/day22-part2-soln day22-input)))))
+    (is (= 142380 (t/part2 day22-input)))))

--- a/test/aoc_clj/2022/day23_test.clj
+++ b/test/aoc_clj/2022/day23_test.clj
@@ -73,12 +73,12 @@
 
 (def day23-input (u/parse-puzzle-input t/parse 2022 23))
 
-(deftest day23-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day23, part1"
-    (is (= 4172 (t/day23-part1-soln day23-input)))))
+    (is (= 4172 (t/part1 day23-input)))))
 
 ;; TODO - Investigate whether there's a faster approach to part 2
 ;; https://github.com/Ken-2scientists/aoc-clj/issues/30
-(deftest ^:slow day23-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day23, part2"
-    (is (= 942 (t/day23-part2-soln day23-input)))))
+    (is (= 942 (t/part2 day23-input)))))

--- a/test/aoc_clj/2022/day24_test.clj
+++ b/test/aoc_clj/2022/day24_test.clj
@@ -111,10 +111,10 @@
 
 (def day24-input (u/parse-puzzle-input t/parse 2022 24))
 
-(deftest day24-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day24, part1"
-    (is (= 286 (t/day24-part1-soln day24-input)))))
+    (is (= 286 (t/part1 day24-input)))))
 
-(deftest day24-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day24, part2"
-    (is (= 820 (t/day24-part2-soln day24-input)))))
+    (is (= 820 (t/part2 day24-input)))))

--- a/test/aoc_clj/2022/day25_test.clj
+++ b/test/aoc_clj/2022/day25_test.clj
@@ -98,7 +98,7 @@
 
 (def day25-input (u/parse-puzzle-input t/parse 2022 25))
 
-(deftest day25-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day25, part1"
     (is (= "2=--00--0220-0-21==1"
-           (t/day25-part1-soln day25-input)))))
+           (t/part1 day25-input)))))

--- a/test/aoc_clj/2023/day01_test.clj
+++ b/test/aoc_clj/2023/day01_test.clj
@@ -54,10 +54,10 @@
 
 (def day01-input (u/parse-puzzle-input t/parse 2023 1))
 
-(deftest day01-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day01, part1"
-    (is (= 55172 (t/day01-part1-soln day01-input)))))
+    (is (= 55172 (t/part1 day01-input)))))
 
-(deftest day01-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day01, part2"
-    (is (= 54925 (t/day01-part2-soln day01-input)))))
+    (is (= 54925 (t/part2 day01-input)))))

--- a/test/aoc_clj/2023/day02_test.clj
+++ b/test/aoc_clj/2023/day02_test.clj
@@ -57,10 +57,10 @@
 
 (def day02-input (u/parse-puzzle-input t/parse 2023 2))
 
-(deftest day02-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day02, part1"
-    (is (= 2162 (t/day02-part1-soln day02-input)))))
+    (is (= 2162 (t/part1 day02-input)))))
 
-(deftest day02-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day02, part2"
-    (is (= 72513 (t/day02-part2-soln day02-input)))))
+    (is (= 72513 (t/part2 day02-input)))))

--- a/test/aoc_clj/2023/day03_test.clj
+++ b/test/aoc_clj/2023/day03_test.clj
@@ -50,10 +50,10 @@
 
 (def day03-input (u/parse-puzzle-input t/parse 2023 3))
 
-(deftest day03-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day03, part1"
-    (is (= 509115 (t/day03-part1-soln day03-input)))))
+    (is (= 509115 (t/part1 day03-input)))))
 
-(deftest day03-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day03, part2"
-    (is (= 75220503 (t/day03-part2-soln day03-input)))))
+    (is (= 75220503 (t/part2 day03-input)))))

--- a/test/aoc_clj/2023/day04_test.clj
+++ b/test/aoc_clj/2023/day04_test.clj
@@ -57,10 +57,10 @@
 
 (def day04-input (u/parse-puzzle-input t/parse 2023 4))
 
-(deftest day04-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day04, part1"
-    (is (= 27059 (t/day04-part1-soln day04-input)))))
+    (is (= 27059 (t/part1 day04-input)))))
 
-(deftest day04-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day04, part2"
-    (is (= 5744979 (t/day04-part2-soln day04-input)))))
+    (is (= 5744979 (t/part2 day04-input)))))

--- a/test/aoc_clj/2023/day06_test.clj
+++ b/test/aoc_clj/2023/day06_test.clj
@@ -38,10 +38,10 @@
 
 (def day06-input (u/parse-puzzle-input t/parse 2023 6))
 
-(deftest day06-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day06, part1"
-    (is (= 2344708 (t/day06-part1-soln day06-input)))))
+    (is (= 2344708 (t/part1 day06-input)))))
 
-(deftest day06-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day06, part2"
-    (is (= 30125202 (t/day06-part2-soln day06-input)))))
+    (is (= 30125202 (t/part2 day06-input)))))

--- a/test/aoc_clj/2023/day07_test.clj
+++ b/test/aoc_clj/2023/day07_test.clj
@@ -68,10 +68,10 @@
 
 (def day07-input (u/parse-puzzle-input t/parse 2023 7))
 
-(deftest day07-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day07, part1"
-    (is (= 248396258 (t/day07-part1-soln day07-input)))))
+    (is (= 248396258 (t/part1 day07-input)))))
 
-(deftest day07-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day07, part2"
-    (is (= 246436046 (t/day07-part2-soln day07-input)))))
+    (is (= 246436046 (t/part2 day07-input)))))

--- a/test/aoc_clj/2023/day08_test.clj
+++ b/test/aoc_clj/2023/day08_test.clj
@@ -79,10 +79,10 @@
 
 (def day08-input (u/parse-puzzle-input t/parse 2023 8))
 
-(deftest day08-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day08, part1"
-    (is (= 12169 (t/day08-part1-soln day08-input)))))
+    (is (= 12169 (t/part1 day08-input)))))
 
-(deftest day08-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day08, part2"
-    (is (= 12030780859469 (t/day08-part2-soln day08-input)))))
+    (is (= 12030780859469 (t/part2 day08-input)))))

--- a/test/aoc_clj/2023/day09_test.clj
+++ b/test/aoc_clj/2023/day09_test.clj
@@ -34,10 +34,10 @@
 
 (def day09-input (u/parse-puzzle-input t/parse 2023 9))
 
-(deftest day09-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day09, part1"
-    (is (= 1647269739 (t/day09-part1-soln day09-input)))))
+    (is (= 1647269739 (t/part1 day09-input)))))
 
-(deftest day09-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day09, part2"
-    (is (= 864 (t/day09-part2-soln day09-input)))))
+    (is (= 864 (t/part2 day09-input)))))

--- a/test/aoc_clj/2023/day10_test.clj
+++ b/test/aoc_clj/2023/day10_test.clj
@@ -92,10 +92,10 @@
 
 (def day10-input (u/parse-puzzle-input t/parse 2023 10))
 
-(deftest day02-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day10, part1"
-    (is (= 7093 (t/day10-part1-soln day10-input)))))
+    (is (= 7093 (t/part1 day10-input)))))
 
-(deftest day02-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day10, part2"
-    (is (= 407 (t/day10-part2-soln day10-input)))))
+    (is (= 407 (t/part2 day10-input)))))

--- a/test/aoc_clj/2023/day11_test.clj
+++ b/test/aoc_clj/2023/day11_test.clj
@@ -55,11 +55,11 @@
 
 (def day11-input (u/parse-puzzle-input t/parse 2023 11))
 
-(deftest day11-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day11, part1"
-    (is (= 9312968 (t/day11-part1-soln day11-input)))))
+    (is (= 9312968 (t/part1 day11-input)))))
 
-(deftest day11-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day11, part2"
-    (is (= 597714117556 (t/day11-part2-soln day11-input)))))
+    (is (= 597714117556 (t/part2 day11-input)))))
 

--- a/test/aoc_clj/2023/day12_test.clj
+++ b/test/aoc_clj/2023/day12_test.clj
@@ -66,10 +66,10 @@
 
 (def day12-input (u/parse-puzzle-input t/parse 2023 12))
 
-(deftest day12-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day12, part1"
-    (is (= 8193 (t/day12-part1-soln day12-input)))))
+    (is (= 8193 (t/part1 day12-input)))))
 
-(deftest day12-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day12, part2"
-    (is (= 45322533163795 (t/day12-part2-soln day12-input)))))
+    (is (= 45322533163795 (t/part2 day12-input)))))

--- a/test/aoc_clj/2023/day13_test.clj
+++ b/test/aoc_clj/2023/day13_test.clj
@@ -52,10 +52,10 @@
 
 (def day13-input (u/parse-puzzle-input t/parse 2023 13))
 
-(deftest day13-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day13, part1"
-    (is (= 33195 (t/day13-part1-soln day13-input)))))
+    (is (= 33195 (t/part1 day13-input)))))
 
-(deftest day13-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day13, part2"
-    (is (= 31836 (t/day13-part2-soln day13-input)))))
+    (is (= 31836 (t/part2 day13-input)))))

--- a/test/aoc_clj/2023/day15_test.clj
+++ b/test/aoc_clj/2023/day15_test.clj
@@ -84,10 +84,10 @@
 
 (def day15-input (u/parse-puzzle-input t/parse 2023 15))
 
-(deftest day15-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day15, part1"
-    (is (= 511215 (t/day15-part1-soln day15-input)))))
+    (is (= 511215 (t/part1 day15-input)))))
 
-(deftest day15-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day15, part2"
-    (is (= 236057 (t/day15-part2-soln day15-input)))))
+    (is (= 236057 (t/part2 day15-input)))))

--- a/test/aoc_clj/2023/day16_test.clj
+++ b/test/aoc_clj/2023/day16_test.clj
@@ -53,10 +53,10 @@
 
 (def day16-input (u/parse-puzzle-input t/parse 2023 16))
 
-(deftest day16-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day16, part1"
-    (is (= 8034 (t/day16-part1-soln day16-input)))))
+    (is (= 8034 (t/part1 day16-input)))))
 
-(deftest day16-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day16, part2"
-    (is (= 8225 (t/day16-part2-soln day16-input)))))
+    (is (= 8225 (t/part2 day16-input)))))

--- a/test/aoc_clj/2023/day18_test.clj
+++ b/test/aoc_clj/2023/day18_test.clj
@@ -77,10 +77,10 @@
 
 (def day18-input (u/parse-puzzle-input t/parse 2023 18))
 
-(deftest day18-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day18, part1"
-    (is (= 66993 (t/day18-part1-soln day18-input)))))
+    (is (= 66993 (t/part1 day18-input)))))
 
-(deftest day18-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day18, part2"
-    (is (= 177243763226648 (t/day18-part2-soln day18-input)))))
+    (is (= 177243763226648 (t/part2 day18-input)))))

--- a/test/aoc_clj/2023/day19_test.clj
+++ b/test/aoc_clj/2023/day19_test.clj
@@ -131,10 +131,10 @@
 
 (def day19-input (u/parse-puzzle-input t/parse 2023 19))
 
-(deftest day19-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day19, part1"
-    (is (= 319062 (t/day19-part1-soln day19-input)))))
+    (is (= 319062 (t/part1 day19-input)))))
 
-(deftest day19-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day19, part2"
-    (is (= 118638369682135 (t/day19-part2-soln day19-input)))))
+    (is (= 118638369682135 (t/part2 day19-input)))))

--- a/test/aoc_clj/2023/day20_test.clj
+++ b/test/aoc_clj/2023/day20_test.clj
@@ -97,10 +97,10 @@
 
 (def day20-input (u/parse-puzzle-input t/parse 2023 20))
 
-(deftest day20-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day20, part1"
-    (is (= 821985143 (t/day20-part1-soln day20-input)))))
+    (is (= 821985143 (t/part1 day20-input)))))
 
-(deftest day20-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day20, part2"
-    (is (= 240853834793347 (t/day20-part2-soln day20-input)))))
+    (is (= 240853834793347 (t/part2 day20-input)))))

--- a/test/aoc_clj/2023/day21_test.clj
+++ b/test/aoc_clj/2023/day21_test.clj
@@ -59,6 +59,6 @@
 
 (def day21-input (u/parse-puzzle-input t/parse 2023 21))
 
-(deftest day21-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day21, part1"
-    (is (= 3764 (t/day21-part1-soln day21-input)))))
+    (is (= 3764 (t/part1 day21-input)))))

--- a/test/aoc_clj/2023/day22_test.clj
+++ b/test/aoc_clj/2023/day22_test.clj
@@ -124,10 +124,10 @@
 
 (def day22-input (u/parse-puzzle-input t/parse 2023 22))
 
-(deftest day22-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day22, part1"
-    (is (= 418 (t/day22-part1-soln day22-input)))))
+    (is (= 418 (t/part1 day22-input)))))
 
-(deftest day22-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day22, part2"
-    (is (= 70702 (t/day22-part2-soln day22-input)))))
+    (is (= 70702 (t/part2 day22-input)))))

--- a/test/aoc_clj/2023/day23_test.clj
+++ b/test/aoc_clj/2023/day23_test.clj
@@ -96,10 +96,10 @@
 
 (def day23-input (u/parse-puzzle-input t/parse 2023 23))
 
-(deftest day23-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day23, part1"
-    (is (= 2334 (t/day23-part1-soln day23-input)))))
+    (is (= 2334 (t/part1 day23-input)))))
 
-(deftest ^:slow day23-part2-soln
+(deftest ^:slow part2
   (testing "Reproduces the answer for day23, part2"
-    (is (= 6422 (t/day23-part2-soln day23-input)))))
+    (is (= 6422 (t/part2 day23-input)))))

--- a/test/aoc_clj/2023/day24_test.clj
+++ b/test/aoc_clj/2023/day24_test.clj
@@ -49,11 +49,11 @@
 
 (def day24-input (u/parse-puzzle-input t/parse 2023 24))
 
-(deftest day24-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day24, part1"
-    (is (= 16172 (t/day24-part1-soln day24-input)))))
+    (is (= 16172 (t/part1 day24-input)))))
 
 (apply t/rock-parameters (take 3 day24-input))
-(deftest day24-part2-soln
+(deftest part2-test
   (testing "Reproduces the answer for day24, part2"
-    (is (= 600352360036779 (t/day24-part2-soln day24-input)))))
+    (is (= 600352360036779 (t/part2 day24-input)))))

--- a/test/aoc_clj/2023/day25_test.clj
+++ b/test/aoc_clj/2023/day25_test.clj
@@ -84,6 +84,6 @@
 
 (def day25-input (u/parse-puzzle-input t/parse 2023 25))
 
-(deftest day25-part1-soln
+(deftest part1-test
   (testing "Reproduces the answer for day25, part1"
-    (is (= 606062 (t/day25-part1-soln day25-input)))))
+    (is (= 606062 (t/part1 day25-input)))))


### PR DESCRIPTION
Previously I was using a pattern for naming the solution functions of `dayNN-partY-soln`. This PR refactors that pattern to just be `partY`