### PR TITLE
Dijkstra mod

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -16,11 +16,12 @@ jobs:
       with:
         submodules: true
         token: ${{ secrets.AOC_INPUTS_TOKEN }}
-        
+
     - name: Build and run Dev Container tasks
       uses: devcontainers/ci@v0.3
-      runCmd: |
-        # Install dependencies
-        lein deps
-        # Run tests
-        lein tests
+      with: 
+        runCmd: |
+          # Install dependencies
+          lein deps
+          # Run tests
+          lein tests

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -8,15 +8,19 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout (GitHub)
+      uses: actions/checkout@v4
       with:
         submodules: true
         token: ${{ secrets.AOC_INPUTS_TOKEN }}
-    - name: Install dependencies
-      run: lein deps
-    - name: Run tests
-      run: lein test
+        
+    - name: Build and run Dev Container tasks
+      uses: devcontainers/ci@v0.3
+      runCmd: |
+        # Install dependencies
+        lein deps
+        # Run tests
+        lein tests

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -24,4 +24,4 @@ jobs:
           # Install dependencies
           lein deps
           # Run tests
-          lein tests
+          lein test

--- a/src/aoc_clj/2015/day22.clj
+++ b/src/aoc_clj/2015/day22.clj
@@ -198,7 +198,7 @@
                 :boss   boss
                 :effects {}}]
      (->>
-      (g/dijkstra (->GameGraph hard?) start player-wins? :limit 5000)
+      (g/shortest-path (->GameGraph hard?) start player-wins?)
       (map :last-spell)
       (drop 1)))))
 

--- a/src/aoc_clj/2016/day11.clj
+++ b/src/aoc_clj/2016/day11.clj
@@ -13,7 +13,7 @@
    4 [3]})
 
 ;; Input parsing
-(defn get-generators 
+(defn get-generators
   [s]
   (map (comp #(vector :g %) second) (re-seq #"(\w+) generator" s)))
 
@@ -100,19 +100,16 @@
    2 #{}
    3 #{}
    4 (->> (select-keys state [1 2 3 4])
-         vals
-         (apply set/union))})
+          vals
+          (apply set/union))})
 
 (defn move-count
   "Counts the minimum number of moves required to get all items moved up to the fourth floor"
   [input]
-  (->> (g/dijkstra
-        (->MoveGraph)
-        input
-        (u/equals? (endstate input))
-        :limit 10000000)
-       count
-       dec))
+  (let [finish? (u/equals? (endstate input))]
+    (->> (g/shortest-path (->MoveGraph) input finish?)
+         count
+         dec)))
 
 (defn extra-items
   "Update the initial state to account for additional items that weren't in the puzzle input"

--- a/src/aoc_clj/2016/day13.clj
+++ b/src/aoc_clj/2016/day13.clj
@@ -1,6 +1,6 @@
 (ns aoc-clj.2016.day13
   "Solution to https://adventofcode.com/2016/day/13"
-  (:require [aoc-clj.utils.core :as u] 
+  (:require [aoc-clj.utils.core :as u]
             [aoc-clj.utils.binary :as b]
             [aoc-clj.utils.graph :as g :refer [Graph]]
             [aoc-clj.utils.grid :as grid]))
@@ -21,7 +21,7 @@
   [[x y]]
   (and (>= x 0) (>= y 0)))
 
-(defn wall-calc 
+(defn wall-calc
   "Compute the _point value_ of a given x,y position using the office
    designer's favorite number `fav`"
   [fav [x y]]
@@ -59,7 +59,7 @@
    for a given office designer's favorite number `fav`"
   [fav finish]
   (let [graph (->CubicleMazeGraph fav)]
-    (->> (g/dijkstra graph start-pos (u/equals? finish) :limit 500)
+    (->> (g/shortest-path graph start-pos (u/equals? finish))
          count
          dec)))
 

--- a/src/aoc_clj/2016/day17.clj
+++ b/src/aoc_clj/2016/day17.clj
@@ -62,7 +62,7 @@
   [passcode]
   (let [init   (init-state passcode)
         final? #(= [3 3] (:pos %))]
-    (->> (g/dijkstra (->VaultGraph) init final? :limit 100000)
+    (->> (g/shortest-path (->VaultGraph) init final?)
          last
          :path)))
 

--- a/src/aoc_clj/2016/day22.clj
+++ b/src/aoc_clj/2016/day22.clj
@@ -83,7 +83,7 @@
         max-x (max-x-pos nodes)
         finish? (partial = [max-x 0])
         graph (->MoveGraph (moveable-nodes nodes unmoveable-size))]
-    (->> (g/dijkstra graph start finish? :limit 10000)
+    (->> (g/shortest-path graph start finish?)
          count
          dec)))
 

--- a/src/aoc_clj/2016/day24.clj
+++ b/src/aoc_clj/2016/day24.clj
@@ -38,7 +38,7 @@
   "Computes the distance between any pair of points of interest.
    Returns a seq of two vecs, with the pair order reversed in the second vec"
   [maze stops [v1 v2]]
-  (let [dist (dec (count (g/dijkstra maze (stops v1) (partial = (stops v2)) :limit 10000)))]
+  (let [dist (dec (count (g/shortest-path maze (stops v1) (partial = (stops v2)))))]
     [[v1 v2 dist]
      [v2 v1 dist]]))
 
@@ -90,7 +90,7 @@
                   :part1 #(= (count graph) (count (:visited %)))
                   :part2 #(and (= (count graph) (count (:visited %)))
                                (= :start (:pos %))))]
