### PR TITLE
Fix slow 2016 day11

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -54,7 +54,7 @@ jobs:
         refFilterForPush: refs/heads/main
         env: |
           CLJ_CACHE_DIR=/workspaces/aoc-clj/.m2-cache
-          JAVA_TOOL_OPTIONS=-Xss4m
+          JAVA_TOOL_OPTIONS=-Xss16m
         runCmd: |
           # The host-mounted workspace has a UID mismatch inside the devcontainer,
           # which triggers git's "dubious ownership" safety check. Without this,

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -54,7 +54,12 @@ jobs:
         refFilterForPush: refs/heads/main
         env: |
           CLJ_CACHE_DIR=/workspaces/aoc-clj/.m2-cache
-          JAVA_TOOL_OPTIONS=-Xss32m
+          # JAVA_TOOL_OPTIONS is honored by the parent JVM running poly,
+          # but Sean Corfield's polylith-external-test-runner forks per-project
+          # test JVMs and explicitly reads JVM args from POLY_TEST_JVM_OPTS.
+          # Both are needed: parent + forked children get the bumped stack.
+          JAVA_TOOL_OPTIONS=-Xss16m
+          POLY_TEST_JVM_OPTS=-Xss16m
         runCmd: |
           # The host-mounted workspace has a UID mismatch inside the devcontainer,
           # which triggers git's "dubious ownership" safety check. Without this,

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -54,6 +54,7 @@ jobs:
         refFilterForPush: refs/heads/main
         env: |
           CLJ_CACHE_DIR=/workspaces/aoc-clj/.m2-cache
+          JAVA_TOOL_OPTIONS=-Xss4m
         runCmd: |
           # The host-mounted workspace has a UID mismatch inside the devcontainer,
           # which triggers git's "dubious ownership" safety check. Without this,

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -54,7 +54,7 @@ jobs:
         refFilterForPush: refs/heads/main
         env: |
           CLJ_CACHE_DIR=/workspaces/aoc-clj/.m2-cache
-          JAVA_TOOL_OPTIONS=-Xss16m
+          JAVA_TOOL_OPTIONS=-Xss32m
         runCmd: |
           # The host-mounted workspace has a UID mismatch inside the devcontainer,
           # which triggers git's "dubious ownership" safety check. Without this,

