### PR TITLE
Parallel MD5 search; unmark 2015 day04 part2 as slow

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,11 +6,13 @@
       "Bash(grep -v '^src/aoc_clj/utils/binary\\\\.clj$')",
       "Bash(grep -v '^test/aoc_clj/utils/binary_test\\\\.clj$')",
       "Bash(xargs -I {} sed -i 's/aoc-clj\\\\.utils\\\\.binary/aoc-clj.binary.interface/g' {})",
+      "Bash(gh issue *)",
       "Bash(git rm *)",
       "Bash(git add *)",
       "Bash(git commit -m ' *)",
       "Bash(clojure -M:poly info)",
       "Bash(clojure --version)",
+      "Bash(clojure -M:dev -e ' *)",
       "Bash(clojure -M:poly create c name:year-2015)",
       "Bash(clojure -M:poly test :dev with:default)",
       "Bash(clojure -M:poly check)"

--- a/components/digest/src/aoc_clj/digest/interface.clj
+++ b/components/digest/src/aoc_clj/digest/interface.clj
@@ -2,12 +2,12 @@
   (:import java.security.MessageDigest)
   (:require [clojure.string :as str]))
 
-(def md5-alg (MessageDigest/getInstance "MD5"))
+(def md5-alg (ThreadLocal/withInitial #(MessageDigest/getInstance "MD5")))
 
 (defn md5-digest
   "Computes the MD5 digest of s as a byte array"
   [^String s]
-  (.digest md5-alg (.getBytes s)))
+  (.digest ^MessageDigest (.get ^ThreadLocal md5-alg) (.getBytes s)))
 
 (defn md5-str
   "Computes the string representation of the MD5 digest of s"
@@ -18,11 +18,40 @@
 
 (defn five-zero-start?
   "Whether the digest (as bytes) starts with five zeroes"
-  [digest]
-  (let [[a b c] (take 3 digest)]
-    (and (zero? a) (zero? b) (<= 0 c 15))))
+  [^bytes digest]
+  (and (zero? (aget digest 0)) (zero? (aget digest 1)) (<= 0 (aget digest 2) 15)))
 
 (defn six-zero-start?
   "Whether the digest (as bytes) starts with six zeroes"
-  [bytes]
-  (every? zero? (take 3 bytes)))
+  [^bytes digest]
+  (and (zero? (aget digest 0)) (zero? (aget digest 1)) (zero? (aget digest 2))))
+
+(defn- search-batch
+  "First long n in [start, end) for which (pred n) is truthy, else nil."
+  [pred ^long start ^long end]
+  (loop [n start]
+    (cond
+      (>= n end)   nil
+      (pred n)     n
+      :else        (recur (inc n)))))
+
+(defn find-first-int
+  "Smallest non-negative integer n for which (pred n) is truthy.
+
+   Distributes work across `availableProcessors` threads in batched rounds:
+   each round dispatches one batch per thread, advancing only after no
+   thread in the round finds a match. Bounded wasted work — at most
+   `nthreads * batch-size` candidates past the answer."
+  ([pred] (find-first-int pred 100000))
+  ([pred batch-size]
+   (let [nthreads (.. Runtime getRuntime availableProcessors)
+         step     (* nthreads (long batch-size))]
+     (loop [round-start 0]
+       (let [futures (mapv (fn [i]
+                             (let [s (+ round-start (* i (long batch-size)))]
+                               (future (search-batch pred s (+ s (long batch-size))))))
+                           (range nthreads))
+             hits    (keep deref futures)]
+         (if (seq hits)
+           (apply min hits)
+           (recur (+ round-start step))))))))

--- a/components/digest/test/aoc_clj/digest/interface_test.clj
+++ b/components/digest/test/aoc_clj/digest/interface_test.clj
@@ -30,3 +30,18 @@
   (testing "Determines whether the byte array starts with six zeros"
     (is (= true (d/six-zero-start? s02)))
     (is (= false (d/six-zero-start? s00)))))