-    (->> (g/dijkstra move-graph start finish? :limit 100000)
+    (->> (g/shortest-path move-graph start finish?)
          (g/path-distance move-graph))))
 
 ;; Puzzle solutions

--- a/src/aoc_clj/2019/day15.clj
+++ b/src/aoc_clj/2019/day15.clj
@@ -44,7 +44,7 @@
         start [0 0]
         finish (maze/find-target thismaze :oxygen)
         simplified-maze (-> thismaze maze/Maze->Graph (g/pruned #{start finish}))
-        path (g/dijkstra simplified-maze start (u/equals? finish))]
+        path (g/shortest-path simplified-maze start (u/equals? finish))]
     (g/path-distance simplified-maze path)))
 
 (defn part2

--- a/src/aoc_clj/2019/day18.clj
+++ b/src/aoc_clj/2019/day18.clj
@@ -101,7 +101,7 @@
 
 (defn path-needs
   [graph node1 node2]
-  (let [path (g/dijkstra graph node1 (u/equals? node2))]
+  (let [path (g/shortest-path graph node1 (u/equals? node2))]
     (set (map str/lower-case (filter (partial door-or-key? graph) (butlast path))))))
 
 (defn subgraph-needs

--- a/src/aoc_clj/2019/day18.clj
+++ b/src/aoc_clj/2019/day18.clj
@@ -167,7 +167,7 @@
       (if (= max-keys (inc (count (first vertex))))
         (g/path-retrace (:prev state) vertex)
         (let [neighbors (filter (complement visited) (edges graph vertex))
-              new-state (reduce (partial g/dijkstra-update graph vertex) state neighbors)]
+              new-state (reduce #(g/a-star-update graph vertex (constantly 0) %1 %2) state neighbors)]
           (recur (conj visited vertex)
                  (ffirst (g/entries-not-in-set visited (state :dist)))
                  new-state))))))

--- a/src/aoc_clj/2019/day20.clj
+++ b/src/aoc_clj/2019/day20.clj
@@ -139,7 +139,7 @@
         start (get-in state [:ends "AA"])
         end   (u/equals? (get-in state [:ends "ZZ"]))
         graph (:graph state)]
-    (g/path-distance graph (g/dijkstra graph start end))))
+    (g/path-distance graph (g/shortest-path graph start end))))
 
 (defrecord RecursiveMaze [lookup3d]
   Graph
@@ -199,7 +199,7 @@
         start (conj (get-in state [:ends "AA"]) 0)
         end   (u/equals? (conj (get-in state [:ends "ZZ"]) 0))
         rmaze (recursive-maze state)]
