### PR TITLE
Rewrite graph/core/dfs iteratively (closes #197)

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -54,12 +54,6 @@ jobs:
         refFilterForPush: refs/heads/main
         env: |
           CLJ_CACHE_DIR=/workspaces/aoc-clj/.m2-cache
-          # JAVA_TOOL_OPTIONS is honored by the parent JVM running poly,
-          # but Sean Corfield's polylith-external-test-runner forks per-project
-          # test JVMs and explicitly reads JVM args from POLY_TEST_JVM_OPTS.
-          # Both are needed: parent + forked children get the bumped stack.
-          JAVA_TOOL_OPTIONS=-Xss16m
-          POLY_TEST_JVM_OPTS=-Xss16m
         runCmd: |
           # The host-mounted workspace has a UID mismatch inside the devcontainer,
           # which triggers git's "dubious ownership" safety check. Without this,

--- a/components/graph/src/aoc_clj/graph/core.clj
+++ b/components/graph/src/aoc_clj/graph/core.clj
@@ -160,21 +160,36 @@
 
 
 (defn- dfs
-  "Helper function for performing a depth-first search (DFS) of a `graph`"
-  [graph finish? path visited]
-  (let [node (peek path)]
-    (if (finish? node)
-      [path]
-      (->> (edges graph node)
-           (remove visited)
-           (mapcat #(dfs graph finish? (conj path %) (conj visited %)))))))
+  "Iterative depth-first search of `graph` from `start`. Returns a vector
+   of every simple path ending at a vertex satisfying `finish?`. Uses an
+   explicit work-stack of `[path visited]` frames so memory grows with
+   the number of in-flight paths rather than path depth — the prior
+   recursive-mapcat formulation built one nested LazySeq layer per level
+   and overflowed the JVM stack when realized on long paths."
+  [graph finish? start]
+  (loop [stack   [[[start] #{start}]]
+         results []]
+    (if-let [frame (peek stack)]
+      (let [[path visited] frame
+            stack'         (pop stack)
+            node           (peek path)]
+        (if (finish? node)
+          (recur stack' (conj results path))
+          (recur (->> (edges graph node)
+                      (remove visited)
+                      ;; Reverse so the first-returned child is popped
+                      ;; first — preserves the original DFS ordering.
+                      reverse
+                      (map (fn [n] [(conj path n) (conj visited n)]))
+                      (into stack'))
+                 results)))
+      results)))
 
 (defn all-paths-dfs
-  "Return a seq of all paths (if any) in a `graph` from `start` until
-   reaching a vertex satisfying the `finish?` predicate by using a
-   Depth-First Search (DFS)"
+  "Return a vector of all simple paths in `graph` from `start` to any
+   vertex satisfying `finish?`, found via depth-first search."
   [graph start finish?]
-  (dfs graph finish? [start] #{start}))
+  (dfs graph finish? start))
 
 (defn- unroll
   [[start nodes]]


### PR DESCRIPTION
## Summary
- Replaces the recursive `mapcat` formulation of `dfs` in `aoc-clj.graph.core` with an iterative `loop`/`recur` traversal using an explicit work-stack of `[path visited]` frames. Memory now scales with the number of in-flight paths, not with path depth.
- Removes `JAVA_TOOL_OPTIONS=-Xss16m` and `POLY_TEST_JVM_OPTS=-Xss16m` from `.github/workflows/clojure.yml` — the workaround introduced for the recursive overflow is no longer needed.
- Closes #197.

## Why
The recursive form built one nested `LazySeq` layer per recursion level (mapcat → concat → LazySeq). Realizing the resulting seq via `Cons.next` chains consumed JVM stack proportional to maximum path depth. For 2016 day 17 part 2 (depth 536), that exceeded CI's default `-Xss` and crashed the test run. Bumping `-Xss` was a workaround; this change removes the dependency on stack size entirely.

## Implementation notes
- Children are pushed in **reverse** order onto the work-stack so the first-returned child is popped first — preserves the original DFS ordering, which `all-paths-dfs-test` asserts strictly (the 10-path `t3` case).
- Public API of `all-paths-dfs` is unchanged; it now returns a vector instead of a lazy seq, but both existing callers (`longest-path-length` in 2016 day 17, and `all-shortest-paths` in graph/core) consume the result eagerly so this is non-breaking.

## Test plan
- [x] `clojure -M:dev` graph and day-17 test runs — all pass.
- [x] **Acceptance criterion from #197**: `clojure -J-Xss256k -M:dev -e '(d17/part2 input)'` completes successfully (272 ms, returns 536).
- [x] Full `clojure -M:poly test :all-bricks with:default` sweep — 0 failures, 0 errors.
- [ ] CI with workaround removed (this PR) should remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)