+
+(deftest find-first-int-test
+  (testing "Finds the smallest non-negative int satisfying the predicate"
+    (is (= 0     (d/find-first-int #(= 0 %))))
+    (is (= 7     (d/find-first-int #(= 7 %))))
+    (is (= 1024  (d/find-first-int #(= 1024 %)))))
+  (testing "Honors a small batch-size (covers cross-round answers)"
+    ;; batch-size of 10 with N cores means a round covers 10*N candidates;
+    ;; an answer past the first round exercises the loop/recur path.
+    (is (= 137   (d/find-first-int #(= 137 %) 10)))
+    (is (= 1234  (d/find-first-int #(= 1234 %) 10))))
+  (testing "Takes min when multiple threads find hits in the same round"
+    ;; Predicate matches many candidates; smallest must win regardless of
+    ;; which thread happens to find which.
+    (is (= 50    (d/find-first-int #(<= 50 % 200) 10)))))

--- a/components/year-2015/deps.edn
+++ b/components/year-2015/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src"]
  :deps  {poly/util                       {:local/root "../util"}
+         poly/digest                     {:local/root "../digest"}
          poly/graph                      {:local/root "../graph"}
          poly/grid                       {:local/root "../grid"}
          cheshire/cheshire               {:mvn/version "5.10.0"}

--- a/components/year-2015/src/aoc_clj/year_2015/day04.clj
+++ b/components/year-2015/src/aoc_clj/year_2015/day04.clj
@@ -9,8 +9,7 @@
 (defn first-integer
   "The first integer that satifies the supplied `pred` given the `secret`"
   [pred secret]
-  (let [passing-hash? #(pred (d/md5-digest (str secret %)))]
-    (first (filter passing-hash? (range)))))
+  (d/find-first-int #(pred (d/md5-digest (str secret %)))))
 
 (def first-five-zero-int (partial first-integer d/five-zero-start?))
 (def first-six-zero-int (partial first-integer d/six-zero-start?))

--- a/components/year-2015/test/aoc_clj/year_2015/day04_test.clj
+++ b/components/year-2015/test/aoc_clj/year_2015/day04_test.clj
@@ -18,6 +18,6 @@
   (testing "Reproduces the answer for day04, part1"
     (is (= 282749 (d04/part1 day04-input)))))
 
-(deftest ^:slow part2-test
+(deftest part2-test
   (testing "Reproduces the answer for day04, part2"
     (is (= 9962624 (d04/part2 day04-input)))))

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
 {:aliases
  {:dev  {:extra-paths []
          :extra-deps  {org.clojure/clojure {:mvn/version "1.12.4"}
+                       criterium/criterium  {:mvn/version "0.4.6"}
                        poly/cli             {:local/root "bases/cli"}
                        poly/util            {:local/root "components/util"}
                        poly/binary          {:local/root "components/binary"}


### PR DESCRIPTION
## Summary
- Optimize `aoc-clj.digest.interface` so 2015 day04 part2 runs ~13× faster (3.6 s → 0.28 s on a 10-core machine), and remove its `^:slow` marker.
- Add a generic `find-first-int` to the `digest` component for parallel "smallest-int-satisfying-pred" search; reusable by other puzzles in the same shape.
- Closes #1.

## What changed
- **Predicate hot path** — `five-zero-start?` / `six-zero-start?` rewritten with `^bytes` + `aget` instead of `(take 3 digest)` lazy-seq destructuring (~130× faster predicate, ~30% faster per-iteration).
- **MD5 reflection removed** — `MessageDigest` cached in a `ThreadLocal`, with `^MessageDigest` and `^ThreadLocal` hints so `.digest` and `.get` are direct virtual calls. Halved `md5-digest` cost (363 ns → 169 ns).
- **Parallel search** — new `find-first-int` fans batched rounds across `availableProcessors` threads, takes the min of any hits in a round, advances otherwise. Bounded wasted work (≤ `nthreads × batch-size` past the answer). Replaces the sequential `(first (filter ... (range)))` in `day04/first-integer`.
- **Tooling** — added `criterium` to the `:dev` alias for profiling.
- **Polylith hygiene** — added the missing `digest` dep to `year-2015/deps.edn`.

## Perf timeline (part2 wall-clock, `yzbqklnj`)
| Step | Time |
|---|---|
| Original | 3.63 s |
| `aget` predicate | 3.70 s (predicate cost recovered, masked by JIT noise) |
| `^MessageDigest` hint | 2.50 s |
| Parallel (10 cores) | **0.28 s** |

## Test plan
- [x] `aoc-clj.digest.interface-test` — 5 tests, 12 assertions pass (includes new `find-first-int-test` covering single-batch hits, cross-round hits, and min-of-many-hits).
- [x] `aoc-clj.year-2015.day04-test` — 3 tests, 4 assertions pass, including the previously-`^:slow` `part2-test` (now a normal test).
- [x] `clojure -M:poly test :project with:default` — full polylith default sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)