-    (g/path-distance rmaze (g/dijkstra rmaze start end :limit 100000))))
+    (g/path-distance rmaze (g/shortest-path rmaze start end))))
 
 (defn part1
   [input]

--- a/src/aoc_clj/2021/day15.clj
+++ b/src/aoc_clj/2021/day15.clj
@@ -17,7 +17,7 @@
   [{:keys [width height grid] :as input}]
   (let [start  [0 0]
         end    (u/equals? [(dec width) (dec height)])
-        path (g/dijkstra (->GridGraph input) start end)]
+        path (g/shortest-path (->GridGraph input) start end)]
     (map grid path)))
 
 (defn path-risk

--- a/src/aoc_clj/2022/day12.clj
+++ b/src/aoc_clj/2022/day12.clj
@@ -43,7 +43,7 @@
 
 (defn shortest-path-length
   [g s e]
-  (-> (graph/dijkstra g s (u/equals? e)) count dec))
+  (-> (graph/shortest-path g s (u/equals? e)) count dec))
 
 (defn shortest-path-from-start
   "Find the fewest number of steps from the start to the finish given the map"

--- a/src/aoc_clj/2022/day16.clj
+++ b/src/aoc_clj/2022/day16.clj
@@ -52,7 +52,7 @@
         pairs  (combo/combinations (keys valves) 2)
         all-pairs (concat pairs (map reverse pairs))
         args   (map (fn [[a b]] [a (u/equals? b)]) all-pairs)
-        dists  (map #(dec (count (apply graph/dijkstra g %))) args)]
+        dists  (map #(dec (count (apply graph/shortest-path g %))) args)]
     (->> (map #(conj (vec %1) %2) all-pairs dists)
          (group-by first)
          (u/fmap #(into {} (map (comp vec rest)) %))

--- a/src/aoc_clj/2022/day24.clj
+++ b/src/aoc_clj/2022/day24.clj
@@ -104,11 +104,7 @@
    destination, using the heuristic of the manhattan distance from
    any grid position to the destination"
   [graph start dest]
-  (graph/a-star
-   graph
-   start
-   (destination? dest)
-   (heuristic dest)))
+  (graph/shortest-path graph start (destination? dest) (heuristic dest)))
 
 (defn path-to-exit
   "Find the path from the start to the cell immediately before the exit,

--- a/src/aoc_clj/2024/day18.clj
+++ b/src/aoc_clj/2024/day18.clj
@@ -49,7 +49,7 @@
   (let [graph   (->MoveGraph size (set (take limit bytes)))
         start   [0 0]
         finish? #(= [(dec size) (dec size)] %)]
-    (dec (count (graph/dijkstra graph start finish?)))))
+    (dec (count (graph/shortest-path graph start finish?)))))
 
 (defn first-blocking-byte
   "Returns the first byte to fall that completely blocks the path

--- a/test/aoc_clj/utils/graph_test.clj
+++ b/test/aoc_clj/utils/graph_test.clj
@@ -64,11 +64,6 @@
     (is (= [[:g :f :b]]
            (g/all-paths t2 :g)))))
 
-(deftest dijkstra-test
-  (testing "Can find the shortest path between two vertices"
-    (is (= [:a :d :c :f] (g/shortest-path t3 :a #(= :f %))))))
-
-
 (def t5 (->MapGraph {:a {:b 1.5 :e 2}
                      :b {:c 2}
                      :c {:d 3}
@@ -76,10 +71,11 @@
                      :e {:f 3}
                      :f {:g 2}}))
 (def h5 {:a 6.5 :b 4 :c 2 :d 4 :e 4.5 :f 2 :g 0})
-(deftest a-star-test
-  (testing "Can find the shortest path between two vertices using A* alg"
-    (is (= [:a :e :f :g] (g/a-star t5 :a (u/equals? :g) h5)))))
 
+(deftest dijkstra-test
+  (testing "Can find the shortest path between two vertices"
+    (is (= [:a :d :c :f] (g/shortest-path t3 :a #(= :f %))))
+    (is (= [:a :e :f :g] (g/shortest-path t5 :a (u/equals? :g) h5)))))
 
 (deftest all-paths-dfs-test
   (testing "Finds all of the paths from start to finish using a depth-first

--- a/test/aoc_clj/utils/graph_test.clj
+++ b/test/aoc_clj/utils/graph_test.clj
@@ -66,7 +66,7 @@
 
 (deftest dijkstra-test
   (testing "Can find the shortest path between two vertices"
-    (is (= [:a :d :c :f] (g/dijkstra t3 :a #(= :f %))))))
+    (is (= [:a :d :c :f] (g/shortest-path t3 :a #(= :f %))))))
 
 
 (def t5 (->MapGraph {:a {:b 1.5 :e 2}


### PR DESCRIPTION
* Removes the `:limit` argument to Dijkstra's algorithm that had bitten me quite a few times when I forgot to remove it
* Collapsed the Dijkstra and A* algorithms to one --- effectively Dijkstra is just A* with the heuristic always returning zero
* Updated all the call sites that used the `:limit` argument