--- a/components/year-2016/src/aoc_clj/year_2016/day11.clj
+++ b/components/year-2016/src/aoc_clj/year_2016/day11.clj
@@ -16,19 +16,30 @@
 
 ;; Input parsing
 (defn get-generators
+  "Map of element-name to `{:g floor}` for each generator named on `s`."
   [floor s]
   (into {} (map (comp #(vector % {:g floor}) second) (re-seq #"(\w+) generator" s))))
 
 (defn get-microchips
+  "Map of element-name to `{:m floor}` for each microchip named on `s`."
   [floor s]
   (into {} (map (comp #(vector % {:m floor}) second) (re-seq #"(\w+)-compatible microchip" s))))
 
 (defn parse-line
+  "Map of element-name to `{:m chip-floor :g gen-floor}` for one input line."
   [floor line]
   (merge-with into (get-generators floor line)
               (get-microchips floor line)))
 
+;; State representation: a vector `[elev pairs]`, where `elev` is the
+;; current elevator floor (0-3) and `pairs` is a frequency map keyed by
+;; `[chip-floor gen-floor]` tuples. Each tuple represents one anonymous
+;; element-pair: tracking only where the chip and generator sit, not
+;; which element it is. 
 (defn parse
+  "Parses puzzle input into the canonical state vector `[elev pairs]`,
+   where `pairs` is a frequency map of `[chip-floor gen-floor]` tuples
+   keyed structurally rather than by element identity."
   [input]
   (let [items (->> input
                    (map-indexed parse-line)
@@ -37,16 +48,13 @@
 
 ;; Puzzle logic
 ;; Rules:
-;; At least one but no more than two objects can move up or down with the elevator in any single move.
-;; The elevator can only move items that are currently on the same floor as it.
-;; Possible combinations of objects to move:
-;; - A single microchip
-;; - A single generator
-;; - Two distinct generators
-;; - Two distinct microchips
-;; - A paired microchip and generator
-;; 
-;; A naked (unpaired) microchip cannot be on a floor with different generator
+;; - The elevator carries one or two items, moves up or down one floor.
+;; - The elevator can only move items currently on its floor.
+;; - Possible payload shapes (the only ones that yield legal source AND
+;;   destination states): one chip, one generator, two chips, two
+;;   generators, or a matched chip+generator pair.
+;; - A chip on a floor without its own generator is fried by any other
+;;   generator on that floor.
 
 (defn pair-count
   "Counts the total number of microchip-generator pairs"
@@ -59,36 +67,55 @@
   [state]
   [3 {[3 3] (pair-count state)}])
 
-(defn rm-pair [pairs p]
+(defn rm-pair
+  "Decrement the count of pair-tuple `p`, dissoc'ing the entry when it
+   would otherwise reach zero."
+  [pairs p]
   (if (= 1 (pairs p))
     (dissoc pairs p)
     (update pairs p dec)))
 
-(defn add-pair [pairs p]
+(defn add-pair
+  "Increment the count of pair-tuple `p`, defaulting to 1 if absent."
+  [pairs p]
   (update pairs p (fnil inc 0)))
 
-(defn move-pair [pairs from to]
+(defn move-pair
+  "Move one occurrence of pair-tuple `from` to pair-tuple `to`."
+  [pairs from to]
   (-> pairs (rm-pair from) (add-pair to)))
 
 (defn chip-candidate
+  "New pair-tuple after shifting the chip-floor of `p` by `delta`."
   [delta p]
   (v/vec-add [delta 0] p))
 
 (defn generator-candidate
+  "New pair-tuple after shifting the gen-floor of `p` by `delta`."
   [delta p]
   (v/vec-add [0 delta] p))
 
 (defn pairs-candidate
+  "New pair-tuple after shifting both chip-floor and gen-floor by `delta`
+   (used for a matched chip+generator move)."
   [delta p]
   (v/vec-add [delta delta] p))
 
-(defn chips-on [pairs elev]
+(defn chips-on
+  "Pair-tuples in `pairs` whose chip is on floor `elev`. Includes
+   tuples whose generator is also on `elev` (matched pairs)."
+  [pairs elev]
   (filter #(= elev (first %)) (keys pairs)))
 
-(defn gens-on [pairs elev]
+(defn gens-on
+  "Pair-tuples in `pairs` whose generator is on floor `elev`. Includes
+   matched pairs."
+  [pairs elev]
   (filter #(= elev (second %)) (keys pairs)))
 
-(defn matched-on [pairs elev]
+(defn matched-on
+  "Pair-tuples in `pairs` whose chip and generator are both on `elev`."
+  [pairs elev]
   (filter #(= elev (first %) (second %)) (keys pairs)))
 
 (defn pair-singles
@@ -108,10 +135,16 @@
       [[t1 (candidate delta t1)]
        [t2 (candidate delta t2)]])))
 
-(defn apply-updates [pairs updates]
+(defn apply-updates
+  "Apply a sequence of `[old-tuple new-tuple]` rewrites to `pairs`."
+  [pairs updates]
   (reduce (fn [p [old new]] (move-pair p old new)) pairs updates))
 
 (defn candidate-moves
+  "Candidate next-states reachable from `[elev pairs]` by moving the
+   elevator `delta` floors. No matched-pair `pair-doubles` line because
+   carrying two matched pairs would exceed the two-item elevator limit.
+   Results are not yet legality-filtered — call `legal?` downstream."
   [[elev pairs] delta]
   (for [updates (concat
                  (pair-singles chips-on   chip-candidate      pairs elev delta)
@@ -122,10 +155,14 @@
     [(+ elev delta) (apply-updates pairs updates)]))
 
 (defn all-candidates
+  "Set of all candidate next-states across both elevator directions."
   [[elev :as state]]
   (set (mapcat #(candidate-moves state %) (elevator-options elev))))
 
 (defn legal?
+  "A state is legal when no floor has both a lone chip and any generator
+   present. A paired chip+gen on a floor counts as a generator from the
+   perspective of any *other* lone chip on that floor."
   [[_ pairs]]
   (let [chips (->> (keys pairs)
                    (filter #(not= (first %) (second %)))

--- a/components/year-2016/src/aoc_clj/year_2016/day11.clj
+++ b/components/year-2016/src/aoc_clj/year_2016/day11.clj
@@ -3,83 +3,145 @@
   (:require [clojure.math.combinatorics :as combo]
             [clojure.set :as set]
             [aoc-clj.util.interface :as u]
-            [aoc-clj.graph.interface :as g :refer [Graph]]))
+            [aoc-clj.graph.interface :as g :refer [Graph]]
+            [aoc-clj.vectors.interface :as v]))
 
 ;; Constants
 (def elevator-options
-  {1 [2]
-   2 [1 3]
-   3 [2 4]
-   4 [3]})
+  "A map of the viable floor moves that the elevator can undertake."
+  {0 [1]
+   1 [1 -1]
+   2 [1 -1]
+   3 [-1]})
 
 ;; Input parsing
 (defn get-generators
-  [s]
-  (map (comp #(vector :g %) second) (re-seq #"(\w+) generator" s)))
+  [floor s]
+  (into {} (map (comp #(vector % {:g floor}) second) (re-seq #"(\w+) generator" s))))
 
 (defn get-microchips
-  [s]
-  (map (comp #(vector :m %) second) (re-seq #"(\w+)-compatible microchip" s)))
+  [floor s]
+  (into {} (map (comp #(vector % {:m floor}) second) (re-seq #"(\w+)-compatible microchip" s))))
 
 (defn parse-line
-  [line]
-  (into #{} (concat (get-generators line) (get-microchips line))))
+  [floor line]
+  (merge-with into (get-generators floor line)
+              (get-microchips floor line)))
 
 (defn parse
   [input]
-  (merge (zipmap [1 2 3 4] (map parse-line input)) {:e 1}))
+  (let [items (->> input
+                   (map-indexed parse-line)
+                   (apply merge-with into))]
+    [0 (frequencies (map (fn [{:keys [m g]}] [m g]) (vals items)))]))
 
 ;; Puzzle logic
-(defn move
-  "Return a new state map with the given `objects` removed from the `from` floor
-   and added to the `to` floor"
-  [state from to objects]
-  (assoc state
-         :e to
-         from (apply disj (state from) objects)
-         to   (apply conj (state to) objects)))
+;; Rules:
+;; At least one but no more than two objects can move up or down with the elevator in any single move.
+;; The elevator can only move items that are currently on the same floor as it.
+;; Possible combinations of objects to move:
+;; - A single microchip
+;; - A single generator
+;; - Two distinct generators
+;; - Two distinct microchips
+;; - A paired microchip and generator
+;; 
+;; A naked (unpaired) microchip cannot be on a floor with different generator
 
-(defn get-typed-items
-  [item-type]
-  (fn [items]
-    (->> items
-         (filter #(= item-type (first %)))
-         (map second)
-         set)))
+(defn pair-count
+  "Counts the total number of microchip-generator pairs"
+  [[_ pairs]]
+  (reduce + (vals pairs)))
 
-(def microchips (get-typed-items :m))
-(def generators (get-typed-items :g))
+(defn endstate
+  "Given the initial state, return the desired endstate with all items and the elevator
+   on the fourth floor"
+  [state]
+  [3 {[3 3] (pair-count state)}])
 
+(defn rm-pair [pairs p]
+  (if (= 1 (pairs p))
+    (dissoc pairs p)
+    (update pairs p dec)))
 
-(defn legal-items?
-  "A combination of items on a given floor is legal if it doesn't result in any
-   microchips getting fried, which means that any microchip, if present, must either
-   not be next to any other generators or that every microchip is paired with its
-   corresponding generator."
-  [items]
-  (let [chips (microchips items)
-        gens  (generators items)]
-    (or (empty? gens)
-        (set/subset? chips gens))))
+(defn add-pair [pairs p]
+  (update pairs p (fnil inc 0)))
+
+(defn move-pair [pairs from to]
+  (-> pairs (rm-pair from) (add-pair to)))
+
+(defn chip-candidate
+  [delta p]
+  (v/vec-add [delta 0] p))
+
+(defn generator-candidate
+  [delta p]
+  (v/vec-add [0 delta] p))
+
+(defn pairs-candidate
+  [delta p]
+  (v/vec-add [delta delta] p))
+
+(defn chips-on [pairs elev]
+  (filter #(= elev (first %)) (keys pairs)))
+
+(defn gens-on [pairs elev]
+  (filter #(= elev (second %)) (keys pairs)))
+
+(defn matched-on [pairs elev]
+  (filter #(= elev (first %) (second %)) (keys pairs)))
+
+(defn pair-singles
+  "All single-item moves: one [old new] update each."
+  [select candidate pairs elev delta]
+  (for [t (select pairs elev)]
+    [[t (candidate delta t)]]))
+
+(defn pair-doubles
+  "All two-item moves: two [old new] updates each. Includes same-tuple
+   pairs when their multiplicity is at least 2."
+  [select candidate pairs elev delta]
+  (let [ts        (select pairs elev)
+        same-key  (for [t ts :when (>= (pairs t) 2)] [t t])
+        diff-keys (combo/combinations ts 2)]
+    (for [[t1 t2] (concat same-key diff-keys)]
+      [[t1 (candidate delta t1)]
+       [t2 (candidate delta t2)]])))
+
+(defn apply-updates [pairs updates]
+  (reduce (fn [p [old new]] (move-pair p old new)) pairs updates))
+
+(defn candidate-moves
+  [[elev pairs] delta]
+  (for [updates (concat
+                 (pair-singles chips-on   chip-candidate      pairs elev delta)
+                 (pair-singles gens-on    generator-candidate pairs elev delta)
+                 (pair-singles matched-on pairs-candidate     pairs elev delta)
+                 (pair-doubles chips-on   chip-candidate      pairs elev delta)
+                 (pair-doubles gens-on    generator-candidate pairs elev delta))]
+    [(+ elev delta) (apply-updates pairs updates)]))
+
+(defn all-candidates
+  [[elev :as state]]
+  (set (mapcat #(candidate-moves state %) (elevator-options elev))))
 
 (defn legal?
-  "A state is deemed legal if, on every floor, the combination of items is legal"
-  [state]
-  (every? legal-items? (map (partial get state) [1 2 3 4])))
+  [[_ pairs]]
+  (let [chips (->> (keys pairs)
+                   (filter #(not= (first %) (second %)))
+                   (map first)
+                   set)
+        gens  (->> (keys pairs)
+                   (map second)
+                   set)]
+    (empty? (clojure.set/intersection chips gens))))
 
 (defn legal-moves
   "Given the current state, return a seq of the possible next states that are legal
    (i.e. won't result in a microchip getting fried)"
   [state]
-  (let [elev (get state :e)
-        floor (seq (get state elev))
-        moves (elevator-options elev)
-        objects (->> (concat (combo/combinations floor 1)
-                             (combo/combinations floor 2))
-                     (filter legal-items?))]
-    (->> (for [m moves o objects]
-           (move state elev m o))
-         (filter legal?))))
+  (->> (all-candidates state)
+       (filter legal?)))
 
 (defrecord MoveGraph []
   Graph
@@ -91,18 +153,6 @@
     [_ _ _]
     1))
 
-(defn endstate
-  "Given the initial state, return the desired endstate with all items and the elevator
-   on the fourth floor"
-  [state]
-  {:e 4
-   1 #{}
-   2 #{}
-   3 #{}
-   4 (->> (select-keys state [1 2 3 4])
-          vals
-          (apply set/union))})
-
 (defn move-count
   "Counts the minimum number of moves required to get all items moved up to the fourth floor"
   [input]
@@ -113,8 +163,8 @@
 
 (defn extra-items
   "Update the initial state to account for additional items that weren't in the puzzle input"
-  [state]
-  (update state 1 conj [:m "elerium"] [:g "elerium"] [:m "dilithium"] [:g "dilithium"]))
+  [[elev pairs]]
+  [elev (-> pairs (add-pair [0 0]) (add-pair [0 0]))])
 
 ;; Puzzle solutions
 (defn part1
@@ -127,4 +177,3 @@
    discovered on the first floor"
   [input]
   (move-count (extra-items input)))
-

--- a/components/year-2016/test/aoc_clj/year_2016/day11_test.clj
+++ b/components/year-2016/test/aoc_clj/year_2016/day11_test.clj
@@ -10,11 +10,7 @@
    "The fourth floor contains nothing relevant."])
 
 (def d11-s00
-  {:e 1
-   1 #{[:m "hydrogen"] [:m "lithium"]}
-   2 #{[:g "hydrogen"]}
-   3 #{[:g "lithium"]}
-   4 #{}})
+  [0 {[0 1] 1 [0 2] 1}])
 
 (deftest parse-test
   (testing "Correctly parses the input"
@@ -22,12 +18,7 @@
 
 (deftest endstate-test
   (testing "Defines the desired endstate (with all objects on the fourth floor), given the initial state"
-    (is (= {:e 4
-            1 #{}
-            2 #{}
-            3 #{}
-            4 #{[:m "hydrogen"] [:m "lithium"] [:g "hydrogen"] [:g "lithium"]}}
-           (d11/endstate d11-s00)))))
+    (is (= [3 {[3 3] 2}] (d11/endstate d11-s00)))))
 
 (deftest move-count
   (testing "Counts the minimum number of moves "
@@ -36,12 +27,10 @@
 
 (def day11-input (u/parse-puzzle-input d11/parse 2016 11))
 
-;; FIXME: Implementation is too slow
-;; https://github.com/klsmithphd/aoc-clj/issues/31
-(deftest ^:slow part1
+(deftest part1
   (testing "Reproduces the answer for day11, part1"
     (is (= 31 (d11/part1 day11-input)))))
 
-(deftest ^:slow part2
+(deftest  part2
   (testing "Reproduces the answer for day11, part2"
     (is (= 55 (d11/part2 day11-input)))))

--- a/components/year-2016/test/aoc_clj/year_2016/day11_test.clj
+++ b/components/year-2016/test/aoc_clj/year_2016/day11_test.clj
@@ -9,16 +9,62 @@
    "The third floor contains a lithium generator."
    "The fourth floor contains nothing relevant."])
 
+(def d11-s01-raw
+  ["The first floor contains a hydrogen generator."
+   "The second floor contains a hydrogen-compatible microchip."
+   "The third floor contains nothing relevant."
+   "The fourth floor contains nothing relevant."])
+
 (def d11-s00
   [0 {[0 1] 1 [0 2] 1}])
 
+(def d11-s01
+  [0 {[1 0] 1}])
+
 (deftest parse-test
   (testing "Correctly parses the input"
-    (is (= d11-s00 (d11/parse d11-s00-raw)))))
+    (is (= d11-s00 (d11/parse d11-s00-raw)))
+    (is (= d11-s01 (d11/parse d11-s01-raw)))))
 
 (deftest endstate-test
   (testing "Defines the desired endstate (with all objects on the fourth floor), given the initial state"
     (is (= [3 {[3 3] 2}] (d11/endstate d11-s00)))))
+
+(deftest selectors-test
+  (let [pairs {[0 1] 1 [1 2] 1 [1 1] 1 [3 3] 2}]
+    (testing "chips-on includes both lone and paired chips on the floor"
+      (is (= #{[1 2] [1 1]} (set (d11/chips-on pairs 1)))))
+    (testing "gens-on includes both lone and paired generators on the floor"
+      (is (= #{[0 1] [1 1]} (set (d11/gens-on pairs 1)))))
+    (testing "matched-on requires both chip and generator on the floor"
+      (is (= #{[1 1]} (set (d11/matched-on pairs 1))))
+      (is (= #{[3 3]} (set (d11/matched-on pairs 3)))))))
+
+(deftest pair-doubles-multiplicity-test
+  (testing "Same tuple-type may be picked twice when its multiplicity is at least 2"
+    (let [updates (d11/pair-doubles d11/chips-on d11/chip-candidate
+                                    {[0 1] 2} 0 1)]
+      (is (= [[[[0 1] [1 1]] [[0 1] [1 1]]]] updates))))
+  (testing "Same tuple-type is not picked twice when its multiplicity is 1"
+    (is (empty? (d11/pair-doubles d11/chips-on d11/chip-candidate
+                                  {[0 1] 1} 0 1)))))
+
+(deftest legal?-test
+  (testing "Empty state is legal"
+    (is (true? (d11/legal? [0 {}]))))
+  (testing "All paired tuples on a single floor is legal"
+    (is (true? (d11/legal? [0 {[0 0] 3}]))))
+  (testing "A lone chip is legal when no generators share its floor"
+    (is (true? (d11/legal? [0 {[1 2] 1 [0 2] 1}]))))
+  (testing "A lone chip with a foreign lone generator on the same floor is illegal"
+    (is (false? (d11/legal? [0 {[0 1] 1 [2 0] 1}]))))
+  (testing "A lone chip with a paired chip+gen of another element on the same floor is illegal"
+    (is (false? (d11/legal? [0 {[0 0] 1 [0 1] 1}])))))
+
+(deftest extra-items-test
+  (testing "Adds two matched [0 0] pair-tuples without disturbing the elevator floor"
+    (is (= [0 {[0 1] 1 [0 2] 1 [0 0] 2}]
+           (d11/extra-items d11-s00)))))
 
 (deftest move-count
   (testing "Counts the minimum number of moves "


### PR DESCRIPTION
Fixes #31

This change replaces the existing state structure, realizing that we don't need to keep track of each individual microchip and generator, we just need to track where the two pieces of any given pair are (i.e. which floor they're on).

This significantly collapses the state space that needs to be searched, and brings this down to sub-second solutions for both parts.